### PR TITLE
feat: split Rules into 4 separate tray destinations

### DIFF
--- a/Xomper/Features/League/RulesView.swift
+++ b/Xomper/Features/League/RulesView.swift
@@ -1,9 +1,19 @@
 import SwiftUI
 
+/// Page filter — when set, RulesView renders only that single section.
+/// `nil` (default) renders the full multi-section page (legacy behavior).
+enum RulesPage {
+    case scoring
+    case leagueSettings
+    case ruleProposals
+    case rulebook
+}
+
 struct RulesView: View {
     var league: League
     var rulesStore: RulesStore
     var authStore: AuthStore
+    var page: RulesPage? = nil
 
     @State private var showProposalForm = false
     @State private var expandedRuleSections: Set<Int> = []
@@ -15,11 +25,23 @@ struct RulesView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: XomperTheme.Spacing.lg) {
-                scoringSettingsSection
-                rosterSlotsSection
-                leagueSettingsSection
-                proposalsSection
-                leagueRulebookSection
+                switch page {
+                case .scoring:
+                    scoringSettingsSection
+                    rosterSlotsSection
+                case .leagueSettings:
+                    leagueSettingsSection
+                case .ruleProposals:
+                    proposalsSection
+                case .rulebook:
+                    leagueRulebookSection
+                case .none:
+                    scoringSettingsSection
+                    rosterSlotsSection
+                    leagueSettingsSection
+                    proposalsSection
+                    leagueRulebookSection
+                }
             }
             .padding(.horizontal, XomperTheme.Spacing.md)
             .padding(.vertical, XomperTheme.Spacing.sm)

--- a/Xomper/Features/Shell/DrawerView.swift
+++ b/Xomper/Features/Shell/DrawerView.swift
@@ -33,8 +33,8 @@ struct DrawerView: View {
             entries: [.myTeam, .taxiSquad]
         ),
         TraySection(
-            title: "Meta",
-            entries: [.rules]
+            title: "Rules",
+            entries: [.rulebook, .scoring, .leagueSettings, .ruleProposals]
         ),
     ]
 

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -161,20 +161,17 @@ struct MainShell: View {
                     taxiSquadStore: taxiSquadStore
                 )
 
-            case .rules:
-                if let league = leagueStore.currentLeague ?? leagueStore.myLeague {
-                    RulesView(
-                        league: league,
-                        rulesStore: rulesStore,
-                        authStore: authStore
-                    )
-                } else {
-                    EmptyStateView(
-                        icon: "book",
-                        title: "No League Loaded",
-                        message: "Rules will appear once your league is loaded."
-                    )
-                }
+            case .rulebook:
+                rulesPage(.rulebook)
+
+            case .scoring:
+                rulesPage(.scoring)
+
+            case .leagueSettings:
+                rulesPage(.leagueSettings)
+
+            case .ruleProposals:
+                rulesPage(.ruleProposals)
 
             case .profile:
                 MyProfileView(
@@ -197,6 +194,27 @@ struct MainShell: View {
     }
 
     // MARK: - My Team root
+
+    /// Resolves a `RulesView` filtered to a single page (Scoring / League
+    /// Settings / Rule Proposals / Rulebook). Falls back to an empty state
+    /// when the league isn't loaded yet.
+    @ViewBuilder
+    private func rulesPage(_ page: RulesPage) -> some View {
+        if let league = leagueStore.currentLeague ?? leagueStore.myLeague {
+            RulesView(
+                league: league,
+                rulesStore: rulesStore,
+                authStore: authStore,
+                page: page
+            )
+        } else {
+            EmptyStateView(
+                icon: "book",
+                title: "No League Loaded",
+                message: "Rules will appear once your league is loaded."
+            )
+        }
+    }
 
     /// Resolves `teamStore.myTeam` to a TeamView at the root. Falls back to
     /// an empty-state placeholder if the team / roster / league hasn't loaded.

--- a/Xomper/Features/Shell/TrayDestination.swift
+++ b/Xomper/Features/Shell/TrayDestination.swift
@@ -7,7 +7,7 @@ import Foundation
 /// - Compete:  standings, matchups, playoffs
 /// - History:  draftHistory, matchupHistory, worldCup
 /// - Roster:   myTeam, taxiSquad
-/// - Meta:     rules
+/// - Rules:    rulebook, scoring, leagueSettings, ruleProposals
 /// - Profile/Settings are surfaced via the profile card and pinned footer.
 enum TrayDestination: Hashable {
     case standings
@@ -18,7 +18,10 @@ enum TrayDestination: Hashable {
     case worldCup
     case myTeam
     case taxiSquad
-    case rules
+    case rulebook
+    case scoring
+    case leagueSettings
+    case ruleProposals
     case profile
     case settings
 
@@ -34,7 +37,10 @@ enum TrayDestination: Hashable {
         case .worldCup:       "World Cup"
         case .myTeam:         "My Team"
         case .taxiSquad:      "Taxi Squad"
-        case .rules:          "Rules"
+        case .rulebook:       "Rulebook"
+        case .scoring:        "Scoring"
+        case .leagueSettings: "League Settings"
+        case .ruleProposals:  "Rule Proposals"
         case .profile:        "Profile"
         case .settings:       "Settings"
         }
@@ -51,7 +57,10 @@ enum TrayDestination: Hashable {
         case .worldCup:       "globe.americas.fill"
         case .myTeam:         "person.crop.square.fill"
         case .taxiSquad:      "bus.fill"
-        case .rules:          "book.fill"
+        case .rulebook:       "book.fill"
+        case .scoring:        "function"
+        case .leagueSettings: "slider.horizontal.3"
+        case .ruleProposals:  "checkmark.bubble.fill"
         case .profile:        "person.crop.circle.fill"
         case .settings:       "gearshape.fill"
         }


### PR DESCRIPTION
Closes #36.

## Summary
The single `.rules` tray destination jammed Scoring + Roster Slots + League Settings + Rule Proposals + Rulebook all onto one page, which buried the rulebook at the bottom and mixed read-only config with the proposal form.

Splits into 4 dedicated destinations grouped under a new "Rules" drawer section:
- **Rulebook** — collapsible markdown sections (promoted from bottom-buried to top of section)
- **Scoring** — scoring settings + roster slots
- **League Settings** — format/teams/playoff structure tiles
- **Rule Proposals** — proposal list + propose button + form sheet

## Implementation
- `TrayDestination`: replace `.rules` with `.rulebook` / `.scoring` / `.leagueSettings` / `.ruleProposals`
- `RulesView`: add `page: RulesPage?` filter; switch in body renders only the requested page; `nil` keeps legacy behavior
- `MainShell`: `rulesPage(_:)` helper routes each destination with the right page filter + league-not-loaded fallback
- `DrawerView`: "Meta" section renamed "Rules" with the four entries (rulebook first)

## Test plan
- [ ] Drawer shows 4 entries under Rules section
- [ ] Each opens to its own focused page
- [ ] Rulebook is no longer buried — it's the first entry
- [ ] Rule Proposals form sheet still works
- [ ] Build clean under Swift 6 strict concurrency