### PR TITLE
fix: @preconcurrency imports + pip3 flag

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -84,8 +84,7 @@ jobs:
             -authenticationKeyIssuerID "$ASC_API_ISSUER_ID" \
             -authenticationKeyPath "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_API_KEY_ID}.p8" \
             MARKETING_VERSION=${{ steps.version.outputs.marketing }} \
-            CURRENT_PROJECT_VERSION=${{ steps.version.outputs.build }} \
-            SWIFT_STRICT_CONCURRENCY=minimal
+            CURRENT_PROJECT_VERSION=${{ steps.version.outputs.build }}
 
       - name: Create ExportOptions.plist
         env:
@@ -141,7 +140,7 @@ jobs:
             --apiIssuer "$ASC_API_ISSUER_ID"
 
       - name: Install Python deps for TestFlight group assignment
-        run: pip3 install --quiet PyJWT cryptography requests
+        run: pip3 install --quiet --break-system-packages PyJWT cryptography requests
 
       - name: Assign build to TestFlight groups
         env:

--- a/Xomper/Core/Stores/AuthStore.swift
+++ b/Xomper/Core/Stores/AuthStore.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Supabase
+@preconcurrency import Supabase
 
 @MainActor
 @Observable

--- a/Xomper/Core/Stores/RulesStore.swift
+++ b/Xomper/Core/Stores/RulesStore.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Supabase
+@preconcurrency import Supabase
 
 @Observable
 @MainActor

--- a/Xomper/Core/Stores/TaxiSquadStore.swift
+++ b/Xomper/Core/Stores/TaxiSquadStore.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Supabase
+@preconcurrency import Supabase
 
 // MARK: - Supabase Response Types
 

--- a/Xomper/Features/Profile/SettingsView.swift
+++ b/Xomper/Features/Profile/SettingsView.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import UserNotifications
+@preconcurrency import UserNotifications
 
 struct SettingsView: View {
     var pushManager: PushNotificationManager


### PR DESCRIPTION
## Summary
Swift 6 language mode ignores \`SWIFT_STRICT_CONCURRENCY=minimal\`, so the earlier workflow-level override was a no-op and the Release archive failed on PostgREST / UserNotifications sendability. Mark the offending modules \`@preconcurrency\` and drop the useless override.

Also pass \`--break-system-packages\` to pip3 so the TestFlight group assignment step can install its deps on macos-15.

## Test plan
- [ ] Archive compiles without sendable errors
- [ ] Upload to TestFlight succeeds
- [ ] Build is assigned to Beta group