### PR TITLE
feat: auto-bump version + auto-resolve home league across dynasty rollovers

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -30,6 +30,7 @@ jobs:
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           API_GATEWAY_URL: ${{ secrets.API_GATEWAY_URL }}
           WHITELISTED_LEAGUE_ID: ${{ secrets.WHITELISTED_LEAGUE_ID }}
+          WHITELISTED_LEAGUE_NAME: ${{ secrets.WHITELISTED_LEAGUE_NAME }}
         run: |
           cat > Xomper/Config/Config.swift <<EOF
           import Foundation
@@ -40,6 +41,7 @@ jobs:
               static let oauthCallbackURL = "xomper://login-callback"
               static let apiGatewayURL = "${API_GATEWAY_URL}"
               static let whitelistedLeagueId = "${WHITELISTED_LEAGUE_ID}"
+              static let whitelistedLeagueName = "${WHITELISTED_LEAGUE_NAME}"
 
               static var isConfigured: Bool {
                   !supabaseURL.contains("YOUR_") && !supabaseAnonKey.contains("YOUR_")
@@ -59,8 +61,16 @@ jobs:
       - name: Compute version and build number
         id: version
         run: |
-          MARKETING_VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
-          MARKETING_VERSION=${MARKETING_VERSION:-2.0.0}
+          # Derive major.minor from the latest tag (e.g. v2.1.0 → 2.1).
+          # Fallback to 2.0 when no tags exist. Patch auto-increments on
+          # every workflow run via github.run_number, so the version
+          # bumps from 2.0.0 to 2.0.N on each deploy without manual
+          # tagging. Tag a new minor (e.g. v2.1.0) when you want to
+          # bump from 2.0.X → 2.1.X.
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
+          BASE_VERSION=${LATEST_TAG:-2.0.0}
+          MAJOR_MINOR=$(echo "$BASE_VERSION" | cut -d. -f1,2)
+          MARKETING_VERSION="${MAJOR_MINOR}.${{ github.run_number }}"
           BUILD_NUMBER=$(date +%Y%m%d%H%M)
           echo "marketing=$MARKETING_VERSION" >> "$GITHUB_OUTPUT"
           echo "build=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"

--- a/Xomper/Config/Config.swift.template
+++ b/Xomper/Config/Config.swift.template
@@ -5,5 +5,17 @@ enum Config {
     static let supabaseAnonKey = "YOUR_ANON_KEY"
     static let oauthCallbackURL = "xomper://login-callback"
     static let apiGatewayURL = "https://YOUR_API_GATEWAY.execute-api.us-east-1.amazonaws.com"
+
+    /// Hardcoded fallback Sleeper league ID. This value is used on first
+    /// boot before the user is signed in. Once `whitelistedLeagueName`
+    /// is set and the user signs in, the app auto-resolves to that
+    /// season's matching league (so dynasty rollovers Just Work).
     static let whitelistedLeagueId = "YOUR_LEAGUE_ID"
+
+    /// League name used to find the *current* season's incarnation of
+    /// your home dynasty league among the user's Sleeper leagues. Set
+    /// this to the exact name of your Sleeper league (e.g.
+    /// "Charlotte Dynasty League"). Leave empty to disable name-based
+    /// resolution and rely solely on `whitelistedLeagueId`.
+    static let whitelistedLeagueName = ""
 }

--- a/Xomper/Core/Stores/LeagueStore.swift
+++ b/Xomper/Core/Stores/LeagueStore.swift
@@ -85,6 +85,53 @@ final class LeagueStore {
         isLoading = false
     }
 
+    // MARK: - Resolve current-season home league by name
+
+    /// Re-anchors `myLeague` (and `currentLeague` if it currently equals
+    /// the old `myLeague`) to the current-season incarnation of the home
+    /// dynasty league. Looks for a league in `userLeagues` whose `name`
+    /// matches `Config.whitelistedLeagueName`. No-op when the name isn't
+    /// configured, when no match is found, or when the match is already
+    /// the active `myLeague`.
+    ///
+    /// Solves the dynasty-rollover problem: each new Sleeper season
+    /// produces a *new* leagueId, so the hardcoded `whitelistedLeagueId`
+    /// goes stale every year. By matching on the stable league name we
+    /// follow the league forward automatically.
+    func resolveAndAnchorMyLeagueByName() async {
+        let targetName = Config.whitelistedLeagueName.trimmingCharacters(in: .whitespaces)
+        guard !targetName.isEmpty else { return }
+
+        let resolvedLeague = userLeagues.first { league in
+            (league.name ?? "").caseInsensitiveCompare(targetName) == .orderedSame
+        }
+
+        guard let resolved = resolvedLeague else { return }
+        guard resolved.leagueId != myLeague?.leagueId else { return }
+
+        do {
+            let context = try await fetchLeagueContext(leagueId: resolved.leagueId)
+            let wasCurrentMatchingMy = currentLeague?.leagueId == myLeague?.leagueId
+
+            myLeague = resolved
+            myLeagueUsers = context.users
+            myLeagueRosters = context.rosters
+
+            if wasCurrentMatchingMy {
+                currentLeague = resolved
+                currentLeagueUsers = context.users
+                currentLeagueRosters = context.rosters
+            }
+
+            // Invalidate the chain cache so subsequent loadLeagueChain
+            // calls walk back from the new (current-season) league.
+            leagueChainCache = nil
+            leagueChain = []
+        } catch {
+            // Non-fatal — keep the previously-loaded myLeague.
+        }
+    }
+
     // MARK: - Load League Chain (Dynasty History)
 
     func loadLeagueChain(startingFrom leagueId: String) async {

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -413,6 +413,18 @@ struct MainShell: View {
 
         await userStore.loadMyUser(userId: sleeperUserId)
 
+        // Load user's leagues for the current season *before* resolving
+        // myTeam, so the name-based home-league anchor (Phase 1 used the
+        // potentially-stale hardcoded ID) can re-anchor to this season's
+        // league before we build standings against it.
+        let season = nflStateStore.nflState?.season ?? leagueStore.myLeague?.season ?? "2024"
+        await leagueStore.loadUserLeagues(userId: sleeperUserId, season: season)
+
+        // Re-anchor myLeague to the current-season league matching
+        // Config.whitelistedLeagueName. No-op when the name isn't set or
+        // no match is found — the Phase 1 ID-based load remains.
+        await leagueStore.resolveAndAnchorMyLeagueByName()
+
         if let league = leagueStore.myLeague {
             let standings = StandingsBuilder.buildStandings(
                 rosters: leagueStore.myLeagueRosters,
@@ -421,9 +433,5 @@ struct MainShell: View {
             )
             teamStore.loadMyTeam(from: standings, userId: sleeperUserId)
         }
-
-        // Load all user's leagues for the home screen
-        let season = nflStateStore.nflState?.season ?? leagueStore.myLeague?.season ?? "2024"
-        await leagueStore.loadUserLeagues(userId: sleeperUserId, season: season)
     }
 }


### PR DESCRIPTION
Two TestFlight-affecting fixes.

## 1. Auto-bump marketing version
The deploy workflow was stuck on `2.0.0` because no git tags exist and the fallback was a literal `2.0.0`. Now uses `github.run_number` for the patch, so each deploy auto-increments: `2.0.N`. Tag a new minor (e.g. `v2.1.0`) when you want to bump the major/minor — patch keeps using `run_number` from there.

## 2. Auto-resolve home league by name
Sleeper rolls each dynasty league into a new `leagueId` every season, so the hardcoded `Config.whitelistedLeagueId` goes stale every year. The app was loading the wrong league for current-season views.

Adds `Config.whitelistedLeagueName`. After Phase 2 bootstrap loads `userLeagues`, `LeagueStore.resolveAndAnchorMyLeagueByName()` finds the user's current-season league matching that name and re-anchors `myLeague` to it. Dynasty rollovers handled forever; no manual ID update needed.

## Required follow-up (manual one-time)
Set the GitHub secret `WHITELISTED_LEAGUE_NAME` to the exact Sleeper league name (e.g. `Charlotte Dynasty League`). Without it, the deployed app falls back to ID-only behavior. Local `Config.swift` already updated.

## Test plan
- [ ] Next deploy bumps from `2.0.0` to `2.0.{run_number}`
- [ ] After sign-in, app loads current-season CLT (regardless of whether the hardcoded ID is current-year or stale)
- [ ] Dynasty history chain walks back from the new myLeague (cache invalidated)
- [ ] Header pill shows the current-season league name
- [ ] Build clean under Swift 6 strict concurrency

## Notes
- Both changes are independent. Versioning takes effect on next deploy. League resolution takes effect on next sign-in once the secret is set.