### PR TITLE
feat: push notification support

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		7607DB7C775FCCC3B7C3377B /* StandingsTeam.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29D510D87CD290AE7F76FBF /* StandingsTeam.swift */; };
 		76260F26A40213A62E5F22FB /* RecordBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AD376EFB7AD4A192FAB3E8F /* RecordBadge.swift */; };
 		77A0EFCEE4340D3A7853BF08 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43685B0C212A644C0EF202E5 /* ProfileView.swift */; };
+		7D94ADAC136455C3056D5867 /* PushNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAEC7A4917990425085AE71 /* PushNotificationManager.swift */; };
 		7E34464209AAF9EC6801191A /* NflState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E5A60EE78F668F02CF63C0 /* NflState.swift */; };
 		7EA8F8FCEFFE3C165655208C /* MatchupHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF491605034E9F8C00BC0572 /* MatchupHistoryView.swift */; };
 		80E6A85F05ED2AFFC648FAFA /* RulesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9382BCB18DFEB416A50A039 /* RulesView.swift */; };
@@ -50,6 +51,7 @@
 		8E8B3EC17A43676ACA176FC3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6F2D6E80C100927C4C20FAD7 /* Assets.xcassets */; };
 		901F54CB41785D269CC63160 /* WorldCupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E1C6D5A18697DE79586C1B /* WorldCupStore.swift */; };
 		98F895FBCECB23325658339C /* StandingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A47FD1CF3BE7AE0B940DEC /* StandingsView.swift */; };
+		9D9E8D2C4A8A0C623AC1EF0D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E767CD5492176E84C2092B0F /* AppDelegate.swift */; };
 		9E5C71DAB504EDCDF2084DF3 /* MyProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558164667DF7D89C4DF2F32E /* MyProfileView.swift */; };
 		A28A24923C27CF0929ED97E1 /* Double+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669A80C2A9F46A0C4612388C /* Double+Formatting.swift */; };
 		A4D93DF4C02A8DE6C695CE4D /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E94170F987E8EFE5C566B9B /* LoginView.swift */; };
@@ -129,10 +131,12 @@
 		B66A2C896FE4C62CF9719D7A /* TaxiStealConfirmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiStealConfirmView.swift; sourceTree = "<group>"; };
 		BB5E661424C55F695BF96281 /* AuthGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthGateView.swift; sourceTree = "<group>"; };
 		BC44D14381C74E97D8AF868F /* PlayerDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerDetailView.swift; sourceTree = "<group>"; };
+		C1CD5644F6F8376CA86092AF /* Xomper.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Xomper.entitlements; sourceTree = "<group>"; };
 		C82B0FEAAB9BC80BA0801E98 /* XomperColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperColors.swift; sourceTree = "<group>"; };
 		C83EF3C6C93199CF3FCBAE42 /* Matchup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Matchup.swift; sourceTree = "<group>"; };
 		C9382BCB18DFEB416A50A039 /* RulesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesView.swift; sourceTree = "<group>"; };
 		CC3F6B5022E8151683A45F4F /* PlayerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerStore.swift; sourceTree = "<group>"; };
+		CEAEC7A4917990425085AE71 /* PushNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationManager.swift; sourceTree = "<group>"; };
 		DB1FE16B5220928685DCF19E /* SleeperAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleeperAPIClient.swift; sourceTree = "<group>"; };
 		DBD0F6820960B354EAB3E89D /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		DC24A8748C940FC57B142AFF /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
@@ -140,6 +144,7 @@
 		DF491605034E9F8C00BC0572 /* MatchupHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupHistoryView.swift; sourceTree = "<group>"; };
 		E1E5A60EE78F668F02CF63C0 /* NflState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NflState.swift; sourceTree = "<group>"; };
 		E6A47FD1CF3BE7AE0B940DEC /* StandingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsView.swift; sourceTree = "<group>"; };
+		E767CD5492176E84C2092B0F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E7F510E2F428E107F1AD75CD /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		E969C4A894017F9D0072CCFA /* WorldCup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCup.swift; sourceTree = "<group>"; };
 		ECC70812B3E7E07BA6658A54 /* AvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
@@ -192,6 +197,7 @@
 		27302FD4ACE49B1C63222F13 /* App */ = {
 			isa = PBXGroup;
 			children = (
+				E767CD5492176E84C2092B0F /* AppDelegate.swift */,
 				22D61F12E32D7C81FCA8F8CE /* ContentView.swift */,
 				A8BD31456E25771C8D7D39C9 /* XomperApp.swift */,
 			);
@@ -340,6 +346,7 @@
 				D8964B32007F666B41D138C5 /* Extensions */,
 				B3F6F3856481009365322743 /* Models */,
 				258608C1F12AB1DDE8EA751F /* Networking */,
+				E7C39A75BB7E636569F65BF7 /* Notifications */,
 				E1A7A2D932D868B1C49CE814 /* Stores */,
 				E7C661C0A256DAE14C4C5532 /* Theme */,
 			);
@@ -349,6 +356,7 @@
 		D35130CF3DC0C4469E9698DA /* Xomper */ = {
 			isa = PBXGroup;
 			children = (
+				C1CD5644F6F8376CA86092AF /* Xomper.entitlements */,
 				27302FD4ACE49B1C63222F13 /* App */,
 				6FCB5AB805D7BDEE3A200785 /* Config */,
 				D257CB729EDFC6660FF4B0A8 /* Core */,
@@ -384,6 +392,14 @@
 				43E1C6D5A18697DE79586C1B /* WorldCupStore.swift */,
 			);
 			path = Stores;
+			sourceTree = "<group>";
+		};
+		E7C39A75BB7E636569F65BF7 /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				CEAEC7A4917990425085AE71 /* PushNotificationManager.swift */,
+			);
+			path = Notifications;
 			sourceTree = "<group>";
 		};
 		E7C661C0A256DAE14C4C5532 /* Theme */ = {
@@ -488,6 +504,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9D9E8D2C4A8A0C623AC1EF0D /* AppDelegate.swift in Sources */,
 				8C67D3AAFE5A0A124BDE5F1A /* AppRouter.swift in Sources */,
 				C82AE6076A6555CD294777EE /* AppTab.swift in Sources */,
 				D78D5302B3D17DE9BE7D557C /* AuthGateView.swift in Sources */,
@@ -525,6 +542,7 @@
 				CB47F51AA46AEBC59183C449 /* PlayoffBracketView.swift in Sources */,
 				6C89029D05AEE66FB2315616 /* Profile.swift in Sources */,
 				77A0EFCEE4340D3A7853BF08 /* ProfileView.swift in Sources */,
+				7D94ADAC136455C3056D5867 /* PushNotificationManager.swift in Sources */,
 				76260F26A40213A62E5F22FB /* RecordBadge.swift in Sources */,
 				54863F3F6ECDD3BE00083582 /* Roster.swift in Sources */,
 				CFE915FD4020FDEB923157C2 /* RuleProposal.swift in Sources */,
@@ -564,6 +582,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Xomper/Xomper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -713,6 +732,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Xomper/Xomper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = NO;

--- a/Xomper/App/AppDelegate.swift
+++ b/Xomper/App/AppDelegate.swift
@@ -1,0 +1,31 @@
+import UIKit
+import UserNotifications
+
+final class AppDelegate: NSObject, UIApplicationDelegate, Sendable {
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        UNUserNotificationCenter.current().delegate = PushNotificationManager.shared
+        return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        Task { @MainActor in
+            PushNotificationManager.shared.registerDeviceToken(deviceToken)
+        }
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        Task { @MainActor in
+            PushNotificationManager.shared.handleRegistrationError(error)
+        }
+    }
+}

--- a/Xomper/App/XomperApp.swift
+++ b/Xomper/App/XomperApp.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 @main
 struct XomperApp: App {
-    @State private var authStore = AuthStore()
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    @State private var authStore: AuthStore
     @State private var leagueStore = LeagueStore()
     @State private var userStore = UserStore()
     @State private var teamStore = TeamStore()
@@ -12,6 +14,12 @@ struct XomperApp: App {
     @State private var worldCupStore = WorldCupStore()
     @State private var taxiSquadStore = TaxiSquadStore()
     @State private var rulesStore = RulesStore()
+
+    init() {
+        _authStore = State(initialValue: AuthStore(
+            pushManager: PushNotificationManager.shared
+        ))
+    }
 
     var body: some Scene {
         WindowGroup {

--- a/Xomper/Core/Networking/XomperAPIClient.swift
+++ b/Xomper/Core/Networking/XomperAPIClient.swift
@@ -3,10 +3,12 @@ import Foundation
 // MARK: - Protocol
 
 protocol XomperAPIClientProtocol: Sendable {
-    func sendRuleProposalEmail(proposal: RuleProposalEmailPayload, recipients: [String]) async throws
-    func sendRuleAcceptedEmail(proposal: RuleProposalEmailPayload, approvedBy: [String], rejectedBy: [String], recipients: [String]) async throws
-    func sendRuleDeniedEmail(proposal: RuleProposalEmailPayload, approvedBy: [String], rejectedBy: [String], recipients: [String]) async throws
-    func sendTaxiStealEmail(stealer: TaxiStealerPayload, player: TaxiPlayerPayload, owner: TaxiOwnerPayload, recipients: [String], leagueName: String) async throws
+    func sendRuleProposalEmail(proposal: RuleProposalEmailPayload, recipients: [String], userIds: [String]) async throws
+    func sendRuleAcceptedEmail(proposal: RuleProposalEmailPayload, approvedBy: [String], rejectedBy: [String], recipients: [String], userIds: [String]) async throws
+    func sendRuleDeniedEmail(proposal: RuleProposalEmailPayload, approvedBy: [String], rejectedBy: [String], recipients: [String], userIds: [String]) async throws
+    func sendTaxiStealEmail(stealer: TaxiStealerPayload, player: TaxiPlayerPayload, owner: TaxiOwnerPayload, recipients: [String], userIds: [String], leagueName: String) async throws
+    func registerDevice(userId: String, deviceToken: String) async throws
+    func unregisterDevice(userId: String, deviceToken: String) async throws
 }
 
 // MARK: - Request Payloads
@@ -118,7 +120,7 @@ final class XomperAPIClient: XomperAPIClientProtocol {
 
     // MARK: - Rule Emails
 
-    func sendRuleProposalEmail(proposal: RuleProposalEmailPayload, recipients: [String]) async throws {
+    func sendRuleProposalEmail(proposal: RuleProposalEmailPayload, recipients: [String], userIds: [String]) async throws {
         let body: [String: Any] = [
             "proposal": [
                 "title": proposal.title,
@@ -126,7 +128,8 @@ final class XomperAPIClient: XomperAPIClientProtocol {
                 "proposed_by_username": proposal.proposedByUsername,
                 "league_name": proposal.leagueName
             ],
-            "recipients": recipients
+            "recipients": recipients,
+            "user_ids": userIds
         ]
         try await post("/email/rule-proposal", body: body)
     }
@@ -135,7 +138,8 @@ final class XomperAPIClient: XomperAPIClientProtocol {
         proposal: RuleProposalEmailPayload,
         approvedBy: [String],
         rejectedBy: [String],
-        recipients: [String]
+        recipients: [String],
+        userIds: [String]
     ) async throws {
         let body: [String: Any] = [
             "proposal": [
@@ -146,7 +150,8 @@ final class XomperAPIClient: XomperAPIClientProtocol {
             ],
             "approved_by": approvedBy,
             "rejected_by": rejectedBy,
-            "recipients": recipients
+            "recipients": recipients,
+            "user_ids": userIds
         ]
         try await post("/email/rule-accept", body: body)
     }
@@ -155,7 +160,8 @@ final class XomperAPIClient: XomperAPIClientProtocol {
         proposal: RuleProposalEmailPayload,
         approvedBy: [String],
         rejectedBy: [String],
-        recipients: [String]
+        recipients: [String],
+        userIds: [String]
     ) async throws {
         let body: [String: Any] = [
             "proposal": [
@@ -166,7 +172,8 @@ final class XomperAPIClient: XomperAPIClientProtocol {
             ],
             "approved_by": approvedBy,
             "rejected_by": rejectedBy,
-            "recipients": recipients
+            "recipients": recipients,
+            "user_ids": userIds
         ]
         try await post("/email/rule-deny", body: body)
     }
@@ -178,6 +185,7 @@ final class XomperAPIClient: XomperAPIClientProtocol {
         player: TaxiPlayerPayload,
         owner: TaxiOwnerPayload,
         recipients: [String],
+        userIds: [String],
         leagueName: String
     ) async throws {
         let body: [String: Any] = [
@@ -196,9 +204,29 @@ final class XomperAPIClient: XomperAPIClientProtocol {
                 "email": owner.email
             ],
             "recipients": recipients,
+            "user_ids": userIds,
             "league_name": leagueName
         ]
         try await post("/email/taxi", body: body)
+    }
+
+    // MARK: - Device Registration
+
+    func registerDevice(userId: String, deviceToken: String) async throws {
+        let body: [String: Any] = [
+            "user_id": userId,
+            "device_token": deviceToken,
+            "platform": "ios"
+        ]
+        try await post("/device/register", body: body)
+    }
+
+    func unregisterDevice(userId: String, deviceToken: String) async throws {
+        let body: [String: Any] = [
+            "user_id": userId,
+            "device_token": deviceToken
+        ]
+        try await post("/device/unregister", body: body)
     }
 
     // MARK: - Private

--- a/Xomper/Core/Notifications/PushNotificationManager.swift
+++ b/Xomper/Core/Notifications/PushNotificationManager.swift
@@ -1,0 +1,69 @@
+import Foundation
+import UserNotifications
+import UIKit
+
+@Observable
+@MainActor
+final class PushNotificationManager: NSObject, Sendable {
+
+    // MARK: - State
+
+    private(set) var deviceToken: String?
+    private(set) var permissionGranted = false
+
+    // MARK: - Shared Instance
+
+    /// Shared instance used by AppDelegate for token forwarding.
+    static let shared = PushNotificationManager()
+
+    // MARK: - Permission
+
+    func requestPermission() async {
+        let center = UNUserNotificationCenter.current()
+
+        do {
+            let granted = try await center.requestAuthorization(
+                options: [.alert, .badge, .sound]
+            )
+            permissionGranted = granted
+
+            if granted {
+                UIApplication.shared.registerForRemoteNotifications()
+            }
+        } catch {
+            permissionGranted = false
+        }
+    }
+
+    // MARK: - Token Handling
+
+    func registerDeviceToken(_ tokenData: Data) {
+        let hexToken = tokenData.map { String(format: "%02x", $0) }.joined()
+        deviceToken = hexToken
+    }
+
+    func handleRegistrationError(_ error: Error) {
+        deviceToken = nil
+    }
+}
+
+// MARK: - UNUserNotificationCenterDelegate
+
+extension PushNotificationManager: UNUserNotificationCenterDelegate {
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound])
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        completionHandler()
+    }
+}

--- a/Xomper/Core/Stores/AuthStore.swift
+++ b/Xomper/Core/Stores/AuthStore.swift
@@ -24,9 +24,19 @@ final class AuthStore {
         isAuthenticated && isWhitelisted && sleeperUserId != nil
     }
 
+    // MARK: - Dependencies
+
+    private let pushManager: PushNotificationManager
+    private let apiClient: XomperAPIClientProtocol
+
     // MARK: - Init
 
-    init() {
+    init(
+        pushManager: PushNotificationManager = PushNotificationManager.shared,
+        apiClient: XomperAPIClientProtocol = XomperAPIClient()
+    ) {
+        self.pushManager = pushManager
+        self.apiClient = apiClient
         Task { await listenForAuthChanges() }
     }
 
@@ -105,6 +115,12 @@ final class AuthStore {
 
     func signOut() async {
         errorMessage = nil
+
+        // Unregister device token before signing out
+        if let token = pushManager.deviceToken, let userId = sleeperUserId {
+            try? await apiClient.unregisterDevice(userId: userId, deviceToken: token)
+        }
+
         do {
             try await supabase.auth.signOut()
         } catch {
@@ -120,6 +136,15 @@ final class AuthStore {
     private func loadUserData() async {
         await checkWhitelist()
         await resolveSleeperUser()
+        await registerForPushNotifications()
+    }
+
+    private func registerForPushNotifications() async {
+        await pushManager.requestPermission()
+
+        if let token = pushManager.deviceToken, let userId = sleeperUserId {
+            try? await apiClient.registerDevice(userId: userId, deviceToken: token)
+        }
     }
 
     /// Resolve Sleeper user ID from the whitelist's sleeper_username via Sleeper API

--- a/Xomper/Core/Stores/RulesStore.swift
+++ b/Xomper/Core/Stores/RulesStore.swift
@@ -347,18 +347,20 @@ final class RulesStore {
 
     // MARK: - Private: Email Notifications
 
-    private func getLeagueMemberEmails() async -> [String] {
+    private func getLeagueMembers() async -> (emails: [String], userIds: [String]) {
         do {
-            let rows: [SupabaseEmailRow] = try await supabase
+            let rows: [SupabaseEmailUserIdRow] = try await supabase
                 .from("whitelisted_users")
-                .select("email")
+                .select("email, user_id")
                 .eq("is_active", value: true)
                 .execute()
                 .value
 
-            return rows.map(\.email).filter { !$0.isEmpty }
+            let emails = rows.map(\.email).filter { !$0.isEmpty }
+            let userIds = rows.compactMap(\.userId).filter { !$0.isEmpty }
+            return (emails, userIds)
         } catch {
-            return []
+            return ([], [])
         }
     }
 
@@ -368,8 +370,8 @@ final class RulesStore {
         proposerName: String,
         leagueName: String
     ) async {
-        let recipients = await getLeagueMemberEmails()
-        guard !recipients.isEmpty else { return }
+        let members = await getLeagueMembers()
+        guard !members.emails.isEmpty else { return }
 
         let payload = RuleProposalEmailPayload(
             title: title,
@@ -378,7 +380,11 @@ final class RulesStore {
             leagueName: leagueName
         )
 
-        try? await apiClient.sendRuleProposalEmail(proposal: payload, recipients: recipients)
+        try? await apiClient.sendRuleProposalEmail(
+            proposal: payload,
+            recipients: members.emails,
+            userIds: members.userIds
+        )
     }
 
     private func sendStatusEmail(
@@ -387,10 +393,10 @@ final class RulesStore {
         leagueName: String
     ) async {
         async let voterNames = getVoterNames(proposalId: proposal.id)
-        async let recipients = getLeagueMemberEmails()
+        async let members = getLeagueMembers()
 
-        let (voters, emails) = await (voterNames, recipients)
-        guard !emails.isEmpty else { return }
+        let (voters, leagueMembers) = await (voterNames, members)
+        guard !leagueMembers.emails.isEmpty else { return }
 
         let payload = RuleProposalEmailPayload(
             title: proposal.title,
@@ -404,14 +410,16 @@ final class RulesStore {
                 proposal: payload,
                 approvedBy: voters.approvedBy,
                 rejectedBy: voters.rejectedBy,
-                recipients: emails
+                recipients: leagueMembers.emails,
+                userIds: leagueMembers.userIds
             )
         } else {
             try? await apiClient.sendRuleDeniedEmail(
                 proposal: payload,
                 approvedBy: voters.approvedBy,
                 rejectedBy: voters.rejectedBy,
-                recipients: emails
+                recipients: leagueMembers.emails,
+                userIds: leagueMembers.userIds
             )
         }
     }
@@ -498,6 +506,12 @@ private struct SupabaseVoteWithProfileRow: Decodable, Sendable {
     let profiles: SupabaseProfileJoin?
 }
 
-private struct SupabaseEmailRow: Decodable, Sendable {
+private struct SupabaseEmailUserIdRow: Decodable, Sendable {
     let email: String
+    let userId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case email
+        case userId = "user_id"
+    }
 }

--- a/Xomper/Core/Stores/TaxiSquadStore.swift
+++ b/Xomper/Core/Stores/TaxiSquadStore.swift
@@ -23,6 +23,12 @@ private struct OwnerEmailRow: Decodable, Sendable {
 
 private struct MemberEmailRow: Decodable, Sendable {
     let email: String
+    let userId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case email
+        case userId = "user_id"
+    }
 }
 
 // MARK: - TaxiSquadStore
@@ -165,12 +171,12 @@ final class TaxiSquadStore {
                 ])
                 .execute()
 
-            // 2. Fetch owner email and all league member emails in parallel
+            // 2. Fetch owner email and all league members in parallel
             async let ownerInfoTask = fetchOwnerEmail(sleeperUsername: player.ownerUsername)
-            async let recipientsTask = fetchLeagueMemberEmails()
+            async let membersTask = fetchLeagueMembers()
 
             let ownerInfo = await ownerInfoTask
-            let recipients = await recipientsTask
+            let members = await membersTask
 
             // 3. Send email notification (fire and forget, don't block on failure)
             let team = player.player.displayTeam
@@ -195,7 +201,8 @@ final class TaxiSquadStore {
                 stealer: stealerPayload,
                 player: playerPayload,
                 owner: ownerPayload,
-                recipients: recipients,
+                recipients: members.emails,
+                userIds: members.userIds,
                 leagueName: leagueName
             )
 
@@ -279,18 +286,20 @@ final class TaxiSquadStore {
         }
     }
 
-    /// Fetches all active league member emails from whitelisted_users.
-    private func fetchLeagueMemberEmails() async -> [String] {
+    /// Fetches all active league member emails and user IDs from whitelisted_users.
+    private func fetchLeagueMembers() async -> (emails: [String], userIds: [String]) {
         do {
             let rows: [MemberEmailRow] = try await supabase
                 .from("whitelisted_users")
-                .select("email")
+                .select("email, user_id")
                 .eq("is_active", value: true)
                 .execute()
                 .value
-            return rows.map(\.email).filter { !$0.isEmpty }
+            let emails = rows.map(\.email).filter { !$0.isEmpty }
+            let userIds = rows.compactMap(\.userId).filter { !$0.isEmpty }
+            return (emails, userIds)
         } catch {
-            return []
+            return ([], [])
         }
     }
 

--- a/Xomper/Xomper.entitlements
+++ b/Xomper/Xomper.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>aps-environment</key>
+    <string>development</string>
+</dict>
+</plist>

--- a/project.yml
+++ b/project.yml
@@ -31,6 +31,7 @@ targets:
     settings:
       base:
         INFOPLIST_FILE: Xomper/Resources/Info.plist
+        CODE_SIGN_ENTITLEMENTS: Xomper/Xomper.entitlements
         PRODUCT_BUNDLE_IDENTIFIER: com.Xomware.Xomper
         CODE_SIGN_IDENTITY: "Apple Development"
         PROVISIONING_PROFILE_SPECIFIER: ""


### PR DESCRIPTION
## Summary
- Add `PushNotificationManager` (@Observable, @MainActor) with APNs token registration and foreground notification display
- Add `AppDelegate` bridging via `@UIApplicationDelegateAdaptor` for push token relay
- Add `registerDevice`/`unregisterDevice` API endpoints to `XomperAPIClient`
- Auto-request push permission after sign-in, register device token, unregister on sign-out
- Pass `user_ids` alongside emails in rule proposal and taxi steal API calls for server-side push
- Add `aps-environment` entitlement for push notifications

## Deploy Notes
- Requires Push Notifications capability enabled on App ID `com.Xomware.Xomper` in Apple Developer portal
- Merging to main triggers Xcode Cloud build → TestFlight
- Backend + infra PRs must be deployed first for device registration endpoints to work

## Test plan
- [ ] Build succeeds (verified locally on iOS Simulator)
- [ ] Push permission prompt appears after sign-in
- [ ] Device token registered with backend after granting permission
- [ ] Push notifications received for rule proposals, votes, and taxi steal requests
- [ ] Token unregistered on sign-out