### PR TITLE
Fix #1: Xomper bugs — roster, bracket, matchup, world cup, navigation

### DIFF
--- a/Xomper/Features/League/MatchupDetailView.swift
+++ b/Xomper/Features/League/MatchupDetailView.swift
@@ -51,6 +51,7 @@ struct MatchupDetailView: View {
                 scoreHeader(pair)
                 seasonLabel
                 startersSection(pair)
+                benchSection(pair)
             }
             .padding(.horizontal, XomperTheme.Spacing.md)
             .padding(.vertical, XomperTheme.Spacing.sm)
@@ -199,11 +200,12 @@ struct MatchupDetailView: View {
 
             // Column headers
             HStack {
-                Text("Team A")
+                Text(teamAName)
                     .font(.caption2)
                     .fontWeight(.semibold)
                     .foregroundStyle(XomperColors.textMuted)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .lineLimit(1)
 
                 Text("PTS")
                     .font(.caption2)
@@ -220,11 +222,12 @@ struct MatchupDetailView: View {
                     .foregroundStyle(XomperColors.textMuted)
                     .frame(width: 44, alignment: .leading)
 
-                Text("Team B")
+                Text(teamBName)
                     .font(.caption2)
                     .fontWeight(.semibold)
                     .foregroundStyle(XomperColors.textMuted)
                     .frame(maxWidth: .infinity, alignment: .trailing)
+                    .lineLimit(1)
             }
             .padding(.horizontal, XomperTheme.Spacing.sm)
 
@@ -300,7 +303,61 @@ struct MatchupDetailView: View {
         .frame(maxWidth: .infinity, alignment: frameAlignment)
     }
 
+    // MARK: - Bench Section
+
+    private func benchSection(_ pair: MatchupPair) -> some View {
+        let rawA = resolvedTeamA(pair)
+        let rawB = resolvedTeamB(pair)
+
+        let starterSetA = Set(rawA.starters ?? [])
+        let starterSetB = Set(rawB.starters ?? [])
+        let allA = rawA.players ?? []
+        let allB = rawB.players ?? []
+        let pointsMapA = rawA.playersPoints ?? [:]
+        let pointsMapB = rawB.playersPoints ?? [:]
+
+        let benchA = allA.filter { !starterSetA.contains($0) && $0 != "0" }
+        let benchB = allB.filter { !starterSetB.contains($0) && $0 != "0" }
+
+        let maxCount = max(benchA.count, benchB.count)
+
+        if maxCount == 0 { return AnyView(EmptyView()) }
+
+        return AnyView(
+            VStack(spacing: XomperTheme.Spacing.xs) {
+                HStack {
+                    Text("Bench")
+                        .font(.headline)
+                        .foregroundStyle(XomperColors.textPrimary)
+                    Spacer()
+                }
+
+                ForEach(0..<maxCount, id: \.self) { index in
+                    let idA = index < benchA.count ? benchA[index] : nil
+                    let idB = index < benchB.count ? benchB[index] : nil
+                    starterRow(
+                        playerIdA: idA,
+                        pointsA: idA.flatMap { pointsMapA[$0] },
+                        playerIdB: idB,
+                        pointsB: idB.flatMap { pointsMapB[$0] }
+                    )
+                }
+            }
+            .padding(XomperTheme.Spacing.md)
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        )
+    }
+
     // MARK: - Helpers
+
+    private var teamAName: String {
+        record.teamATeamName.isEmpty ? record.teamAUsername : record.teamATeamName
+    }
+
+    private var teamBName: String {
+        record.teamBTeamName.isEmpty ? record.teamBUsername : record.teamBTeamName
+    }
 
     private func resolvedTeamA(_ pair: MatchupPair) -> Matchup {
         if pair.teamA.rosterId == record.teamARosterId {

--- a/Xomper/Features/League/PlayoffBracketView.swift
+++ b/Xomper/Features/League/PlayoffBracketView.swift
@@ -5,6 +5,12 @@ struct PlayoffBracketView: View {
 
     @State private var standings: [StandingsTeam] = []
     @State private var bracketType: BracketType = .winners
+    @State private var selectedMatch: PlayoffBracketMatch?
+    @State private var cardFrames: [String: CGRect] = [:]
+
+    private var seedMap: [Int: Int] {
+        Dictionary(uniqueKeysWithValues: standings.map { ($0.rosterId, $0.leagueRank) })
+    }
 
     var body: some View {
         ScrollView {
@@ -38,6 +44,15 @@ struct PlayoffBracketView: View {
                 Task { await loadBrackets() }
             }
         }
+        .sheet(item: $selectedMatch) { match in
+            NavigationStack {
+                BracketMatchDetailSheet(
+                    match: match,
+                    standings: standings
+                )
+            }
+            .presentationDetents([.medium])
+        }
     }
 
     // MARK: - Bracket Toggle
@@ -50,6 +65,7 @@ struct PlayoffBracketView: View {
                     generator.impactOccurred()
                     withAnimation(XomperTheme.defaultAnimation) {
                         bracketType = type
+                        cardFrames.removeAll()
                     }
                 } label: {
                     Text(type.title)
@@ -91,33 +107,226 @@ struct PlayoffBracketView: View {
             )
         } else {
             ScrollView(.horizontal, showsIndicators: false) {
-                HStack(alignment: .top, spacing: XomperTheme.Spacing.lg) {
-                    ForEach(rounds, id: \.round) { roundData in
-                        roundColumn(roundData)
-                    }
-                }
+                BracketGridView(
+                    rounds: rounds,
+                    cardFrames: $cardFrames,
+                    selectedMatch: $selectedMatch,
+                    standings: standings,
+                    seedMap: seedMap,
+                    teamForRoster: teamForRoster,
+                    teamDisplayName: teamDisplayName
+                )
                 .padding(.horizontal, XomperTheme.Spacing.md)
                 .padding(.bottom, XomperTheme.Spacing.md)
             }
         }
     }
 
+    // MARK: - Helpers
+
+    private func teamDisplayName(rosterId: Int?, source: BracketSource?) -> String {
+        if let rosterId, let team = teamForRoster(rosterId) {
+            return team.teamName
+        }
+        if let rosterId {
+            return "Roster \(rosterId)"
+        }
+        if let source {
+            if let w = source.winnerOfMatch {
+                return "W of Match \(w)"
+            }
+            if let l = source.loserOfMatch {
+                return "L of Match \(l)"
+            }
+        }
+        return "TBD"
+    }
+
+    private func teamForRoster(_ rosterId: Int?) -> StandingsTeam? {
+        guard let rosterId else { return nil }
+        return standings.first { $0.rosterId == rosterId }
+    }
+
+    private func groupByRound(_ matches: [PlayoffBracketMatch]) -> [BracketRound] {
+        var roundMap: [Int: [PlayoffBracketMatch]] = [:]
+        for match in matches {
+            roundMap[match.round, default: []].append(match)
+        }
+        let minRound = roundMap.keys.min() ?? 1
+        return roundMap.keys.sorted().map { round in
+            BracketRound(round: round, matches: roundMap[round] ?? [], minRound: minRound)
+        }
+    }
+
+    private func buildStandings() {
+        guard let league = leagueStore.currentLeague else { return }
+        standings = StandingsBuilder.buildStandings(
+            rosters: leagueStore.currentLeagueRosters,
+            users: leagueStore.currentLeagueUsers,
+            league: league
+        )
+    }
+
+    private func loadBrackets() async {
+        guard let league = leagueStore.currentLeague else { return }
+        await leagueStore.fetchBrackets(leagueId: league.leagueId)
+    }
+}
+
+// MARK: - Bracket Grid with Connector Lines
+
+private struct BracketGridView: View {
+    @Binding var cardFrames: [String: CGRect]
+    @Binding var selectedMatch: PlayoffBracketMatch?
+
+    let rounds: [BracketRound]
+    let standings: [StandingsTeam]
+    let seedMap: [Int: Int]
+    let teamForRoster: (Int?) -> StandingsTeam?
+    let teamDisplayName: (Int?, BracketSource?) -> String
+
+    private static let cardWidth: CGFloat = 200
+    private static let roundSpacing: CGFloat = XomperTheme.Spacing.xxl
+
+    init(
+        rounds: [BracketRound],
+        cardFrames: Binding<[String: CGRect]>,
+        selectedMatch: Binding<PlayoffBracketMatch?>,
+        standings: [StandingsTeam],
+        seedMap: [Int: Int],
+        teamForRoster: @escaping (Int?) -> StandingsTeam?,
+        teamDisplayName: @escaping (Int?, BracketSource?) -> String
+    ) {
+        self.rounds = rounds
+        self._cardFrames = cardFrames
+        self._selectedMatch = selectedMatch
+        self.standings = standings
+        self.seedMap = seedMap
+        self.teamForRoster = teamForRoster
+        self.teamDisplayName = teamDisplayName
+    }
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            // Connector lines layer
+            connectorLines
+
+            // Cards layer
+            HStack(alignment: .top, spacing: Self.roundSpacing) {
+                ForEach(rounds, id: \.round) { roundData in
+                    roundColumn(roundData)
+                }
+            }
+        }
+        .coordinateSpace(name: "bracket")
+    }
+
     // MARK: - Round Column
 
     private func roundColumn(_ roundData: BracketRound) -> some View {
-        VStack(spacing: XomperTheme.Spacing.md) {
+        let roundIndex = roundData.round - (rounds.first?.round ?? 1)
+        let verticalSpacing = verticalSpacingFor(roundIndex: roundIndex)
+
+        return VStack(spacing: verticalSpacing) {
             Text(roundData.label)
                 .font(.caption)
                 .fontWeight(.semibold)
                 .foregroundStyle(XomperColors.textSecondary)
                 .textCase(.uppercase)
                 .tracking(0.5)
+                .padding(.bottom, XomperTheme.Spacing.xs)
 
             ForEach(roundData.matches) { match in
                 matchCard(match, isFirstRound: roundData.round == roundData.minRound)
+                    .background(
+                        GeometryReader { geo in
+                            Color.clear
+                                .preference(
+                                    key: CardFramePreferenceKey.self,
+                                    value: [match.id: geo.frame(in: .named("bracket"))]
+                                )
+                        }
+                    )
             }
         }
-        .frame(width: 200)
+        .frame(width: Self.cardWidth)
+        .onPreferenceChange(CardFramePreferenceKey.self) { frames in
+            cardFrames.merge(frames) { _, new in new }
+        }
+    }
+
+    private func verticalSpacingFor(roundIndex: Int) -> CGFloat {
+        switch roundIndex {
+        case 0: return XomperTheme.Spacing.md
+        case 1: return XomperTheme.Spacing.xxl + XomperTheme.Spacing.md
+        case 2: return XomperTheme.Spacing.xxxl + XomperTheme.Spacing.xxl
+        default: return XomperTheme.Spacing.xxxl * 2
+        }
+    }
+
+    // MARK: - Connector Lines
+
+    private var connectorLines: some View {
+        Canvas { context, _ in
+            let lineColor = XomperColors.surfaceLight
+            for roundData in rounds {
+                for match in roundData.matches {
+                    drawConnectorsForMatch(match, in: &context, color: lineColor)
+                }
+            }
+        }
+        .allowsHitTesting(false)
+    }
+
+    private func drawConnectorsForMatch(
+        _ match: PlayoffBracketMatch,
+        in context: inout GraphicsContext,
+        color: Color
+    ) {
+        // Draw lines from source matches to this match
+        let targetFrame = cardFrames[match.id]
+        guard let targetFrame else { return }
+
+        let sources: [(BracketSource?, Bool)] = [
+            (match.team1From, true),
+            (match.team2From, false)
+        ]
+
+        for (source, isTop) in sources {
+            guard let source else { continue }
+            let sourceMatchId = sourceMatchIdString(source: source, currentRound: match.round)
+            guard let sourceFrame = cardFrames[sourceMatchId] else { continue }
+
+            let startX = sourceFrame.maxX
+            let startY = sourceFrame.midY
+            let endX = targetFrame.minX
+            let endY = isTop ? targetFrame.minY + targetFrame.height * 0.25
+                             : targetFrame.minY + targetFrame.height * 0.75
+            let midX = (startX + endX) / 2
+
+            var path = Path()
+            path.move(to: CGPoint(x: startX, y: startY))
+            path.addLine(to: CGPoint(x: midX, y: startY))
+            path.addLine(to: CGPoint(x: midX, y: endY))
+            path.addLine(to: CGPoint(x: endX, y: endY))
+
+            context.stroke(
+                path,
+                with: .color(color),
+                lineWidth: 1.5
+            )
+        }
+    }
+
+    private func sourceMatchIdString(source: BracketSource, currentRound: Int) -> String {
+        let sourceRound = currentRound - 1
+        if let matchNum = source.winnerOfMatch {
+            return "r\(sourceRound)-m\(matchNum)"
+        }
+        if let matchNum = source.loserOfMatch {
+            return "r\(sourceRound)-m\(matchNum)"
+        }
+        return ""
     }
 
     // MARK: - Match Card
@@ -125,56 +334,64 @@ struct PlayoffBracketView: View {
     private func matchCard(_ match: PlayoffBracketMatch, isFirstRound: Bool) -> some View {
         let isChampionship = match.placement == 1
 
-        return VStack(spacing: 0) {
-            if let label = matchLabel(match) {
-                Text(label)
-                    .font(.caption2)
-                    .fontWeight(.bold)
-                    .foregroundStyle(isChampionship ? XomperColors.championGold : XomperColors.textSecondary)
-                    .textCase(.uppercase)
-                    .tracking(0.5)
-                    .padding(.vertical, XomperTheme.Spacing.xs)
-                    .frame(maxWidth: .infinity)
-                    .background(
-                        isChampionship
-                            ? XomperColors.championGold.opacity(0.1)
-                            : XomperColors.surfaceLight.opacity(0.3)
-                    )
-            }
+        return Button {
+            let generator = UIImpactFeedbackGenerator(style: .medium)
+            generator.impactOccurred()
+            selectedMatch = match
+        } label: {
+            VStack(spacing: 0) {
+                if let label = matchLabel(match) {
+                    Text(label)
+                        .font(.caption2)
+                        .fontWeight(.bold)
+                        .foregroundStyle(isChampionship ? XomperColors.championGold : XomperColors.textSecondary)
+                        .textCase(.uppercase)
+                        .tracking(0.5)
+                        .padding(.vertical, XomperTheme.Spacing.xs)
+                        .frame(maxWidth: .infinity)
+                        .background(
+                            isChampionship
+                                ? XomperColors.championGold.opacity(0.1)
+                                : XomperColors.surfaceLight.opacity(0.3)
+                        )
+                }
 
-            teamRow(
-                rosterId: match.team1RosterId,
-                source: match.team1From,
-                isWinner: match.winnerRosterId != nil && match.winnerRosterId == match.team1RosterId,
-                isLoser: match.winnerRosterId != nil && match.winnerRosterId != match.team1RosterId,
-                showSeed: isFirstRound
-            )
-
-            Divider()
-                .background(XomperColors.surfaceLight.opacity(0.3))
-
-            teamRow(
-                rosterId: match.team2RosterId,
-                source: match.team2From,
-                isWinner: match.winnerRosterId != nil && match.winnerRosterId == match.team2RosterId,
-                isLoser: match.winnerRosterId != nil && match.winnerRosterId != match.team2RosterId,
-                showSeed: isFirstRound
-            )
-        }
-        .background(XomperColors.bgCard)
-        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
-        .overlay(
-            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md)
-                .stroke(
-                    isChampionship
-                        ? XomperColors.championGold.opacity(0.5)
-                        : XomperColors.surfaceLight.opacity(0.3),
-                    lineWidth: 1
+                teamRow(
+                    rosterId: match.team1RosterId,
+                    source: match.team1From,
+                    isWinner: match.winnerRosterId != nil && match.winnerRosterId == match.team1RosterId,
+                    isLoser: match.winnerRosterId != nil && match.winnerRosterId != match.team1RosterId,
+                    showSeed: isFirstRound
                 )
-        )
-        .xomperShadow(.sm)
+
+                Divider()
+                    .background(XomperColors.surfaceLight.opacity(0.3))
+
+                teamRow(
+                    rosterId: match.team2RosterId,
+                    source: match.team2From,
+                    isWinner: match.winnerRosterId != nil && match.winnerRosterId == match.team2RosterId,
+                    isLoser: match.winnerRosterId != nil && match.winnerRosterId != match.team2RosterId,
+                    showSeed: isFirstRound
+                )
+            }
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md)
+                    .stroke(
+                        isChampionship
+                            ? XomperColors.championGold.opacity(0.5)
+                            : XomperColors.surfaceLight.opacity(0.3),
+                        lineWidth: isChampionship ? 2 : 1
+                    )
+            )
+            .xomperShadow(.sm)
+        }
+        .buttonStyle(BracketCardButtonStyle())
         .accessibilityElement(children: .combine)
         .accessibilityLabel(matchAccessibilityLabel(match))
+        .accessibilityHint("Double tap to view match details")
     }
 
     // MARK: - Team Row
@@ -190,7 +407,7 @@ struct PlayoffBracketView: View {
             teamAvatar(rosterId: rosterId)
                 .frame(width: 28, height: 28)
 
-            Text(teamDisplayName(rosterId: rosterId, source: source))
+            Text(teamDisplayName(rosterId, source))
                 .font(.subheadline)
                 .fontWeight(isWinner ? .bold : .regular)
                 .foregroundStyle(
@@ -201,7 +418,7 @@ struct PlayoffBracketView: View {
                 .lineLimit(1)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-            if showSeed, let seed = rosterId {
+            if showSeed, let rosterId, let seed = seedMap[rosterId] {
                 Text("#\(seed)")
                     .font(.caption2)
                     .fontDesign(.monospaced)
@@ -240,30 +457,7 @@ struct PlayoffBracketView: View {
         .overlay(Circle().stroke(XomperColors.surfaceLight, lineWidth: 1))
     }
 
-    // MARK: - Helpers
-
-    private func teamDisplayName(rosterId: Int?, source: BracketSource?) -> String {
-        if let rosterId, let team = teamForRoster(rosterId) {
-            return team.teamName
-        }
-        if let rosterId {
-            return "Roster \(rosterId)"
-        }
-        if let source {
-            if let w = source.winnerOfMatch {
-                return "W of Match \(w)"
-            }
-            if let l = source.loserOfMatch {
-                return "L of Match \(l)"
-            }
-        }
-        return "TBD"
-    }
-
-    private func teamForRoster(_ rosterId: Int?) -> StandingsTeam? {
-        guard let rosterId else { return nil }
-        return standings.first { $0.rosterId == rosterId }
-    }
+    // MARK: - Label Helpers
 
     private func matchLabel(_ match: PlayoffBracketMatch) -> String? {
         switch match.placement {
@@ -276,39 +470,190 @@ struct PlayoffBracketView: View {
     }
 
     private func matchAccessibilityLabel(_ match: PlayoffBracketMatch) -> String {
-        let t1 = teamDisplayName(rosterId: match.team1RosterId, source: match.team1From)
-        let t2 = teamDisplayName(rosterId: match.team2RosterId, source: match.team2From)
+        let t1 = teamDisplayName(match.team1RosterId, match.team1From)
+        let t2 = teamDisplayName(match.team2RosterId, match.team2From)
         let label = matchLabel(match).map { "\($0): " } ?? ""
         if let winnerId = match.winnerRosterId {
-            let winner = teamDisplayName(rosterId: winnerId, source: nil)
+            let winner = teamDisplayName(winnerId, nil)
             return "\(label)\(t1) vs \(t2), winner: \(winner)"
         }
         return "\(label)\(t1) vs \(t2)"
     }
+}
 
-    private func groupByRound(_ matches: [PlayoffBracketMatch]) -> [BracketRound] {
-        var roundMap: [Int: [PlayoffBracketMatch]] = [:]
-        for match in matches {
-            roundMap[match.round, default: []].append(match)
+// MARK: - Button Style
+
+private struct BracketCardButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+            .animation(.easeInOut(duration: 0.15), value: configuration.isPressed)
+    }
+}
+
+// MARK: - Preference Key for Card Frames
+
+private struct CardFramePreferenceKey: PreferenceKey {
+    nonisolated(unsafe) static var defaultValue: [String: CGRect] = [:]
+    static func reduce(value: inout [String: CGRect], nextValue: () -> [String: CGRect]) {
+        value.merge(nextValue()) { _, new in new }
+    }
+}
+
+// MARK: - Match Detail Sheet
+
+private struct BracketMatchDetailSheet: View {
+    let match: PlayoffBracketMatch
+    let standings: [StandingsTeam]
+
+    @Environment(\.dismiss) private var dismiss
+
+    private var team1: StandingsTeam? {
+        guard let id = match.team1RosterId else { return nil }
+        return standings.first { $0.rosterId == id }
+    }
+
+    private var team2: StandingsTeam? {
+        guard let id = match.team2RosterId else { return nil }
+        return standings.first { $0.rosterId == id }
+    }
+
+    private var isChampionship: Bool { match.placement == 1 }
+
+    var body: some View {
+        VStack(spacing: XomperTheme.Spacing.lg) {
+            if let label = placementLabel {
+                HStack(spacing: XomperTheme.Spacing.xs) {
+                    if isChampionship {
+                        Image(systemName: "trophy.fill")
+                            .foregroundStyle(XomperColors.championGold)
+                    }
+                    Text(label)
+                        .font(.headline)
+                        .foregroundStyle(isChampionship ? XomperColors.championGold : XomperColors.textSecondary)
+                }
+            }
+
+            HStack(alignment: .top, spacing: XomperTheme.Spacing.md) {
+                teamColumn(team: team1, rosterId: match.team1RosterId, isWinner: match.winnerRosterId == match.team1RosterId)
+                vsColumn
+                teamColumn(team: team2, rosterId: match.team2RosterId, isWinner: match.winnerRosterId == match.team2RosterId)
+            }
+            .padding(XomperTheme.Spacing.md)
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+            .overlay(
+                RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                    .stroke(
+                        isChampionship ? XomperColors.championGold.opacity(0.5) : XomperColors.surfaceLight.opacity(0.3),
+                        lineWidth: isChampionship ? 2 : 1
+                    )
+            )
+
+            if match.winnerRosterId == nil {
+                Text("Match not yet played")
+                    .font(.subheadline)
+                    .foregroundStyle(XomperColors.textMuted)
+            }
+
+            Spacer()
         }
-        let minRound = roundMap.keys.min() ?? 1
-        return roundMap.keys.sorted().map { round in
-            BracketRound(round: round, matches: roundMap[round] ?? [], minRound: minRound)
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .navigationTitle("Match Details")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Close") { dismiss() }
+                    .foregroundStyle(XomperColors.championGold)
+            }
         }
     }
 
-    private func buildStandings() {
-        guard let league = leagueStore.currentLeague else { return }
-        standings = StandingsBuilder.buildStandings(
-            rosters: leagueStore.currentLeagueRosters,
-            users: leagueStore.currentLeagueUsers,
-            league: league
-        )
+    private func teamColumn(team: StandingsTeam?, rosterId: Int?, isWinner: Bool) -> some View {
+        let hasWinner = match.winnerRosterId != nil
+        let isLoser = hasWinner && !isWinner
+
+        return VStack(spacing: XomperTheme.Spacing.sm) {
+            if let team {
+                AsyncImage(url: team.avatarURL) { image in
+                    image.resizable().scaledToFill()
+                } placeholder: {
+                    Image(systemName: "person.circle.fill")
+                        .resizable()
+                        .foregroundStyle(XomperColors.textMuted)
+                }
+                .frame(width: 48, height: 48)
+                .clipShape(Circle())
+                .overlay(Circle().stroke(isWinner ? XomperColors.successGreen : XomperColors.surfaceLight, lineWidth: 2))
+
+                Text(team.teamName)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(isWinner ? XomperColors.successGreen : isLoser ? XomperColors.textMuted : XomperColors.textPrimary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+
+                Text(team.record)
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textSecondary)
+
+                if let seed = standings.first(where: { $0.rosterId == team.rosterId })?.leagueRank {
+                    Text("Seed #\(seed)")
+                        .font(.caption2)
+                        .fontDesign(.monospaced)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .padding(.horizontal, XomperTheme.Spacing.sm)
+                        .padding(.vertical, XomperTheme.Spacing.xs)
+                        .background(XomperColors.surfaceLight.opacity(0.3))
+                        .clipShape(Capsule())
+                }
+
+                if isWinner {
+                    Text("WINNER")
+                        .font(.caption2)
+                        .fontWeight(.bold)
+                        .foregroundStyle(XomperColors.deepNavy)
+                        .padding(.horizontal, XomperTheme.Spacing.sm)
+                        .padding(.vertical, XomperTheme.Spacing.xs)
+                        .background(XomperColors.championGold)
+                        .clipShape(Capsule())
+                }
+            } else {
+                Image(systemName: "questionmark.circle.fill")
+                    .resizable()
+                    .frame(width: 48, height: 48)
+                    .foregroundStyle(XomperColors.textMuted)
+
+                Text("TBD")
+                    .font(.subheadline)
+                    .foregroundStyle(XomperColors.textMuted)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .opacity(isLoser ? 0.6 : 1.0)
     }
 
-    private func loadBrackets() async {
-        guard let league = leagueStore.currentLeague else { return }
-        await leagueStore.fetchBrackets(leagueId: league.leagueId)
+    private var vsColumn: some View {
+        VStack(spacing: XomperTheme.Spacing.xs) {
+            Spacer().frame(height: XomperTheme.Spacing.md)
+            Text("VS")
+                .font(.caption)
+                .fontWeight(.bold)
+                .foregroundStyle(XomperColors.textMuted)
+        }
+    }
+
+    private var placementLabel: String? {
+        switch match.placement {
+        case 1: return "Championship"
+        case 3: return "3rd Place Match"
+        case 5: return "5th Place Match"
+        case 7: return "7th Place Match"
+        default: return "Round \(match.round)"
+        }
     }
 }
 

--- a/Xomper/Features/League/StandingsView.swift
+++ b/Xomper/Features/League/StandingsView.swift
@@ -80,6 +80,8 @@ struct StandingsView: View {
                     playoffCutoff: leagueStore.currentLeague?.settings?.playoffTeams
                 ) {
                     selectTeam(team)
+                } onProfileTap: {
+                    navigateToProfile(team)
                 }
             }
         }
@@ -121,6 +123,8 @@ struct StandingsView: View {
                     playoffCutoff: nil
                 ) {
                     selectTeam(team)
+                } onProfileTap: {
+                    navigateToProfile(team)
                 }
             }
         }
@@ -152,6 +156,10 @@ struct StandingsView: View {
     }
 
     // MARK: - Actions
+
+    private func navigateToProfile(_ team: StandingsTeam) {
+        router.navigate(to: .userProfile(userId: team.userId))
+    }
 
     private func selectTeam(_ team: StandingsTeam) {
         let user = leagueStore.currentLeagueUsers.first { $0.userId == team.userId }
@@ -195,6 +203,7 @@ private struct StandingsRowView: View {
     let isMyTeam: Bool
     let playoffCutoff: Int?
     let onTap: () -> Void
+    var onProfileTap: (() -> Void)?
 
     @State private var isPressed = false
 
@@ -234,6 +243,15 @@ private struct StandingsRowView: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityDescription)
         .accessibilityHint("Double tap to view team details")
+        .contextMenu {
+            if let onProfileTap {
+                Button {
+                    onProfileTap()
+                } label: {
+                    Label("View Owner Profile", systemImage: "person.circle")
+                }
+            }
+        }
     }
 
     private var rankBadge: some View {

--- a/Xomper/Features/League/WorldCupView.swift
+++ b/Xomper/Features/League/WorldCupView.swift
@@ -129,7 +129,6 @@ private struct WorldCupDivisionSection: View {
         VStack(spacing: XomperTheme.Spacing.md) {
             divisionHeader
             standingsTable
-            qualifyLine
         }
         .padding(XomperTheme.Spacing.lg)
         .background(XomperColors.bgCard.opacity(0.6))
@@ -159,8 +158,42 @@ private struct WorldCupDivisionSection: View {
                     rank: index + 1,
                     seasons: seasons
                 )
+
+                if index + 1 == qualificationCutoff, index + 1 < division.teams.count {
+                    qualificationDivider
+                }
             }
         }
+    }
+
+    private var qualificationCutoff: Int { 2 }
+
+    private var qualificationDivider: some View {
+        HStack(spacing: XomperTheme.Spacing.sm) {
+            Rectangle()
+                .fill(XomperColors.championGold.opacity(0.4))
+                .frame(height: 2)
+
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                Image(systemName: "checkmark.seal.fill")
+                    .font(.caption2)
+                Text("QUALIFIED")
+                    .font(.caption2)
+                    .fontWeight(.heavy)
+                    .tracking(1)
+            }
+            .foregroundStyle(XomperColors.championGold)
+            .padding(.horizontal, XomperTheme.Spacing.sm)
+            .padding(.vertical, XomperTheme.Spacing.xs)
+            .background(XomperColors.championGold.opacity(0.12))
+            .clipShape(Capsule())
+
+            Rectangle()
+                .fill(XomperColors.championGold.opacity(0.4))
+                .frame(height: 2)
+        }
+        .padding(.vertical, XomperTheme.Spacing.sm)
+        .accessibilityLabel("Qualification cutoff. Top \(qualificationCutoff) teams above this line are qualified.")
     }
 
     private var tableHeader: some View {
@@ -194,27 +227,6 @@ private struct WorldCupDivisionSection: View {
             .frame(width: width, alignment: alignment)
     }
 
-    @ViewBuilder
-    private var qualifyLine: some View {
-        if division.teams.count > 2 {
-            HStack(spacing: XomperTheme.Spacing.sm) {
-                Text("Qualified")
-                    .font(.caption2)
-                    .fontWeight(.bold)
-                    .foregroundStyle(XomperColors.championGold)
-                    .padding(.horizontal, XomperTheme.Spacing.sm)
-                    .padding(.vertical, XomperTheme.Spacing.xs)
-                    .background(XomperColors.championGold.opacity(0.15))
-                    .clipShape(Capsule())
-
-                Rectangle()
-                    .fill(XomperColors.championGold.opacity(0.3))
-                    .frame(height: 1)
-            }
-            .padding(.top, XomperTheme.Spacing.xs)
-            .accessibilityLabel("Top 2 teams above this line are qualified")
-        }
-    }
 }
 
 // MARK: - Team Row
@@ -263,17 +275,33 @@ private struct WorldCupTeamRow: View {
 
     private var teamInfoCell: some View {
         VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
-            Text(team.teamName.isEmpty ? team.username : team.teamName)
-                .font(.caption)
-                .fontWeight(.semibold)
-                .foregroundStyle(XomperColors.textPrimary)
-                .lineLimit(1)
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                Text(team.teamName.isEmpty ? team.username : team.teamName)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .lineLimit(1)
+
+                if team.qualified {
+                    qualifiedBadge
+                }
+            }
             Text(team.username)
                 .font(.caption2)
                 .foregroundStyle(XomperColors.textSecondary)
                 .lineLimit(1)
         }
         .frame(width: 120, alignment: .leading)
+    }
+
+    private var qualifiedBadge: some View {
+        Text("Q")
+            .font(.system(size: 9, weight: .heavy, design: .rounded))
+            .foregroundStyle(XomperColors.bgDark)
+            .frame(width: 16, height: 16)
+            .background(XomperColors.successGreen)
+            .clipShape(Circle())
+            .accessibilityLabel("Qualified")
     }
 
     private func statCell(
@@ -316,7 +344,7 @@ private struct WorldCupTeamRow: View {
 
     private var rowBackground: Color {
         team.qualified
-            ? XomperColors.championGold.opacity(0.05)
+            ? XomperColors.successGreen.opacity(0.1)
             : XomperColors.bgCard.opacity(0.3)
     }
 

--- a/Xomper/Features/Team/TeamView.swift
+++ b/Xomper/Features/Team/TeamView.swift
@@ -13,20 +13,41 @@ struct TeamView: View {
         league.rosterPositions ?? []
     }
 
+    private var hasPlayers: Bool {
+        !playerStore.players.isEmpty
+    }
+
     var body: some View {
         ScrollView {
             VStack(spacing: XomperTheme.Spacing.lg) {
                 teamHeader
-                startersSection
-                benchSection
-                taxiSection
-                irSection
+
+                if !hasPlayers && playerStore.isLoading {
+                    LoadingView(message: "Loading players...")
+                        .frame(height: 200)
+                } else if !hasPlayers {
+                    EmptyStateView(
+                        icon: "arrow.clockwise",
+                        title: "Players Not Loaded",
+                        message: "Pull to refresh to load player data."
+                    )
+                } else {
+                    startersSection
+                    benchSection
+                    taxiSection
+                    irSection
+                }
             }
             .padding(.horizontal, XomperTheme.Spacing.md)
             .padding(.bottom, XomperTheme.Spacing.xl)
         }
         .refreshable {
             await refreshRoster()
+        }
+        .task {
+            if !hasPlayers {
+                await playerStore.loadPlayers()
+            }
         }
         .background(XomperColors.bgDark)
         .sheet(item: $selectedPlayer) { player in


### PR DESCRIPTION
## Summary
- **Team view**: Show loading state when player database hasn't loaded yet, auto-trigger load
- **Playoff bracket**: Full rework with connector lines, correct seed numbers, clickable matches with detail sheet
- **Matchup detail**: Add bench player section, show real team names instead of "Team A/B"
- **World Cup**: Gold QUALIFIED divider with checkmark, green tint + Q badge for qualified teams
- **Standings**: Context menu on rows to navigate to owner profile

## Test plan
- [ ] Open standings, tap a team → verify roster loads (or shows loading spinner)
- [ ] Open playoff bracket → verify connector lines between rounds, correct seed numbers
- [ ] Tap a bracket match → verify detail sheet opens
- [ ] Toggle to consolation bracket → verify it renders
- [ ] Open a matchup detail → verify bench players show below starters
- [ ] Open World Cup → verify QUALIFIED divider and green row tinting
- [ ] Long-press a standings row → verify "View Owner Profile" context menu

Closes #1, Closes #2, Closes #3, Closes #4, Closes #5, Closes #6