### PR TITLE
#13 add settings page and enhance profile

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		7607DB7C775FCCC3B7C3377B /* StandingsTeam.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29D510D87CD290AE7F76FBF /* StandingsTeam.swift */; };
 		76260F26A40213A62E5F22FB /* RecordBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AD376EFB7AD4A192FAB3E8F /* RecordBadge.swift */; };
 		77A0EFCEE4340D3A7853BF08 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43685B0C212A644C0EF202E5 /* ProfileView.swift */; };
+		77CFB7F9C5E4975E6350662B /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AFC2ADE424F95E3121BF22 /* SettingsView.swift */; };
 		7D94ADAC136455C3056D5867 /* PushNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAEC7A4917990425085AE71 /* PushNotificationManager.swift */; };
 		7E34464209AAF9EC6801191A /* NflState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E5A60EE78F668F02CF63C0 /* NflState.swift */; };
 		7EA8F8FCEFFE3C165655208C /* MatchupHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF491605034E9F8C00BC0572 /* MatchupHistoryView.swift */; };
@@ -132,6 +133,7 @@
 		BB5E661424C55F695BF96281 /* AuthGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthGateView.swift; sourceTree = "<group>"; };
 		BC44D14381C74E97D8AF868F /* PlayerDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerDetailView.swift; sourceTree = "<group>"; };
 		C1CD5644F6F8376CA86092AF /* Xomper.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Xomper.entitlements; sourceTree = "<group>"; };
+		C3AFC2ADE424F95E3121BF22 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		C82B0FEAAB9BC80BA0801E98 /* XomperColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperColors.swift; sourceTree = "<group>"; };
 		C83EF3C6C93199CF3FCBAE42 /* Matchup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Matchup.swift; sourceTree = "<group>"; };
 		C9382BCB18DFEB416A50A039 /* RulesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesView.swift; sourceTree = "<group>"; };
@@ -180,6 +182,7 @@
 			children = (
 				558164667DF7D89C4DF2F32E /* MyProfileView.swift */,
 				43685B0C212A644C0EF202E5 /* ProfileView.swift */,
+				C3AFC2ADE424F95E3121BF22 /* SettingsView.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -550,6 +553,7 @@
 				133F58C70F4FA02676079E9A /* RulesStore.swift in Sources */,
 				80E6A85F05ED2AFFC648FAFA /* RulesView.swift in Sources */,
 				F7E0A8B9AECD0291527E0D0E /* SearchView.swift in Sources */,
+				77CFB7F9C5E4975E6350662B /* SettingsView.swift in Sources */,
 				65DC95B6907B22347616C3D7 /* SleeperAPIClient.swift in Sources */,
 				B48B9F6061A67CFC74A096CC /* StandingsStore.swift in Sources */,
 				7607DB7C775FCCC3B7C3377B /* StandingsTeam.swift in Sources */,

--- a/Xomper/App/ContentView.swift
+++ b/Xomper/App/ContentView.swift
@@ -146,6 +146,8 @@ struct ContentView: View {
                 leagueStore: leagueStore,
                 router: router
             )
+        case .settings:
+            SettingsView(pushManager: PushNotificationManager.shared)
         }
     }
 

--- a/Xomper/Features/Profile/MyProfileView.swift
+++ b/Xomper/Features/Profile/MyProfileView.swift
@@ -24,6 +24,17 @@ struct MyProfileView: View {
         .navigationTitle("Profile")
         .navigationBarTitleDisplayMode(.large)
         .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    router.navigate(to: .settings)
+                } label: {
+                    Image(systemName: "gearshape.fill")
+                        .foregroundStyle(XomperColors.championGold)
+                }
+                .accessibilityLabel("Settings")
+            }
+        }
         .confirmationDialog(
             "Sign Out",
             isPresented: $showSignOutConfirmation,
@@ -112,15 +123,21 @@ struct MyProfileView: View {
 
     @ViewBuilder
     private var leagueSection: some View {
-        if let league = leagueStore.myLeague {
+        let leagues = leagueStore.userLeagues.isEmpty
+            ? (leagueStore.myLeague.map { [$0] } ?? [])
+            : leagueStore.userLeagues
+
+        if !leagues.isEmpty {
             VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
-                Text("My League")
+                Text("My Leagues")
                     .font(.subheadline)
                     .fontWeight(.semibold)
                     .foregroundStyle(XomperColors.textSecondary)
                     .padding(.leading, XomperTheme.Spacing.xs)
 
-                leagueRow(league)
+                ForEach(leagues, id: \.leagueId) { league in
+                    leagueRow(league)
+                }
             }
         }
     }
@@ -129,7 +146,10 @@ struct MyProfileView: View {
         Button {
             let generator = UIImpactFeedbackGenerator(style: .medium)
             generator.impactOccurred()
-            router.switchTab(.league)
+            Task {
+                await leagueStore.switchToLeague(id: league.leagueId)
+                router.switchTab(.league)
+            }
         } label: {
             HStack(spacing: XomperTheme.Spacing.md) {
                 AvatarView(
@@ -150,6 +170,17 @@ struct MyProfileView: View {
                     }
                     .font(.caption)
                     .foregroundStyle(XomperColors.textSecondary)
+
+                    if league.isDynasty {
+                        Text("Dynasty")
+                            .font(.caption2)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(XomperColors.deepNavy)
+                            .padding(.horizontal, XomperTheme.Spacing.sm)
+                            .padding(.vertical, XomperTheme.Spacing.xs)
+                            .background(XomperColors.championGold)
+                            .clipShape(Capsule())
+                    }
                 }
 
                 Spacer()

--- a/Xomper/Features/Profile/SettingsView.swift
+++ b/Xomper/Features/Profile/SettingsView.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+import UserNotifications
+
+struct SettingsView: View {
+    var pushManager: PushNotificationManager
+
+    @State private var notificationsEnabled = false
+    @State private var notificationStatus: UNAuthorizationStatus?
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: XomperTheme.Spacing.lg) {
+                notificationsSection
+                aboutSection
+            }
+            .padding(XomperTheme.Spacing.md)
+        }
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .navigationTitle("Settings")
+        .navigationBarTitleDisplayMode(.large)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .task {
+            await checkNotificationStatus()
+        }
+    }
+
+    // MARK: - Notifications
+
+    private var notificationsSection: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            Text("Notifications")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundStyle(XomperColors.textSecondary)
+                .padding(.leading, XomperTheme.Spacing.xs)
+
+            VStack(spacing: 0) {
+                HStack {
+                    Image(systemName: "bell.fill")
+                        .font(.title3)
+                        .foregroundStyle(XomperColors.championGold)
+                        .frame(width: 32)
+
+                    VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+                        Text("Push Notifications")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                            .foregroundStyle(XomperColors.textPrimary)
+
+                        Text(notificationStatusMessage)
+                            .font(.caption)
+                            .foregroundStyle(XomperColors.textMuted)
+                    }
+
+                    Spacer()
+
+                    if notificationStatus == .denied {
+                        Button("Open Settings") {
+                            openAppSettings()
+                        }
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(XomperColors.championGold)
+                    } else {
+                        Toggle("", isOn: $notificationsEnabled)
+                            .tint(XomperColors.championGold)
+                            .labelsHidden()
+                            .onChange(of: notificationsEnabled) { _, newValue in
+                                Task {
+                                    if newValue {
+                                        await pushManager.requestPermission()
+                                    }
+                                    await checkNotificationStatus()
+                                }
+                            }
+                    }
+                }
+                .padding(XomperTheme.Spacing.md)
+            }
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        }
+    }
+
+    private var notificationStatusMessage: String {
+        switch notificationStatus {
+        case .authorized:
+            "Rule proposals, votes, and taxi steal alerts"
+        case .denied:
+            "Notifications are disabled in System Settings"
+        case .provisional:
+            "Delivering quietly"
+        case .notDetermined:
+            "Enable to get alerts for league activity"
+        default:
+            "Enable to get alerts for league activity"
+        }
+    }
+
+    // MARK: - About
+
+    private var aboutSection: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            Text("About")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundStyle(XomperColors.textSecondary)
+                .padding(.leading, XomperTheme.Spacing.xs)
+
+            VStack(spacing: 0) {
+                aboutRow(label: "Version", value: appVersion)
+                Divider().overlay(XomperColors.surfaceLight)
+                aboutRow(label: "Build", value: buildNumber)
+                Divider().overlay(XomperColors.surfaceLight)
+                aboutRow(label: "Sleeper API", value: "api.sleeper.app")
+            }
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        }
+    }
+
+    private func aboutRow(label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(.subheadline)
+                .foregroundStyle(XomperColors.textPrimary)
+            Spacer()
+            Text(value)
+                .font(.subheadline)
+                .foregroundStyle(XomperColors.textMuted)
+        }
+        .padding(.horizontal, XomperTheme.Spacing.md)
+        .padding(.vertical, XomperTheme.Spacing.sm)
+        .frame(minHeight: XomperTheme.minTouchTarget)
+    }
+
+    // MARK: - Helpers
+
+    private var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+    }
+
+    private var buildNumber: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+    }
+
+    private func checkNotificationStatus() async {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        notificationStatus = settings.authorizationStatus
+        notificationsEnabled = settings.authorizationStatus == .authorized
+    }
+
+    private func openAppSettings() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url)
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SettingsView(pushManager: PushNotificationManager.shared)
+    }
+    .preferredColorScheme(.dark)
+}

--- a/Xomper/Navigation/AppRouter.swift
+++ b/Xomper/Navigation/AppRouter.swift
@@ -9,6 +9,7 @@ enum AppRoute: Hashable {
     case matchupHistory
     case taxiSquad
     case search
+    case settings
 }
 
 @Observable


### PR DESCRIPTION
- Add SettingsView with push notification toggle and app version info
- Add settings gear icon to profile toolbar
- Show all user's Sleeper leagues on profile (not just one)
- Add dynasty badge to league rows on profile
- Wire .settings route through AppRouter and ContentView