### PR TITLE
fix: Player.depthChartPosition is a string, not an int (THE players-not-loading bug)

### DIFF
--- a/Xomper/Core/Models/Player.swift
+++ b/Xomper/Core/Models/Player.swift
@@ -21,7 +21,15 @@ struct Player: Codable, Identifiable, Sendable {
     let searchFullName: String?
     let searchFirstName: String?
     let searchLastName: String?
-    let depthChartPosition: Int?
+    /// Sleeper returns this as a slot label string ("QB1", "RCB", "OL"…),
+    /// NOT a numeric position. iOS prior to this fix declared it `Int?`,
+    /// which made the strict JSONDecoder throw on every player with a
+    /// non-null value — and since `[String: Player]` decodes
+    /// transactionally, the whole 11k-player load failed silently. That
+    /// is the entire reason "no players are loading" was happening in
+    /// production while web (TypeScript types are erased at runtime)
+    /// shrugged it off.
+    let depthChartPosition: String?
     let depthChartOrder: Int?
     let searchRank: Int?
 
@@ -51,6 +59,91 @@ struct Player: Codable, Identifiable, Sendable {
         case depthChartPosition = "depth_chart_position"
         case depthChartOrder = "depth_chart_order"
         case searchRank = "search_rank"
+    }
+
+    /// Lenient decoder: every optional field uses `try?` so a single
+    /// type mismatch in Sleeper's response (e.g., a future field that
+    /// drifts from int → string) degrades the affected field to `nil`
+    /// instead of taking down the entire `[String: Player]` decode.
+    /// `playerId` is the only required field and is the dictionary key
+    /// in the parent decode anyway.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.playerId = try c.decode(String.self, forKey: .playerId)
+        self.firstName = try? c.decodeIfPresent(String.self, forKey: .firstName)
+        self.lastName = try? c.decodeIfPresent(String.self, forKey: .lastName)
+        self.fullName = try? c.decodeIfPresent(String.self, forKey: .fullName)
+        self.position = try? c.decodeIfPresent(String.self, forKey: .position)
+        self.team = try? c.decodeIfPresent(String.self, forKey: .team)
+        self.age = try? c.decodeIfPresent(Int.self, forKey: .age)
+        self.college = try? c.decodeIfPresent(String.self, forKey: .college)
+        self.yearsExp = try? c.decodeIfPresent(Int.self, forKey: .yearsExp)
+        self.status = try? c.decodeIfPresent(String.self, forKey: .status)
+        self.injuryStatus = try? c.decodeIfPresent(String.self, forKey: .injuryStatus)
+        self.number = try? c.decodeIfPresent(Int.self, forKey: .number)
+        self.height = try? c.decodeIfPresent(String.self, forKey: .height)
+        self.weight = try? c.decodeIfPresent(String.self, forKey: .weight)
+        self.sport = try? c.decodeIfPresent(String.self, forKey: .sport)
+        self.active = try? c.decodeIfPresent(Bool.self, forKey: .active)
+        self.fantasyPositions = try? c.decodeIfPresent([String].self, forKey: .fantasyPositions)
+        self.searchFullName = try? c.decodeIfPresent(String.self, forKey: .searchFullName)
+        self.searchFirstName = try? c.decodeIfPresent(String.self, forKey: .searchFirstName)
+        self.searchLastName = try? c.decodeIfPresent(String.self, forKey: .searchLastName)
+        self.depthChartPosition = try? c.decodeIfPresent(String.self, forKey: .depthChartPosition)
+        self.depthChartOrder = try? c.decodeIfPresent(Int.self, forKey: .depthChartOrder)
+        self.searchRank = try? c.decodeIfPresent(Int.self, forKey: .searchRank)
+    }
+
+    /// Memberwise initializer preserved for in-app construction
+    /// (preview fixtures, search results, taxi-squad players).
+    init(
+        playerId: String,
+        firstName: String? = nil,
+        lastName: String? = nil,
+        fullName: String? = nil,
+        position: String? = nil,
+        team: String? = nil,
+        age: Int? = nil,
+        college: String? = nil,
+        yearsExp: Int? = nil,
+        status: String? = nil,
+        injuryStatus: String? = nil,
+        number: Int? = nil,
+        height: String? = nil,
+        weight: String? = nil,
+        sport: String? = nil,
+        active: Bool? = nil,
+        fantasyPositions: [String]? = nil,
+        searchFullName: String? = nil,
+        searchFirstName: String? = nil,
+        searchLastName: String? = nil,
+        depthChartPosition: String? = nil,
+        depthChartOrder: Int? = nil,
+        searchRank: Int? = nil
+    ) {
+        self.playerId = playerId
+        self.firstName = firstName
+        self.lastName = lastName
+        self.fullName = fullName
+        self.position = position
+        self.team = team
+        self.age = age
+        self.college = college
+        self.yearsExp = yearsExp
+        self.status = status
+        self.injuryStatus = injuryStatus
+        self.number = number
+        self.height = height
+        self.weight = weight
+        self.sport = sport
+        self.active = active
+        self.fantasyPositions = fantasyPositions
+        self.searchFullName = searchFullName
+        self.searchFirstName = searchFirstName
+        self.searchLastName = searchLastName
+        self.depthChartPosition = depthChartPosition
+        self.depthChartOrder = depthChartOrder
+        self.searchRank = searchRank
     }
 
     // MARK: - Computed


### PR DESCRIPTION
## TL;DR
**This is the bug we've been chasing for 10 PRs.** Sleeper's `/players/nfl` returns `depth_chart_position` as a slot label **string** (`"QB1"`, `"RCB"`, `"LOLB"`, `"OL"`...). iOS declared it `Int?`. Swift's strict JSONDecoder threw on every player with a non-null value. Since `[String: Player]` decodes transactionally, **one bad player** killed the entire ~11k-player load. `PlayerStore.players` stayed empty forever → "Team Not Loaded", "Players Not Loaded", every roster lookup empty.

Web has worked the entire time because TypeScript types are erased at runtime — JS just shrugs.

## Verification
```
$ curl /v1/players/nfl | python3 -c "..."
depth_chart_position ['str']     ← BUG
depth_chart_order ['int']
years_exp ['int']
number ['int']
age ['int']
height ['str']
weight ['str']
search_rank ['int']
```

Sample values: `RCB`, `K`, `LOLB`, `QB1`, `OL`, `WR2`, `LWR`, `MLB`, `SS`, `LDT`...

## Fix
- `depthChartPosition: Int? → String?`
- Custom `init(from:)` using `try?`-wrapped `decodeIfPresent` for every optional field. One future field-type drift now degrades that field to nil instead of taking out the whole load. `playerId` stays required (it's the dictionary key).
- Memberwise initializer preserved for in-app construction (preview fixtures, taxi-steal sheet, etc.).

## Test plan
- [ ] Cold launch (or delete app + reinstall): players populate, ~11k+ entries
- [ ] My Team renders the user's roster
- [ ] Taxi Squad, Draft History, and player avatars all populate
- [ ] No silent decode failures even if Sleeper drifts another field type

## Aftermath
After this lands, every "data not loading" report on iOS should resolve. The dozens of patches we shipped to work around symptoms (cache poisoning unpoison, defensive `.task` preflights, retry buttons, Phase 2 race fixes, default-league anchor) were all chasing downstream effects of this one type mismatch.