### PR TITLE
fix: anchor league-specific features and surface league context

### DIFF
--- a/Xomper/Core/Models/Championship.swift
+++ b/Xomper/Core/Models/Championship.swift
@@ -6,6 +6,7 @@ import Foundation
 struct Championship: Identifiable, Sendable, Hashable {
     let season: String
     let leagueId: String
+    let leagueName: String
     let week: Int
     let teamName: String
     let pointsFor: Double

--- a/Xomper/Core/Stores/HistoryStore.swift
+++ b/Xomper/Core/Stores/HistoryStore.swift
@@ -166,18 +166,37 @@ final class HistoryStore {
     /// matchup history. Pure derived computation — no network, no side effects.
     ///
     /// Selection rule: a record is a championship win if `isChampionship == true`
-    /// AND the user is on the winning side. We dedupe by `season` (a season can
-    /// have at most one champ; if both week 16 and week 17 records flag this
-    /// user as winner — typical for multi-week playoff schemas — we keep the
-    /// later week, which is the actual title game).
+    /// AND the user is on the winning side AND the championship game is the
+    /// final week of that season's playoffs (filtering out non-final week-16/17
+    /// games that are flagged `isChampionship: true` due to the loose flag
+    /// semantics in `convertMatchupResults`). We dedupe by `season`.
+    ///
+    /// `leagueNamesById` maps `leagueId → human-readable name` for display.
+    /// If the map doesn't have an entry, falls back to the `season` string.
     ///
     /// Sorted descending by season (newest first).
-    func championships(forUserId userId: String) -> [Championship] {
+    func championships(
+        forUserId userId: String,
+        leagueNamesById: [String: String] = [:]
+    ) -> [Championship] {
         guard !userId.isEmpty else { return [] }
 
-        // Filter to championship-flagged records this user won.
+        // Determine the actual title-game week per (leagueId, season): the max
+        // championship-flagged week. The current ingest tags both week 16 and
+        // week 17 as `isChampionship`, but only the later week is the title
+        // game in a 2-week playoff format.
+        var titleWeekByKey: [String: Int] = [:]
+        for record in matchupHistory where record.isChampionship {
+            let key = "\(record.leagueId)-\(record.season)"
+            titleWeekByKey[key] = max(titleWeekByKey[key] ?? 0, record.week)
+        }
+
+        // Filter to championship-flagged records this user won, and only the
+        // actual title-game week per league/season.
         let wins = matchupHistory.filter { record in
             guard record.isChampionship else { return false }
+            let key = "\(record.leagueId)-\(record.season)"
+            guard record.week == titleWeekByKey[key] else { return false }
 
             if record.teamAUserId == userId,
                record.winnerRosterId == record.teamARosterId {
@@ -198,10 +217,12 @@ final class HistoryStore {
             let opponent = userIsTeamA ? record.teamBTeamName : record.teamATeamName
             let pointsFor = userIsTeamA ? record.teamAPoints : record.teamBPoints
             let pointsAgainst = userIsTeamA ? record.teamBPoints : record.teamAPoints
+            let leagueName = leagueNamesById[record.leagueId] ?? ""
 
             return Championship(
                 season: record.season,
                 leagueId: record.leagueId,
+                leagueName: leagueName,
                 week: record.week,
                 teamName: teamName,
                 pointsFor: pointsFor,
@@ -210,21 +231,26 @@ final class HistoryStore {
             )
         }
 
-        // Dedupe by season — prefer the later week (title game over semi).
-        var bySeason: [String: Championship] = [:]
+        // Dedupe by (leagueId, season) — a user can hold multiple titles
+        // across different leagues in the same year. Prefer later week.
+        var byKey: [String: Championship] = [:]
         for champ in mapped {
-            if let existing = bySeason[champ.season] {
+            let key = "\(champ.leagueId)-\(champ.season)"
+            if let existing = byKey[key] {
                 if champ.week > existing.week {
-                    bySeason[champ.season] = champ
+                    byKey[key] = champ
                 }
             } else {
-                bySeason[champ.season] = champ
+                byKey[key] = champ
             }
         }
 
-        // Sort descending by season (newest first).
-        return bySeason.values.sorted { a, b in
-            (Int(a.season) ?? 0) > (Int(b.season) ?? 0)
+        // Sort: descending by season, then by leagueId for stable order.
+        return byKey.values.sorted { a, b in
+            if a.season != b.season {
+                return (Int(a.season) ?? 0) > (Int(b.season) ?? 0)
+            }
+            return a.leagueId < b.leagueId
         }
     }
 

--- a/Xomper/Features/League/WorldCupView.swift
+++ b/Xomper/Features/League/WorldCupView.swift
@@ -5,15 +5,11 @@ struct WorldCupView: View {
     var historyStore: HistoryStore
     var leagueStore: LeagueStore
 
-    @Environment(\.selectedSeason) private var seasonStore: SeasonStore?
-
-    private var activeSeason: String? {
-        let season = seasonStore?.selectedSeason ?? ""
-        return season.isEmpty ? nil : season
-    }
-
+    /// World Cup is a 3-year cumulative tournament — the full aggregate is
+    /// the only meaningful view. Season filtering does not apply (the picker
+    /// is hidden for this destination in HeaderBar).
     private var displayedDivisions: [WorldCupDivision] {
-        worldCupStore.filteredDivisions(for: activeSeason)
+        worldCupStore.divisions
     }
 
     var body: some View {
@@ -79,9 +75,6 @@ struct WorldCupView: View {
     }
 
     private var seasonsSummary: String {
-        if let season = activeSeason, worldCupStore.seasons.contains(season) {
-            return "Divisional records for \(season)"
-        }
         let count = worldCupStore.seasons.count
         let seasonList = worldCupStore.seasons.joined(separator: ", ")
         let plural = count != 1 ? "s" : ""
@@ -102,14 +95,10 @@ struct WorldCupView: View {
         }
     }
 
-    /// Per-season columns to render in each division's stat table. When a
-    /// single season is selected, we only show that season's column. When the
-    /// selection is unset (or "All"), we keep the multi-season layout.
+    /// Per-season columns rendered in each division's stat table. World Cup is
+    /// always the multi-season aggregate — no single-season filter.
     private var displayedColumnSeasons: [String] {
-        if let season = activeSeason, worldCupStore.seasons.contains(season) {
-            return [season]
-        }
-        return worldCupStore.seasons
+        worldCupStore.seasons
     }
 
     // MARK: - Actions
@@ -117,8 +106,9 @@ struct WorldCupView: View {
     private func loadIfNeeded() async {
         guard !worldCupStore.hasData, !worldCupStore.isLoading else { return }
 
-        // Ensure chain and matchup history are loaded before computing standings
-        if leagueStore.leagueChain.isEmpty, let leagueId = leagueStore.currentLeague?.leagueId ?? leagueStore.myLeague?.leagueId {
+        // World Cup is anchored to myLeague (CLT) regardless of currentLeague
+        // selection. The format is league-specific to the home league.
+        if leagueStore.leagueChain.isEmpty, let leagueId = leagueStore.myLeague?.leagueId {
             await leagueStore.loadLeagueChain(startingFrom: leagueId)
         }
         if historyStore.matchupHistory.isEmpty, !leagueStore.leagueChain.isEmpty {
@@ -135,8 +125,8 @@ struct WorldCupView: View {
     }
 
     private func refreshData() async {
-        // Re-load matchup history from chain, then recompute
-        if let leagueId = leagueStore.currentLeague?.leagueId {
+        // Anchored to myLeague (CLT) — see loadIfNeeded above.
+        if let leagueId = leagueStore.myLeague?.leagueId {
             await leagueStore.loadLeagueChain(startingFrom: leagueId)
             await historyStore.loadMatchupHistory(chain: leagueStore.leagueChain)
         }

--- a/Xomper/Features/Profile/TrophyCaseCard.swift
+++ b/Xomper/Features/Profile/TrophyCaseCard.swift
@@ -19,6 +19,13 @@ struct TrophyCaseCard: View {
                     .foregroundStyle(XomperColors.textPrimary)
                     .lineLimit(1)
 
+                if !championship.leagueName.isEmpty {
+                    Text(championship.leagueName)
+                        .font(.caption)
+                        .foregroundStyle(XomperColors.championGold.opacity(0.85))
+                        .lineLimit(1)
+                }
+
                 Text(championship.teamName)
                     .font(.subheadline)
                     .foregroundStyle(XomperColors.textSecondary)
@@ -71,6 +78,7 @@ struct TrophyCaseCard: View {
             championship: Championship(
                 season: "2024",
                 leagueId: "abc",
+                leagueName: "Charlotte Dynasty League",
                 week: 17,
                 teamName: "Dom's Dynasty",
                 pointsFor: 127.4,
@@ -83,6 +91,7 @@ struct TrophyCaseCard: View {
             championship: Championship(
                 season: "2022",
                 leagueId: "abc",
+                leagueName: "Charlotte Dynasty League",
                 week: 16,
                 teamName: "Dom's Dynasty",
                 pointsFor: 154.2,

--- a/Xomper/Features/Profile/TrophyCaseSection.swift
+++ b/Xomper/Features/Profile/TrophyCaseSection.swift
@@ -31,7 +31,16 @@ struct TrophyCaseSection: View {
 
     @ViewBuilder
     private var content: some View {
-        let titles = historyStore.championships(forUserId: userId)
+        let leagueNames: [String: String] = Dictionary(
+            uniqueKeysWithValues: leagueStore.leagueChain.compactMap { league in
+                guard let name = league.name else { return nil }
+                return (league.leagueId, name)
+            }
+        )
+        let titles = historyStore.championships(
+            forUserId: userId,
+            leagueNamesById: leagueNames
+        )
 
         if historyStore.isLoadingMatchups && historyStore.matchupHistory.isEmpty {
             loadingCard

--- a/Xomper/Features/Shell/HeaderBar.swift
+++ b/Xomper/Features/Shell/HeaderBar.swift
@@ -18,13 +18,15 @@ struct HeaderBar: View {
     let router: AppRouter
     let avatarID: String?
     let seasonStore: SeasonStore
+    let leagueName: String?
 
     /// Destinations that opt into the season picker sub-row. Other
     /// destinations render only the 44pt wordmark row.
+    /// World Cup is intentionally excluded — it's a cumulative 3-year
+    /// tournament, season filtering does not apply.
     private static let seasonScopedDestinations: Set<TrayDestination> = [
         .matchups,
         .draftHistory,
-        .worldCup,
     ]
 
     var body: some View {
@@ -45,13 +47,22 @@ struct HeaderBar: View {
 
     private var wordmarkRow: some View {
         ZStack {
-            // Center wordmark — independent of leading/trailing buttons so it
-            // stays optically centered.
-            Text("Xomper")
-                .font(.title3)
-                .fontWeight(.bold)
-                .foregroundStyle(XomperColors.textPrimary)
-                .accessibilityAddTraits(.isHeader)
+            // Center wordmark + league name stacked.
+            VStack(spacing: 2) {
+                Text("Xomper")
+                    .font(.title3)
+                    .fontWeight(.bold)
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .accessibilityAddTraits(.isHeader)
+
+                if let leagueName, !leagueName.isEmpty {
+                    Text(leagueName)
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .lineLimit(1)
+                        .accessibilityLabel("Active league: \(leagueName)")
+                }
+            }
 
             HStack(spacing: 0) {
                 // Avatar (opens drawer).

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -41,7 +41,8 @@ struct MainShell: View {
                     navStore: navStore,
                     router: router,
                     avatarID: userStore.myUser?.avatar,
-                    seasonStore: seasonStore
+                    seasonStore: seasonStore,
+                    leagueName: leagueStore.currentLeague?.name ?? leagueStore.myLeague?.name
                 )
 
                 NavigationStack(path: $router.path) {

--- a/Xomper/Features/TaxiSquad/TaxiSquadView.swift
+++ b/Xomper/Features/TaxiSquad/TaxiSquadView.swift
@@ -37,8 +37,8 @@ struct TaxiSquadView: View {
             TaxiStealConfirmView(
                 player: player,
                 taxiSquadStore: taxiSquadStore,
-                leagueId: leagueStore.currentLeague?.leagueId ?? "",
-                leagueName: leagueStore.currentLeague?.name ?? "",
+                leagueId: leagueStore.myLeague?.leagueId ?? "",
+                leagueName: leagueStore.myLeague?.name ?? "",
                 stealerName: resolvedStealerName,
                 alreadyStolen: taxiSquadStore.stolenPlayerIds.contains(player.playerId),
                 isOwnPlayer: player.ownerUserId == authStore.sleeperUserId
@@ -191,11 +191,11 @@ struct TaxiSquadView: View {
     }
 
     private func loadTaxiSquad() async {
-        guard let leagueId = leagueStore.currentLeague?.leagueId else { return }
+        guard let leagueId = leagueStore.myLeague?.leagueId else { return }
 
         async let playersLoad: () = taxiSquadStore.loadTaxiSquadPlayers(
-            rosters: leagueStore.currentLeagueRosters,
-            users: leagueStore.currentLeagueUsers,
+            rosters: leagueStore.myLeagueRosters,
+            users: leagueStore.myLeagueUsers,
             playerStore: playerStore,
             leagueId: leagueId
         )


### PR DESCRIPTION
Closes #28, #29, #34.

## Summary
Bundles three post-overhaul QA fixes that surfaced from manual simulator testing:

### #34 — Default-league context
- `HeaderBar`: small caption under the "Xomper" wordmark showing the active league name. Always-visible context indicator.
- `TaxiSquadView` and `WorldCupView`: read `leagueStore.myLeague` (CLT Dynasty) directly instead of `currentLeague`. Both features are CLT-specific by design (taxi format + 3-year tournament). If the user navigates to another league via search/profile, these destinations stay anchored to home.

### #29 — World Cup is not season-switchable
- `HeaderBar`: drop `.worldCup` from `seasonScopedDestinations`. The picker no longer renders for World Cup.
- `WorldCupView`: drop `@Environment(\.selectedSeason)` reads. Always renders the multi-season aggregate via `worldCupStore.divisions`. Removes the misleading "single season" branch that was zeroing out data when 2025 was selected.

### #28 — Trophy Case champion logic
- `HistoryStore.championships(forUserId:)`:
  - Adds optional `leagueNamesById` parameter for display
  - Restricts to the actual title-game week per `(leagueId, season)` (max championship-flagged week) so a non-final week-16 game in a 2-week playoff doesn't qualify
  - Dedupes by `(leagueId, season)` instead of just `season` so titles across multiple leagues in the same year both render
- `Championship` model gains a `leagueName: String` field
- `TrophyCaseSection` builds a `[leagueId: name]` map from `leagueStore.leagueChain` and passes it through
- `TrophyCaseCard` renders the league name as a gold caption between the season title and the team name

## Test plan
- [ ] Header shows "Charlotte Dynasty League" caption under "Xomper" on cold launch
- [ ] Switch league via profile → caption updates
- [ ] Navigate to Taxi Squad after switching leagues → still shows CLT taxi data
- [ ] Navigate to World Cup → no season picker visible, multi-season aggregate renders
- [ ] Trophy case cards show league name on each card
- [ ] Trophy case shows only championships the user actually won (verify via real data)
- [ ] Build clean under Swift 6 strict concurrency

## Notes
- Stacks on #27 (search-extension) → #26 → #25 → #24 → #22.
- #30, #31, #32, #33 still open — to be addressed in follow-up patches.