### PR TITLE
fix: resolve home league from Supabase whitelisted_leagues (was loading wrong league)

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		E2EC532916CAA2FBB779DB35 /* UserStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62948D0A455E7CE99B15CB75 /* UserStore.swift */; };
 		EDDACB3FFB20E468D9D9D67D /* HeaderBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E7D0FD804723AC6A3E4298 /* HeaderBar.swift */; };
 		F201A3A40D624F6AAA0C0CC1 /* PlayoffBracket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */; };
+		F57132F0D80EAB60AC0E07F3 /* WhitelistedLeague.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747C6FC769C117588F8A93E /* WhitelistedLeague.swift */; };
 		F5AD059EF52A068C469AFB6E /* URL+Sleeper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2452A5AEC270BE14CC085E1 /* URL+Sleeper.swift */; };
 		F7E0A8B9AECD0291527E0D0E /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F46A0AAE61A4E963BB15B0 /* SearchView.swift */; };
 		FAE7847413A293EF8CE9090C /* NFLTeamColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DF8F2FE857C55AFB1C1205 /* NFLTeamColors.swift */; };
@@ -122,6 +123,7 @@
 		323F422F2D0E1C2BA5D46C0A /* SearchResults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResults.swift; sourceTree = "<group>"; };
 		36A01820FD0F6643BBF8511D /* TeamStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamStore.swift; sourceTree = "<group>"; };
 		3728C5F6BEF61FE509A3EA32 /* ClinchCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClinchCalculator.swift; sourceTree = "<group>"; };
+		3747C6FC769C117588F8A93E /* WhitelistedLeague.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhitelistedLeague.swift; sourceTree = "<group>"; };
 		3E4EC7FDB93C47A9EE601BA3 /* TrayItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayItem.swift; sourceTree = "<group>"; };
 		42C8A3FA617E9FEB48852C45 /* Profile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
 		42F46A0AAE61A4E963BB15B0 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
@@ -387,6 +389,7 @@
 				B29D510D87CD290AE7F76FBF /* StandingsTeam.swift */,
 				A2DA1B65780757E6CC78CD61 /* TaxiSquadPlayer.swift */,
 				9F49969EE42BDE6462664021 /* TradedPick.swift */,
+				3747C6FC769C117588F8A93E /* WhitelistedLeague.swift */,
 				E969C4A894017F9D0072CCFA /* WorldCup.swift */,
 			);
 			path = Models;
@@ -702,6 +705,7 @@
 				65444EF8D83F3582CE2FC023 /* TrophyCaseSection.swift in Sources */,
 				F5AD059EF52A068C469AFB6E /* URL+Sleeper.swift in Sources */,
 				E2EC532916CAA2FBB779DB35 /* UserStore.swift in Sources */,
+				F57132F0D80EAB60AC0E07F3 /* WhitelistedLeague.swift in Sources */,
 				61EBC3AC052763EAAC807AC9 /* WorldCup.swift in Sources */,
 				901F54CB41785D269CC63160 /* WorldCupStore.swift in Sources */,
 				BBBE8D43F297A49A915AA789 /* WorldCupView.swift in Sources */,

--- a/Xomper/Core/Models/WhitelistedLeague.swift
+++ b/Xomper/Core/Models/WhitelistedLeague.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Mirrors a row in the Supabase `whitelisted_leagues` table. The
+/// `is_active=true` row is the league this build is configured for —
+/// fetched at boot to avoid hardcoding a Sleeper league ID that drifts
+/// every dynasty rollover.
+struct WhitelistedLeague: Codable, Sendable, Identifiable {
+    let id: String
+    let leagueId: String
+    let leagueName: String
+    let season: String
+    let isActive: Bool
+    let isDynasty: Bool
+    let hasTaxi: Bool
+    let divisions: Int?
+    let size: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case leagueId = "league_id"
+        case leagueName = "league_name"
+        case season
+        case isActive = "is_active"
+        case isDynasty = "is_dynasty"
+        case hasTaxi = "has_taxi"
+        case divisions
+        case size
+    }
+}

--- a/Xomper/Core/Stores/LeagueStore.swift
+++ b/Xomper/Core/Stores/LeagueStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+@preconcurrency import Supabase
 
 @Observable
 @MainActor
@@ -66,7 +67,9 @@ final class LeagueStore {
         error = nil
 
         do {
-            let leagueId = Config.whitelistedLeagueId
+            // Use Supabase-resolved league ID when available; falls back
+            // to Config.whitelistedLeagueId.
+            let leagueId = resolvedHomeLeagueId
             let league = try await apiClient.fetchLeague(leagueId)
             let context = try await fetchLeagueContext(leagueId: leagueId)
 
@@ -85,6 +88,45 @@ final class LeagueStore {
         isLoading = false
     }
 
+    // MARK: - Whitelisted league (Supabase source of truth)
+
+    /// The active row from Supabase `whitelisted_leagues`. Populated by
+    /// `fetchActiveWhitelistedLeague`. Acts as the source of truth for
+    /// which Sleeper league the app considers "home". Falls back to
+    /// `Config.whitelistedLeagueId` / `Config.whitelistedLeagueName`
+    /// when the Supabase fetch fails.
+    private(set) var whitelistedLeague: WhitelistedLeague?
+
+    /// Resolved league ID — Supabase first, hardcoded Config fallback.
+    var resolvedHomeLeagueId: String {
+        whitelistedLeague?.leagueId ?? Config.whitelistedLeagueId
+    }
+
+    /// Resolved league name — Supabase first, hardcoded Config fallback.
+    var resolvedHomeLeagueName: String {
+        whitelistedLeague?.leagueName ?? Config.whitelistedLeagueName
+    }
+
+    /// Fetches the single active row from Supabase `whitelisted_leagues`.
+    /// Result lives on `whitelistedLeague`. Non-fatal — if the query
+    /// fails, `whitelistedLeague` stays nil and the resolved-* helpers
+    /// fall through to `Config`.
+    func fetchActiveWhitelistedLeague() async {
+        do {
+            let results: [WhitelistedLeague] = try await supabase
+                .from("whitelisted_leagues")
+                .select()
+                .eq("is_active", value: true)
+                .limit(1)
+                .execute()
+                .value
+
+            self.whitelistedLeague = results.first
+        } catch {
+            // Non-fatal — Config fallback still works.
+        }
+    }
+
     // MARK: - Resolve current-season home league by name
 
     /// Re-anchors `myLeague` (and `currentLeague` if it currently equals
@@ -99,7 +141,8 @@ final class LeagueStore {
     /// goes stale every year. By matching on the stable league name we
     /// follow the league forward automatically.
     func resolveAndAnchorMyLeagueByName() async {
-        let targetName = Config.whitelistedLeagueName.trimmingCharacters(in: .whitespaces)
+        // Prefer the Supabase-resolved name; fall back to Config.
+        let targetName = resolvedHomeLeagueName.trimmingCharacters(in: .whitespaces)
         guard !targetName.isEmpty else { return }
 
         let resolvedLeague = userLeagues.first { league in

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -395,9 +395,17 @@ struct MainShell: View {
 
     // MARK: - Bootstrap
 
-    /// Phase 1: Load league, NFL state, and players in parallel.
-    /// These don't depend on sleeperUserId.
+    /// Phase 1: Resolve the home league from Supabase first (source of
+    /// truth), then load that league's data + NFL state + all players
+    /// in parallel. Resolves the long-standing problem of hardcoded
+    /// league IDs drifting across dynasty rollovers — Supabase is the
+    /// single source of truth.
     private func bootstrapPhase1() async {
+        // Resolve home league from Supabase before fetching it from
+        // Sleeper, so loadMyLeague reads the right ID. Non-fatal — falls
+        // back to Config.whitelistedLeagueId on failure.
+        await leagueStore.fetchActiveWhitelistedLeague()
+
         async let leagueLoad: () = leagueStore.loadMyLeague()
         async let nflLoad: () = nflStateStore.fetchState()
         async let playerLoad: () = playerStore.loadPlayers()


### PR DESCRIPTION
## TL;DR
The hardcoded `Config.whitelistedLeagueId` was pointing at the **wrong Sleeper league** (`1257116481091543040` — some old "smirnoff" league). The actual CLT Dynasty in your Supabase `whitelisted_leagues` table is `1181789700187090944`, named **"CLT DYNASTY"**. The previous name-match fix looked for "Charlotte Dynasty League" which doesn't exist.

That single fact explains every "wrong league" symptom — Standings, Matchups, Drafts all rendered the wrong league because `myLeague` was loaded from the wrong ID.

## Real fix — Supabase as source of truth

You already have the right data in Supabase. The app should read it.

- New `WhitelistedLeague` model
- New `LeagueStore.fetchActiveWhitelistedLeague()` — queries `supabase.from("whitelisted_leagues").eq("is_active", true)`
- Exposes `resolvedHomeLeagueId` / `resolvedHomeLeagueName` helpers (Supabase first, Config fallback)
- `bootstrapPhase1` now awaits this resolution **before** `loadMyLeague`, so the very first Sleeper fetch goes against the correct league ID
- `resolveAndAnchorMyLeagueByName` uses the resolved name too

Local `Config.swift` updated to the correct CLT values as a safety-net fallback.

## Future-proof
Next dynasty rollover: update the row in Supabase (`is_active=true` on new league, `false` on old). App picks it up on next launch. No code change, no secrets to rotate, no app update.

## Test plan
- [ ] Cold launch: Standings lands on CLT DYNASTY immediately, no refresh required
- [ ] HeaderBar pill shows "CLT DYNASTY"
- [ ] Matchups, Draft History, Trophy Case, World Cup, Taxi Squad, My Team all show CLT data
- [ ] Search a player → ownership pill shows CLT roster owner
- [ ] Build clean under Swift 6 strict concurrency

## Notes
- Stacks on #44 (player decode fix) and #45 (anchor-to-myLeague + ownership)
- Hardcoded IDs in Config are now a fallback only. CI secrets `WHITELISTED_LEAGUE_ID` and `WHITELISTED_LEAGUE_NAME` are no longer load-bearing for correctness.