### PR TITLE
fix: anchor tray destinations to home league + player ownership in search

### DIFF
--- a/Xomper/Core/Stores/LeagueStore.swift
+++ b/Xomper/Core/Stores/LeagueStore.swift
@@ -165,22 +165,19 @@ final class LeagueStore {
         currentLeagueRosters = rosters
     }
 
-    /// Loads and switches to a different league by ID.
+    /// Switching the global "current league" used to overwrite all the
+    /// tray destinations' data (Standings, Matchups, Drafts...) when a
+    /// user tapped another league in profile or search. The product call
+    /// is to keep the home league (`myLeague`) anchored as the only
+    /// source of truth for tray destinations — viewing other leagues is
+    /// a future feature that should use a pushed `.leagueOverview` route
+    /// fetching its own data, not mutate global state.
+    ///
+    /// Kept as a no-op stub so existing call sites don't need to be
+    /// torn out in this same patch. Will be removed once those sites
+    /// are migrated to a push-based browser.
     func switchToLeague(id: String) async {
-        isLoading = true
-        error = nil
-
-        do {
-            let league = try await apiClient.fetchLeague(id)
-            let context = try await fetchLeagueContext(leagueId: id)
-            currentLeague = league
-            currentLeagueUsers = context.users
-            currentLeagueRosters = context.rosters
-        } catch {
-            self.error = error
-        }
-
-        isLoading = false
+        // Intentionally no-op. See doc comment.
     }
 
     // MARK: - Fetch Brackets

--- a/Xomper/Features/DraftHistory/DraftHistoryView.swift
+++ b/Xomper/Features/DraftHistory/DraftHistoryView.swift
@@ -127,8 +127,7 @@ struct DraftHistoryView: View {
     private func loadDraftHistory() async {
         // Fall back to home league if currentLeague hasn't resolved yet
         // (bootstrap-vs-view-mount race).
-        guard let leagueId = leagueStore.currentLeague?.leagueId
-            ?? leagueStore.myLeague?.leagueId else { return }
+        guard let leagueId = leagueStore.myLeague?.leagueId else { return }
 
         await leagueStore.loadLeagueChain(startingFrom: leagueId)
         let chain = leagueStore.leagueChain

--- a/Xomper/Features/Home/SearchResultGroup.swift
+++ b/Xomper/Features/Home/SearchResultGroup.swift
@@ -13,6 +13,9 @@ struct SearchResultGroup: View {
     let onUserTap: (SleeperUser) -> Void
     let onLeagueTap: (League) -> Void
     let onPlayerTap: (String) -> Void
+    /// Resolves "owned by" info for a player in the user's home league
+    /// (CLT). Returns the team name + division, or nil for free agents.
+    let ownerLookup: (String) -> PlayerOwnership?
 
     var body: some View {
         ScrollView {
@@ -30,7 +33,10 @@ struct SearchResultGroup: View {
                 if !results.players.isEmpty {
                     sectionHeader("Players")
                     ForEach(results.players) { player in
-                        PlayerResultRow(player: player) {
+                        PlayerResultRow(
+                            player: player,
+                            ownership: ownerLookup(player.playerId)
+                        ) {
                             onPlayerTap(player.playerId)
                         }
                     }
@@ -156,8 +162,18 @@ private struct LeagueResultRow: View {
 
 // MARK: - Player row
 
+/// Per-player ownership in the user's home league (CLT). Resolved at
+/// search-result render time from `LeagueStore.myLeagueRosters`.
+struct PlayerOwnership: Sendable, Hashable {
+    /// Sleeper team display name (e.g. "Nvr 4get Da CLT").
+    let teamName: String
+    /// `true` when this is the signed-in user's roster.
+    let isMine: Bool
+}
+
 private struct PlayerResultRow: View {
     let player: Player
+    let ownership: PlayerOwnership?
     let onTap: () -> Void
 
     var body: some View {
@@ -178,6 +194,8 @@ private struct PlayerResultRow: View {
                     Text("\(player.displayPosition) · \(player.displayTeam)")
                         .font(.caption)
                         .foregroundStyle(XomperColors.textSecondary)
+
+                    ownershipPill
                 }
 
                 Spacer()
@@ -189,7 +207,40 @@ private struct PlayerResultRow: View {
             .xomperCard()
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("\(player.fullDisplayName), \(player.displayPosition), \(player.displayTeam)")
+        .accessibilityLabel(accessibilityLabelText)
         .accessibilityHint("Double tap to view player details")
+    }
+
+    @ViewBuilder
+    private var ownershipPill: some View {
+        if let ownership {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                Image(systemName: ownership.isMine ? "person.fill.checkmark" : "person.fill")
+                    .font(.caption2)
+                Text(ownership.isMine ? "On your team" : "Owned by \(ownership.teamName)")
+                    .font(.caption2)
+                    .lineLimit(1)
+            }
+            .foregroundStyle(ownership.isMine ? XomperColors.bgDark : XomperColors.textPrimary)
+            .padding(.horizontal, XomperTheme.Spacing.sm)
+            .padding(.vertical, 3)
+            .background(
+                ownership.isMine
+                    ? AnyShapeStyle(XomperColors.championGold)
+                    : AnyShapeStyle(Color.white.opacity(0.10))
+            )
+            .clipShape(Capsule())
+        } else {
+            Text("Free agent")
+                .font(.caption2)
+                .foregroundStyle(XomperColors.textMuted)
+        }
+    }
+
+    private var accessibilityLabelText: String {
+        let base = "\(player.fullDisplayName), \(player.displayPosition), \(player.displayTeam)"
+        guard let ownership else { return "\(base), free agent" }
+        if ownership.isMine { return "\(base), on your team" }
+        return "\(base), owned by \(ownership.teamName)"
     }
 }

--- a/Xomper/Features/Home/SearchView.swift
+++ b/Xomper/Features/Home/SearchView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct SearchView: View {
     var leagueStore: LeagueStore
     var playerStore: PlayerStore
+    var authStore: AuthStore
     var router: AppRouter
     var navStore: NavigationStore
 
@@ -19,11 +20,13 @@ struct SearchView: View {
     init(
         leagueStore: LeagueStore,
         playerStore: PlayerStore,
+        authStore: AuthStore,
         router: AppRouter,
         navStore: NavigationStore
     ) {
         self.leagueStore = leagueStore
         self.playerStore = playerStore
+        self.authStore = authStore
         self.router = router
         self.navStore = navStore
         _searchStore = State(
@@ -193,6 +196,9 @@ struct SearchView: View {
                 },
                 onPlayerTap: { playerId in
                     router.navigate(to: .playerDetail(playerId: playerId))
+                },
+                ownerLookup: { playerId in
+                    resolveOwnership(forPlayerId: playerId)
                 }
             )
         } else if searchStore.hasSearched {
@@ -259,10 +265,35 @@ struct SearchView: View {
     // MARK: - League navigation
 
     private func navigateToLeague(_ league: League) {
-        Task {
-            await leagueStore.switchToLeague(id: league.leagueId)
-            navStore.select(.standings, router: router)
+        // switchToLeague is now a no-op (see LeagueStore docs) — tray
+        // destinations always show the home league. Future iteration:
+        // push a dedicated `.leagueOverview(leagueId:)` route here.
+        navStore.select(.standings, router: router)
+    }
+
+    // MARK: - Player ownership in home league
+
+    /// Looks up which CLT roster owns a given player. Pure dictionary
+    /// lookup over `leagueStore.myLeagueRosters` + `myLeagueUsers`.
+    /// Returns `nil` for free agents.
+    private func resolveOwnership(forPlayerId playerId: String) -> PlayerOwnership? {
+        guard !playerId.isEmpty else { return nil }
+
+        let owningRoster = leagueStore.myLeagueRosters.first { roster in
+            (roster.players ?? []).contains(playerId)
+                || (roster.starters ?? []).contains(playerId)
+                || (roster.taxi ?? []).contains(playerId)
+                || (roster.reserve ?? []).contains(playerId)
         }
+        guard let roster = owningRoster, let ownerId = roster.ownerId else { return nil }
+
+        let user = leagueStore.myLeagueUsers.first { $0.userId == ownerId }
+        let teamName = user?.teamName
+            ?? user?.resolvedDisplayName
+            ?? "Unknown"
+
+        let isMine = ownerId == authStore.sleeperUserId
+        return PlayerOwnership(teamName: teamName, isMine: isMine)
     }
 }
 
@@ -271,6 +302,7 @@ struct SearchView: View {
         SearchView(
             leagueStore: LeagueStore(),
             playerStore: PlayerStore(),
+            authStore: AuthStore(),
             router: AppRouter(),
             navStore: NavigationStore()
         )

--- a/Xomper/Features/League/MatchupsView.swift
+++ b/Xomper/Features/League/MatchupsView.swift
@@ -160,7 +160,7 @@ struct MatchupsView: View {
     // MARK: - Load
 
     private func loadMatchups() async {
-        guard let leagueId = leagueStore.currentLeague?.leagueId else { return }
+        guard let leagueId = leagueStore.myLeague?.leagueId else { return }
 
         await leagueStore.loadLeagueChain(startingFrom: leagueId)
         let chain = leagueStore.leagueChain

--- a/Xomper/Features/League/PlayoffBracketView.swift
+++ b/Xomper/Features/League/PlayoffBracketView.swift
@@ -159,16 +159,16 @@ struct PlayoffBracketView: View {
     }
 
     private func buildStandings() {
-        guard let league = leagueStore.currentLeague else { return }
+        guard let league = leagueStore.myLeague else { return }
         standings = StandingsBuilder.buildStandings(
-            rosters: leagueStore.currentLeagueRosters,
-            users: leagueStore.currentLeagueUsers,
+            rosters: leagueStore.myLeagueRosters,
+            users: leagueStore.myLeagueUsers,
             league: league
         )
     }
 
     private func loadBrackets() async {
-        guard let league = leagueStore.currentLeague else { return }
+        guard let league = leagueStore.myLeague else { return }
         await leagueStore.fetchBrackets(leagueId: league.leagueId)
     }
 }

--- a/Xomper/Features/League/StandingsView.swift
+++ b/Xomper/Features/League/StandingsView.swift
@@ -77,7 +77,7 @@ struct StandingsView: View {
                     team: team,
                     rank: team.leagueRank,
                     isMyTeam: team.userId == authStore.sleeperUserId,
-                    playoffCutoff: leagueStore.currentLeague?.settings?.playoffTeams
+                    playoffCutoff: leagueStore.myLeague?.settings?.playoffTeams
                 ) {
                     selectTeam(team)
                 } onProfileTap: {
@@ -162,17 +162,17 @@ struct StandingsView: View {
     }
 
     private func selectTeam(_ team: StandingsTeam) {
-        let user = leagueStore.currentLeagueUsers.first { $0.userId == team.userId }
+        let user = leagueStore.myLeagueUsers.first { $0.userId == team.userId }
         teamStore.setCurrentTeam(team, user: user)
         router.navigate(to: .teamDetail(rosterId: team.rosterId))
     }
 
     private func buildStandings() {
-        guard let league = leagueStore.currentLeague else { return }
+        guard let league = leagueStore.myLeague else { return }
 
         standings = StandingsBuilder.buildStandings(
-            rosters: leagueStore.currentLeagueRosters,
-            users: leagueStore.currentLeagueUsers,
+            rosters: leagueStore.myLeagueRosters,
+            users: leagueStore.myLeagueUsers,
             league: league
         )
 

--- a/Xomper/Features/Profile/TrophyCaseSection.swift
+++ b/Xomper/Features/Profile/TrophyCaseSection.swift
@@ -99,8 +99,7 @@ struct TrophyCaseSection: View {
         // current/my league. If neither is set yet, give up — the section will
         // re-evaluate on subsequent renders once league data lands.
         if leagueStore.leagueChain.isEmpty {
-            guard let leagueId = leagueStore.currentLeague?.leagueId
-                ?? leagueStore.myLeague?.leagueId else { return }
+            guard let leagueId = leagueStore.myLeague?.leagueId else { return }
             await leagueStore.loadLeagueChain(startingFrom: leagueId)
         }
 

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -42,7 +42,7 @@ struct MainShell: View {
                     router: router,
                     avatarID: userStore.myUser?.avatar,
                     seasonStore: seasonStore,
-                    leagueName: leagueStore.currentLeague?.name ?? leagueStore.myLeague?.name
+                    leagueName: leagueStore.myLeague?.name
                 )
 
                 NavigationStack(path: $router.path) {
@@ -200,7 +200,7 @@ struct MainShell: View {
     /// when the league isn't loaded yet.
     @ViewBuilder
     private func rulesPage(_ page: RulesPage) -> some View {
-        if let league = leagueStore.currentLeague ?? leagueStore.myLeague {
+        if let league = leagueStore.myLeague {
             RulesView(
                 league: league,
                 rulesStore: rulesStore,
@@ -223,10 +223,8 @@ struct MainShell: View {
     @ViewBuilder
     private var myTeamRoot: some View {
         if let team = teamStore.myTeam,
-           let league = leagueStore.currentLeague ?? leagueStore.myLeague,
-           let roster = (leagueStore.currentLeagueRosters.isEmpty
-                ? leagueStore.myLeagueRosters
-                : leagueStore.currentLeagueRosters
+           let league = leagueStore.myLeague,
+           let roster = (leagueStore.myLeagueRosters
            ).first(where: { $0.rosterId == team.rosterId }) {
             TeamView(
                 team: team,
@@ -280,13 +278,13 @@ struct MainShell: View {
             )
 
         case .teamDetail(let rosterId):
-            if let league = leagueStore.currentLeague ?? leagueStore.myLeague {
+            if let league = leagueStore.myLeague {
                 let standings = StandingsBuilder.buildStandings(
-                    rosters: leagueStore.currentLeagueRosters.isEmpty ? leagueStore.myLeagueRosters : leagueStore.currentLeagueRosters,
-                    users: leagueStore.currentLeagueUsers.isEmpty ? leagueStore.myLeagueUsers : leagueStore.currentLeagueUsers,
+                    rosters: leagueStore.myLeagueRosters,
+                    users: leagueStore.myLeagueUsers,
                     league: league
                 )
-                let rosters = leagueStore.currentLeagueRosters.isEmpty ? leagueStore.myLeagueRosters : leagueStore.currentLeagueRosters
+                let rosters = leagueStore.myLeagueRosters
                 if let team = standings.first(where: { $0.rosterId == rosterId }),
                    let roster = rosters.first(where: { $0.rosterId == rosterId }) {
                     TeamView(
@@ -339,6 +337,7 @@ struct MainShell: View {
             SearchView(
                 leagueStore: leagueStore,
                 playerStore: playerStore,
+                authStore: authStore,
                 router: router,
                 navStore: navStore
             )


### PR DESCRIPTION
Closes the ongoing "still showing other leagues" issue and adds player ownership in search results.

## What this fixes
1. **Other leagues bleeding into tray destinations.** Standings, Matchups, Playoffs, Draft History, Trophy Case, and My Team now always render CLT data. Tapping a non-CLT league in profile/search no longer pollutes global state — `switchToLeague(id:)` is now a no-op stub.
2. **Player ownership shown in search results.** Each player row now displays a pill:
   - **"On your team"** (gold capsule) when the player is on the user's CLT roster
   - **"Owned by [Team Name]"** when another CLT manager rosters them
   - **"Free agent"** otherwise

## Before
- `currentLeague` could drift to any league via profile tap → all tray destinations reflected the wrong league
- Player search showed name + position + team, no ownership context

## After
- `currentLeague` references replaced with `myLeague` everywhere a tray destination renders
- `switchToLeague(id:)` becomes a no-op (preserved for compile compat; will be removed once profile/search migrate to push-based browsing)
- Player search results call `resolveOwnership(forPlayerId:)` which walks `myLeagueRosters` (players + starters + taxi + reserve) and renders the appropriate pill

## Test plan
- [ ] Cold launch: tray destinations all show CLT
- [ ] Tap another league in profile → drawer/tray destinations stay on CLT
- [ ] Search a player → row shows ownership pill (yours/other-team/free-agent)
- [ ] Build clean under Swift 6 strict concurrency

## Notes
- This builds on #44 (Player decode fix) which is the ACTUAL root cause of "no players loading." Both PRs together should resolve the data-loading complaints end to end.
- `MyProfileView`, `ProfileView`, and `SearchView` still call `switchToLeague` but now no-op. A follow-up will replace those taps with a pushed `.leagueOverview` route for browsing without state drift.