### PR TITLE
fix: revoke oldest Apple Development cert before archive

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -67,6 +67,47 @@ jobs:
           echo "Marketing version: $MARKETING_VERSION"
           echo "Build number: $BUILD_NUMBER"
 
+      - name: Install Python deps for ASC API
+        run: pip3 install --quiet --break-system-packages PyJWT cryptography requests
+
+      - name: Free Apple Development cert slot (revoke oldest if at limit)
+        env:
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+        run: |
+          python3 <<'PY'
+          import os, sys, time, jwt, requests
+          key_id = os.environ["ASC_API_KEY_ID"]
+          issuer = os.environ["ASC_API_ISSUER_ID"]
+          with open(os.path.expanduser(f"~/.appstoreconnect/private_keys/AuthKey_{key_id}.p8")) as f:
+              pk = f.read()
+          def tok():
+              return jwt.encode(
+                  {"iss": issuer, "iat": int(time.time()), "exp": int(time.time()) + 1200, "aud": "appstoreconnect-v1"},
+                  pk, algorithm="ES256", headers={"kid": key_id, "typ": "JWT"})
+          h = {"Authorization": f"Bearer {tok()}"}
+          base = "https://api.appstoreconnect.apple.com/v1"
+          r = requests.get(f"{base}/certificates", headers=h, params={"limit": 200})
+          r.raise_for_status()
+          all_certs = r.json()["data"]
+          dev = [c for c in all_certs if c["attributes"].get("certificateType") in ("IOS_DEVELOPMENT", "DEVELOPMENT")]
+          dev.sort(key=lambda c: c["attributes"].get("expirationDate", ""))
+          print(f"Found {len(dev)} development cert(s):")
+          for c in dev:
+              print(f"  {c['id']} type={c['attributes'].get('certificateType')} name={c['attributes'].get('name')} expires={c['attributes'].get('expirationDate')}")
+          keep_n = 1
+          if len(dev) > keep_n:
+              for c in dev[:len(dev) - keep_n]:
+                  print(f"Revoking {c['id']} ({c['attributes'].get('name')})")
+                  rr = requests.delete(f"{base}/certificates/{c['id']}", headers=h)
+                  if rr.status_code >= 400:
+                      print(f"!! Failed to revoke {c['id']}: {rr.status_code} {rr.text}", file=sys.stderr)
+                  else:
+                      print(f"Revoked {c['id']}")
+          else:
+              print("Under limit, no revocation needed")
+          PY
+
       - name: Archive
         env:
           ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
@@ -138,9 +179,6 @@ jobs:
             -t ios \
             --apiKey "$ASC_API_KEY_ID" \
             --apiIssuer "$ASC_API_ISSUER_ID"
-
-      - name: Install Python deps for TestFlight group assignment
-        run: pip3 install --quiet --break-system-packages PyJWT cryptography requests
 
       - name: Assign build to TestFlight groups
         env:


### PR DESCRIPTION
## Summary
- Call ASC API before archive to revoke the oldest Apple Development cert when at the 2-cert cap
- Prevents '-allowProvisioningUpdates' from failing with "Your account has reached the maximum number of certificates"

## Why
Every ephemeral runner creates a fresh dev cert. Over time this exhausts the team-wide cap and blocks new archives.

## Test plan
- [ ] Archive step succeeds
- [ ] IPA uploaded + visible in App Store Connect
- [ ] Build assigned to external Beta Friends group