### PR TITLE
feat: career stats section on profile

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		556BA960B3DFFACAB2F3DFA6 /* EnvironmentValues+Season.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6504EE31A645398C41BC2ED1 /* EnvironmentValues+Season.swift */; };
 		578172B9CCF7AD92CB66821E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D61F12E32D7C81FCA8F8CE /* ContentView.swift */; };
 		57C17293587E8DBED9A14970 /* TradedPick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F49969EE42BDE6462664021 /* TradedPick.swift */; };
+		6010F16122E110BA50642611 /* CareerStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD43D54AB620DABD559F8A40 /* CareerStats.swift */; };
 		602B6E0F6BCF1DA7E3D75F07 /* AuthStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */; };
 		60FB3A9B54EAB11F015C1828 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC24A8748C940FC57B142AFF /* ErrorView.swift */; };
 		61EBC3AC052763EAAC807AC9 /* WorldCup.swift in Sources */ = {isa = PBXBuildFile; fileRef = E969C4A894017F9D0072CCFA /* WorldCup.swift */; };
@@ -78,6 +79,7 @@
 		BBBE8D43F297A49A915AA789 /* WorldCupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F83A5F997AF6E13C98660E /* WorldCupView.swift */; };
 		BDD14CA33B905F7A31910B1D /* SupabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10CD226D313FDD91E4037D8E /* SupabaseManager.swift */; };
 		C1D86EAE02F0D6EA70291876 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC70812B3E7E07BA6658A54 /* AvatarView.swift */; };
+		C381DCE8472D2F88B04FCBDA /* CareerStatsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CFD764A2BA7FF93B318A7F /* CareerStatsSection.swift */; };
 		C9D656F4702A3483BB8E970C /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A99CAA9B57C1A0144DCA22 /* Player.swift */; };
 		CB47F51AA46AEBC59183C449 /* PlayoffBracketView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581D4F6F3EB8FC0547F49927 /* PlayoffBracketView.swift */; };
 		CDA1A124C81E1FF5127BEE2C /* TraySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A497DF9DD9066BD24A1E19 /* TraySection.swift */; };
@@ -142,6 +144,7 @@
 		6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayoffBracket.swift; sourceTree = "<group>"; };
 		6F2C7D74B3584D53CE601054 /* MatchupDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupDetailView.swift; sourceTree = "<group>"; };
 		6F2D6E80C100927C4C20FAD7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		72CFD764A2BA7FF93B318A7F /* CareerStatsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareerStatsSection.swift; sourceTree = "<group>"; };
 		7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Draft.swift; sourceTree = "<group>"; };
 		840D50097382434B0D123ACB /* NavigationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStore.swift; sourceTree = "<group>"; };
 		8521885A7FF4C6910DFBF549 /* MatchupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupsView.swift; sourceTree = "<group>"; };
@@ -158,6 +161,7 @@
 		A83A8FEFFD8FA91F498D03A0 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		A8BD31456E25771C8D7D39C9 /* XomperApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperApp.swift; sourceTree = "<group>"; };
 		ACCFF9888476668EBE7AA0CC /* XomperTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = XomperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		AD43D54AB620DABD559F8A40 /* CareerStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareerStats.swift; sourceTree = "<group>"; };
 		AE543CB2E49335ADD02E8000 /* Roster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Roster.swift; sourceTree = "<group>"; };
 		B29D510D87CD290AE7F76FBF /* StandingsTeam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsTeam.swift; sourceTree = "<group>"; };
 		B3893B13276074EF6033CEA2 /* ClinchCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClinchCalculatorTests.swift; sourceTree = "<group>"; };
@@ -224,6 +228,7 @@
 		18DB797ECD581E0649842AFC /* Profile */ = {
 			isa = PBXGroup;
 			children = (
+				72CFD764A2BA7FF93B318A7F /* CareerStatsSection.swift */,
 				558164667DF7D89C4DF2F32E /* MyProfileView.swift */,
 				43685B0C212A644C0EF202E5 /* ProfileView.swift */,
 				C3AFC2ADE424F95E3121BF22 /* SettingsView.swift */,
@@ -366,6 +371,7 @@
 		B3F6F3856481009365322743 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				AD43D54AB620DABD559F8A40 /* CareerStats.swift */,
 				18383A0375F5728A9E3FE065 /* Championship.swift */,
 				7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */,
 				A789B8D49FA4430886626289 /* DraftHistory.swift */,
@@ -622,6 +628,8 @@
 				D78D5302B3D17DE9BE7D557C /* AuthGateView.swift in Sources */,
 				602B6E0F6BCF1DA7E3D75F07 /* AuthStore.swift in Sources */,
 				C1D86EAE02F0D6EA70291876 /* AvatarView.swift in Sources */,
+				6010F16122E110BA50642611 /* CareerStats.swift in Sources */,
+				C381DCE8472D2F88B04FCBDA /* CareerStatsSection.swift in Sources */,
 				366C0075FA9F4ABA1C88C1A9 /* Championship.swift in Sources */,
 				9134D2C8A8737083C9FB8F7F /* ClinchCalculator.swift in Sources */,
 				2F50FD9BC26550139DAD2E96 /* Config.swift in Sources */,

--- a/Xomper/Core/Models/CareerStats.swift
+++ b/Xomper/Core/Models/CareerStats.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// All-time per-user stats derived from `MatchupHistoryRecord`. Pure
+/// computation — never serialized, never persisted. Built by
+/// `HistoryStore.careerStats(forUserId:)`.
+struct CareerStats: Sendable, Hashable {
+    let wins: Int
+    let losses: Int
+    let ties: Int
+    let pointsFor: Double
+    let pointsAgainst: Double
+    let highestScore: Double
+    let highestScoreWeek: WeekRef?
+    let lowestScore: Double
+    let lowestScoreWeek: WeekRef?
+    let seasonsPlayed: Int
+    let playoffAppearances: Int
+
+    var totalGames: Int { wins + losses + ties }
+
+    /// Win rate as a fraction in [0, 1]. Returns 0 when no games played.
+    var winRate: Double {
+        guard totalGames > 0 else { return 0 }
+        return Double(wins) / Double(totalGames)
+    }
+
+    /// Average points per game played. Returns 0 when no games played.
+    var averagePointsFor: Double {
+        guard totalGames > 0 else { return 0 }
+        return pointsFor / Double(totalGames)
+    }
+
+    static let empty = CareerStats(
+        wins: 0, losses: 0, ties: 0,
+        pointsFor: 0, pointsAgainst: 0,
+        highestScore: 0, highestScoreWeek: nil,
+        lowestScore: 0, lowestScoreWeek: nil,
+        seasonsPlayed: 0, playoffAppearances: 0
+    )
+
+    var hasGames: Bool { totalGames > 0 }
+
+    struct WeekRef: Sendable, Hashable {
+        let season: String
+        let week: Int
+    }
+}

--- a/Xomper/Core/Stores/HistoryStore.swift
+++ b/Xomper/Core/Stores/HistoryStore.swift
@@ -254,6 +254,86 @@ final class HistoryStore {
         }
     }
 
+    // MARK: - Career Stats (Profile)
+
+    /// Aggregates all-time stats for the given user from `matchupHistory`.
+    /// Pure derived computation — no network, no side effects. Returns
+    /// `.empty` if the user has no recorded games.
+    func careerStats(forUserId userId: String) -> CareerStats {
+        guard !userId.isEmpty else { return .empty }
+
+        var wins = 0
+        var losses = 0
+        var ties = 0
+        var pointsFor: Double = 0
+        var pointsAgainst: Double = 0
+        var highest: Double = -.infinity
+        var highestRef: CareerStats.WeekRef?
+        var lowest: Double = .infinity
+        var lowestRef: CareerStats.WeekRef?
+        var seasons = Set<String>()
+        var playoffSeasons = Set<String>()
+
+        for record in matchupHistory {
+            let userIsTeamA = record.teamAUserId == userId
+            let userIsTeamB = record.teamBUserId == userId
+            guard userIsTeamA || userIsTeamB else { continue }
+
+            let userPoints = userIsTeamA ? record.teamAPoints : record.teamBPoints
+            let oppPoints = userIsTeamA ? record.teamBPoints : record.teamAPoints
+            let userRosterId = userIsTeamA ? record.teamARosterId : record.teamBRosterId
+
+            // Skip records that haven't been played yet (both 0 — preseason
+            // schedule placeholders) — they'd otherwise pollute lowest-score.
+            if userPoints == 0 && oppPoints == 0 { continue }
+
+            pointsFor += userPoints
+            pointsAgainst += oppPoints
+            seasons.insert(record.season)
+
+            if record.isPlayoff {
+                playoffSeasons.insert(record.season)
+            }
+
+            if userPoints > highest {
+                highest = userPoints
+                highestRef = .init(season: record.season, week: record.week)
+            }
+            if userPoints < lowest {
+                lowest = userPoints
+                lowestRef = .init(season: record.season, week: record.week)
+            }
+
+            if let winner = record.winnerRosterId {
+                if winner == userRosterId {
+                    wins += 1
+                } else {
+                    losses += 1
+                }
+            } else {
+                ties += 1
+            }
+        }
+
+        // Normalize sentinels for users with zero games.
+        if highest == -.infinity { highest = 0 }
+        if lowest == .infinity { lowest = 0 }
+
+        return CareerStats(
+            wins: wins,
+            losses: losses,
+            ties: ties,
+            pointsFor: pointsFor,
+            pointsAgainst: pointsAgainst,
+            highestScore: highest,
+            highestScoreWeek: highestRef,
+            lowestScore: lowest,
+            lowestScoreWeek: lowestRef,
+            seasonsPlayed: seasons.count,
+            playoffAppearances: playoffSeasons.count
+        )
+    }
+
     // MARK: - Fetch Raw Matchups for Detail
 
     /// Fetches the raw matchup data for a specific week to get player-level lineups and points.

--- a/Xomper/Features/Profile/CareerStatsSection.swift
+++ b/Xomper/Features/Profile/CareerStatsSection.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+/// Career-stats grid for the Profile page. Renders six tiles derived
+/// from `HistoryStore.careerStats(forUserId:)`. Pure presentation — the
+/// section's parent (`MyProfileView`) owns the history-bootstrap.
+struct CareerStatsSection: View {
+    var historyStore: HistoryStore
+    var userId: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            Text("Career Stats")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundStyle(XomperColors.textSecondary)
+                .padding(.leading, XomperTheme.Spacing.xs)
+
+            content
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        let stats = historyStore.careerStats(forUserId: userId)
+
+        if !stats.hasGames {
+            emptyCard
+        } else {
+            statsGrid(stats)
+        }
+    }
+
+    // MARK: - Stats Grid
+
+    private func statsGrid(_ stats: CareerStats) -> some View {
+        let columns = [
+            GridItem(.flexible(), spacing: XomperTheme.Spacing.sm),
+            GridItem(.flexible(), spacing: XomperTheme.Spacing.sm),
+        ]
+
+        return LazyVGrid(columns: columns, spacing: XomperTheme.Spacing.sm) {
+            statTile(
+                label: "Record",
+                value: recordString(stats),
+                accent: stats.winRate >= 0.5 ? XomperColors.successGreen : XomperColors.textPrimary
+            )
+            statTile(
+                label: "Win %",
+                value: percentString(stats.winRate),
+                accent: stats.winRate >= 0.5 ? XomperColors.successGreen : XomperColors.textPrimary
+            )
+            statTile(
+                label: "PF · Total",
+                value: pointsString(stats.pointsFor),
+                subtitle: "Avg \(pointsString(stats.averagePointsFor))",
+                accent: XomperColors.championGold
+            )
+            statTile(
+                label: "Highest Week",
+                value: pointsString(stats.highestScore),
+                subtitle: weekRefSubtitle(stats.highestScoreWeek),
+                accent: XomperColors.successGreen
+            )
+            statTile(
+                label: "Lowest Week",
+                value: pointsString(stats.lowestScore),
+                subtitle: weekRefSubtitle(stats.lowestScoreWeek),
+                accent: XomperColors.accentRed.opacity(0.85)
+            )
+            statTile(
+                label: "Seasons",
+                value: "\(stats.seasonsPlayed)",
+                subtitle: "\(stats.playoffAppearances) playoffs",
+                accent: XomperColors.textPrimary
+            )
+        }
+    }
+
+    // MARK: - Stat Tile
+
+    private func statTile(
+        label: String,
+        value: String,
+        subtitle: String? = nil,
+        accent: Color
+    ) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(XomperColors.textMuted)
+
+            Text(value)
+                .font(.title3)
+                .fontWeight(.semibold)
+                .foregroundStyle(accent)
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+
+            if let subtitle, !subtitle.isEmpty {
+                Text(subtitle)
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.textSecondary)
+                    .lineLimit(1)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .xomperCard()
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(value)\(subtitle.map { ". \($0)" } ?? "")")
+    }
+
+    // MARK: - Empty
+
+    private var emptyCard: some View {
+        VStack(spacing: XomperTheme.Spacing.sm) {
+            Image(systemName: "chart.bar.xaxis")
+                .font(.title2)
+                .foregroundStyle(XomperColors.textMuted)
+                .accessibilityHidden(true)
+
+            Text("Stats appear once your matchup history loads.")
+                .font(.subheadline)
+                .foregroundStyle(XomperColors.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .xomperCard()
+        .accessibilityElement(children: .combine)
+    }
+
+    // MARK: - Formatters
+
+    private func recordString(_ stats: CareerStats) -> String {
+        if stats.ties > 0 {
+            return "\(stats.wins)-\(stats.losses)-\(stats.ties)"
+        }
+        return "\(stats.wins)-\(stats.losses)"
+    }
+
+    private func percentString(_ value: Double) -> String {
+        String(format: "%.1f%%", value * 100)
+    }
+
+    private func pointsString(_ value: Double) -> String {
+        String(format: "%.1f", value)
+    }
+
+    private func weekRefSubtitle(_ ref: CareerStats.WeekRef?) -> String? {
+        guard let ref else { return nil }
+        return "\(ref.season) W\(ref.week)"
+    }
+}

--- a/Xomper/Features/Profile/MyProfileView.swift
+++ b/Xomper/Features/Profile/MyProfileView.swift
@@ -17,6 +17,7 @@ struct MyProfileView: View {
             VStack(spacing: XomperTheme.Spacing.lg) {
                 profileHeader
                 sleeperLinkStatus
+                careerStatsSection
                 trophyCaseSection
                 leagueSection
                 signOutSection
@@ -108,6 +109,20 @@ struct MyProfileView: View {
         .xomperCard()
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Sleeper account \(authStore.isFullySetUp ? "linked" : "not linked")")
+    }
+
+    // MARK: - Career Stats
+
+    @ViewBuilder
+    private var careerStatsSection: some View {
+        if authStore.isFullySetUp,
+           let userId = authStore.sleeperUserId,
+           !userId.isEmpty {
+            CareerStatsSection(
+                historyStore: historyStore,
+                userId: userId
+            )
+        }
     }
 
     // MARK: - Trophy Case


### PR DESCRIPTION
Closes #37.

## Summary
Profile previously showed only avatar + email + Sleeper-link + Trophy Case + leagues list. Adds a **Career Stats** grid above Trophy Case with six tiles derived from matchup history:

- **Record** — W-L (or W-L-T)
- **Win %** — green when ≥ 50%
- **PF total** — with average-per-game subtitle, gold accent
- **Highest weekly score** — with `2024 W11` style ref, green accent
- **Lowest weekly score** — same ref, red accent
- **Seasons played** — with playoff appearance count

## Implementation
- `CareerStats` model — derived, never persisted
- `HistoryStore.careerStats(forUserId:)` — pure aggregation; skips preseason 0-0 placeholder records so they don't pollute lowest-score
- `CareerStatsSection` — 2-column LazyVGrid of stat tiles, empty-state card when history hasn't loaded
- Inserted in `MyProfileView` between Sleeper-link card and Trophy Case
- Reuses Trophy Case's history bootstrap (same screen, same trigger)

## Test plan
- [ ] Career Stats appears between Sleeper-link and Trophy Case
- [ ] Stats reflect real matchup history (cross-check vs Sleeper)
- [ ] Empty state renders before history loads
- [ ] All accessibility labels read correctly
- [ ] Build clean under Swift 6 strict concurrency