### PR TITLE
fix: data loading fallbacks for race conditions

### DIFF
--- a/Xomper/Features/DraftHistory/DraftHistoryView.swift
+++ b/Xomper/Features/DraftHistory/DraftHistoryView.swift
@@ -125,7 +125,10 @@ struct DraftHistoryView: View {
     // MARK: - Data Loading
 
     private func loadDraftHistory() async {
-        guard let leagueId = leagueStore.currentLeague?.leagueId else { return }
+        // Fall back to home league if currentLeague hasn't resolved yet
+        // (bootstrap-vs-view-mount race).
+        guard let leagueId = leagueStore.currentLeague?.leagueId
+            ?? leagueStore.myLeague?.leagueId else { return }
 
         await leagueStore.loadLeagueChain(startingFrom: leagueId)
         let chain = leagueStore.leagueChain

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -200,6 +200,8 @@ struct MainShell: View {
 
     /// Resolves `teamStore.myTeam` to a TeamView at the root. Falls back to
     /// an empty-state placeholder if the team / roster / league hasn't loaded.
+    /// Triggers a `loadMyTeam` build if the league is loaded but the team
+    /// hasn't been resolved yet (bootstrap-vs-view-mount race).
     @ViewBuilder
     private var myTeamRoot: some View {
         if let team = teamStore.myTeam,
@@ -220,7 +222,28 @@ struct MainShell: View {
                 title: "Team Not Loaded",
                 message: "Your team will appear once your league finishes loading."
             )
+            .task {
+                await ensureMyTeamLoaded()
+            }
         }
+    }
+
+    /// Builds my-team from already-loaded league + rosters when bootstrap
+    /// raced ahead of the team-store population. Bails silently if data
+    /// isn't ready — the next view appearance retries.
+    private func ensureMyTeamLoaded() async {
+        guard teamStore.myTeam == nil,
+              let league = leagueStore.myLeague,
+              let userId = authStore.sleeperUserId,
+              !leagueStore.myLeagueRosters.isEmpty,
+              !leagueStore.myLeagueUsers.isEmpty else { return }
+
+        let standings = StandingsBuilder.buildStandings(
+            rosters: leagueStore.myLeagueRosters,
+            users: leagueStore.myLeagueUsers,
+            league: league
+        )
+        teamStore.loadMyTeam(from: standings, userId: userId)
     }
 
     // MARK: - Pushed routes

--- a/Xomper/Features/Team/TeamView.swift
+++ b/Xomper/Features/Team/TeamView.swift
@@ -22,15 +22,29 @@ struct TeamView: View {
             VStack(spacing: XomperTheme.Spacing.lg) {
                 teamHeader
 
-                if !hasPlayers && playerStore.isLoading {
+                if !hasPlayers && (playerStore.isLoading || isRefreshing) {
                     LoadingView(message: "Loading players...")
                         .frame(height: 200)
                 } else if !hasPlayers {
-                    EmptyStateView(
-                        icon: "arrow.clockwise",
-                        title: "Players Not Loaded",
-                        message: "Pull to refresh to load player data."
-                    )
+                    VStack(spacing: XomperTheme.Spacing.md) {
+                        EmptyStateView(
+                            icon: "arrow.clockwise",
+                            title: "Players Not Loaded",
+                            message: "Player data hasn't loaded yet."
+                        )
+                        Button {
+                            Task { await refreshRoster() }
+                        } label: {
+                            Label("Retry", systemImage: "arrow.clockwise")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(XomperColors.bgDark)
+                                .padding(.horizontal, XomperTheme.Spacing.lg)
+                                .padding(.vertical, XomperTheme.Spacing.sm)
+                                .background(XomperColors.championGold)
+                                .clipShape(Capsule())
+                        }
+                        .accessibilityLabel("Retry loading players")
+                    }
                 } else {
                     startersSection
                     benchSection


### PR DESCRIPTION
Closes #30, #31, #32.

## Summary
Three small race-condition fixes that surfaced in post-overhaul QA:

### #32 — Draft History falls back to home league
When `loadDraftHistory()` runs before `currentLeague` resolves, drafts never load. Adds fallback to `leagueStore.myLeague?.leagueId`.

### #31 — My Team self-heals from bootstrap race
If the user opens the My Team destination before `bootstrapPhase2` populates `teamStore.myTeam`, the empty state now kicks off `ensureMyTeamLoaded()` which builds standings from the already-loaded `myLeague` + rosters + users and populates the store.

### #30 — TeamView retry button
"Players Not Loaded" empty state gains a gold "Retry" capsule button. No more silent pull-to-refresh requirement.

## Test plan
- [ ] Open Draft History on cold launch (before league chain resolves) → drafts populate
- [ ] Open My Team immediately after sign-in → team renders (or self-heals into rendering)
- [ ] Force PlayerStore to be empty (e.g., on poisoned cache) → tap Retry → players load
- [ ] No regressions in normal flows
- [ ] Build clean under Swift 6 strict concurrency

## Notes
- Stacks on #38 (now merged).
- #33 (wrong league teams) likely already resolved by #34's HeaderBar league indicator. Will close after verifying.