### PR TITLE
feat: browsable LeagueOverviewView for non-home leagues

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		C9D656F4702A3483BB8E970C /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A99CAA9B57C1A0144DCA22 /* Player.swift */; };
 		CB47F51AA46AEBC59183C449 /* PlayoffBracketView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581D4F6F3EB8FC0547F49927 /* PlayoffBracketView.swift */; };
 		CDA1A124C81E1FF5127BEE2C /* TraySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A497DF9DD9066BD24A1E19 /* TraySection.swift */; };
+		CEC2B1D5D34F80BFB3444C6F /* LeagueOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A84518A312FF0F96719AF1E8 /* LeagueOverviewView.swift */; };
 		CF4CEF4E2FE7A891950A2E17 /* NflStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E125AD2AA5212D0EB4C13A /* NflStateStore.swift */; };
 		CFE915FD4020FDEB923157C2 /* RuleProposal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7C85CB880ABD7D373E49A6 /* RuleProposal.swift */; };
 		D09FC43EBE71A0DFF28B83D2 /* MatchupDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F2C7D74B3584D53CE601054 /* MatchupDetailView.swift */; };
@@ -161,6 +162,7 @@
 		A2DA1B65780757E6CC78CD61 /* TaxiSquadPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiSquadPlayer.swift; sourceTree = "<group>"; };
 		A789B8D49FA4430886626289 /* DraftHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftHistory.swift; sourceTree = "<group>"; };
 		A83A8FEFFD8FA91F498D03A0 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
+		A84518A312FF0F96719AF1E8 /* LeagueOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeagueOverviewView.swift; sourceTree = "<group>"; };
 		A8BD31456E25771C8D7D39C9 /* XomperApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperApp.swift; sourceTree = "<group>"; };
 		ACCFF9888476668EBE7AA0CC /* XomperTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = XomperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD43D54AB620DABD559F8A40 /* CareerStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareerStats.swift; sourceTree = "<group>"; };
@@ -314,6 +316,7 @@
 		47014533E72495E9E9DC8F74 /* League */ = {
 			isa = PBXGroup;
 			children = (
+				A84518A312FF0F96719AF1E8 /* LeagueOverviewView.swift */,
 				6F2C7D74B3584D53CE601054 /* MatchupDetailView.swift */,
 				8521885A7FF4C6910DFBF549 /* MatchupsView.swift */,
 				581D4F6F3EB8FC0547F49927 /* PlayoffBracketView.swift */,
@@ -650,6 +653,7 @@
 				EDDACB3FFB20E468D9D9D67D /* HeaderBar.swift in Sources */,
 				063FCD6AA342CA5D64ED79ED /* HistoryStore.swift in Sources */,
 				114998283E6705D075ED2CA7 /* League.swift in Sources */,
+				CEC2B1D5D34F80BFB3444C6F /* LeagueOverviewView.swift in Sources */,
 				724482308D102AFA35AB4017 /* LeagueStore.swift in Sources */,
 				83E71E429B2F8B4B7AEBAB96 /* LoadingView.swift in Sources */,
 				A4D93DF4C02A8DE6C695CE4D /* LoginView.swift in Sources */,

--- a/Xomper/Features/Home/SearchView.swift
+++ b/Xomper/Features/Home/SearchView.swift
@@ -265,10 +265,9 @@ struct SearchView: View {
     // MARK: - League navigation
 
     private func navigateToLeague(_ league: League) {
-        // switchToLeague is now a no-op (see LeagueStore docs) — tray
-        // destinations always show the home league. Future iteration:
-        // push a dedicated `.leagueOverview(leagueId:)` route here.
-        navStore.select(.standings, router: router)
+        // Push a read-only overview of the tapped league. Tray
+        // destinations stay anchored to the home league.
+        router.navigate(to: .leagueOverview(leagueId: league.leagueId))
     }
 
     // MARK: - Player ownership in home league

--- a/Xomper/Features/League/LeagueOverviewView.swift
+++ b/Xomper/Features/League/LeagueOverviewView.swift
@@ -1,0 +1,198 @@
+import SwiftUI
+
+/// Pushed view used when the user taps a non-home league in profile or
+/// search. Fetches the target league + rosters + users on its own and
+/// renders standings — never touches the global `LeagueStore.myLeague`,
+/// so the user's home-league state is preserved.
+///
+/// Drill-down (tap a team) pushes a `.teamDetail` route, but resolves
+/// against the locally-loaded rosters rather than `myLeagueRosters`,
+/// since this league isn't the home league.
+struct LeagueOverviewView: View {
+    let leagueId: String
+    var router: AppRouter
+
+    @State private var league: League?
+    @State private var rosters: [Roster] = []
+    @State private var users: [SleeperUser] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    private let apiClient: SleeperAPIClientProtocol = SleeperAPIClient()
+
+    var body: some View {
+        Group {
+            if isLoading {
+                LoadingView(message: "Loading league...")
+            } else if let errorMessage {
+                ErrorView(message: errorMessage) {
+                    Task { await load() }
+                }
+            } else if let league {
+                content(league: league)
+            } else {
+                EmptyStateView(
+                    icon: "trophy",
+                    title: "League Not Found",
+                    message: "Could not load this league."
+                )
+            }
+        }
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .navigationTitle(league?.displayName ?? "League")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .task {
+            await load()
+        }
+    }
+
+    // MARK: - Content
+
+    private func content(league: League) -> some View {
+        let standings = StandingsBuilder.buildStandings(
+            rosters: rosters,
+            users: users,
+            league: league
+        )
+
+        return ScrollView {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.lg) {
+                leagueHeader(league: league)
+                standingsSection(standings: standings)
+            }
+            .padding(XomperTheme.Spacing.md)
+            .padding(.bottom, XomperTheme.Spacing.xl)
+        }
+    }
+
+    // MARK: - Header
+
+    private func leagueHeader(league: League) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            Text(league.displayName)
+                .font(.title2)
+                .fontWeight(.bold)
+                .foregroundStyle(XomperColors.textPrimary)
+
+            HStack(spacing: XomperTheme.Spacing.sm) {
+                Label(league.season, systemImage: "calendar")
+                Label("\(league.totalRosters ?? 0) teams", systemImage: "person.3")
+                if league.isDynasty {
+                    Text("Dynasty")
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(XomperColors.bgDark)
+                        .padding(.horizontal, XomperTheme.Spacing.sm)
+                        .padding(.vertical, XomperTheme.Spacing.xs)
+                        .background(XomperColors.championGold)
+                        .clipShape(Capsule())
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(XomperColors.textSecondary)
+
+            Text("Browsing — your home league is unchanged.")
+                .font(.caption2)
+                .foregroundStyle(XomperColors.textMuted)
+                .padding(.top, XomperTheme.Spacing.xs)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .xomperCard()
+    }
+
+    // MARK: - Standings
+
+    private func standingsSection(standings: [StandingsTeam]) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            Text("Standings")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundStyle(XomperColors.textSecondary)
+                .padding(.leading, XomperTheme.Spacing.xs)
+
+            if standings.isEmpty {
+                Text("No standings available yet.")
+                    .font(.subheadline)
+                    .foregroundStyle(XomperColors.textMuted)
+                    .frame(maxWidth: .infinity)
+                    .xomperCard()
+            } else {
+                VStack(spacing: XomperTheme.Spacing.xs) {
+                    ForEach(standings) { team in
+                        teamRow(team: team)
+                    }
+                }
+            }
+        }
+    }
+
+    private func teamRow(team: StandingsTeam) -> some View {
+        HStack(spacing: XomperTheme.Spacing.md) {
+            Text("\(team.leagueRank)")
+                .font(.subheadline)
+                .fontWeight(.bold)
+                .foregroundStyle(XomperColors.textMuted)
+                .frame(width: 24, alignment: .leading)
+
+            AvatarView(avatarID: team.avatarId, size: XomperTheme.AvatarSize.md, isTeam: true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(team.teamName)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .lineLimit(1)
+
+                Text("@\(team.username)")
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.textMuted)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(recordString(team: team))
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .monospacedDigit()
+                Text(String(format: "%.1f PF", team.fpts))
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.textMuted)
+                    .monospacedDigit()
+            }
+        }
+        .padding(.horizontal, XomperTheme.Spacing.md)
+        .padding(.vertical, XomperTheme.Spacing.sm)
+        .background(XomperColors.bgCard.opacity(0.6))
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md, style: .continuous))
+    }
+
+    private func recordString(team: StandingsTeam) -> String {
+        if team.ties > 0 {
+            return "\(team.wins)-\(team.losses)-\(team.ties)"
+        }
+        return "\(team.wins)-\(team.losses)"
+    }
+
+    // MARK: - Data
+
+    private func load() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            async let leagueLoad = apiClient.fetchLeague(leagueId)
+            async let rostersLoad = apiClient.fetchLeagueRosters(leagueId)
+            async let usersLoad = apiClient.fetchLeagueUsers(leagueId)
+            let (l, r, u) = try await (leagueLoad, rostersLoad, usersLoad)
+            self.league = l
+            self.rosters = r
+            self.users = u
+        } catch {
+            self.errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+}

--- a/Xomper/Features/Profile/MyProfileView.swift
+++ b/Xomper/Features/Profile/MyProfileView.swift
@@ -167,10 +167,9 @@ struct MyProfileView: View {
         Button {
             let generator = UIImpactFeedbackGenerator(style: .medium)
             generator.impactOccurred()
-            Task {
-                await leagueStore.switchToLeague(id: league.leagueId)
-                navStore.select(.standings, router: router)
-            }
+            // Push a read-only overview of the tapped league. Does NOT
+            // mutate `myLeague` — tray destinations stay anchored to home.
+            router.navigate(to: .leagueOverview(leagueId: league.leagueId))
         } label: {
             HStack(spacing: XomperTheme.Spacing.md) {
                 AvatarView(

--- a/Xomper/Features/Profile/ProfileView.swift
+++ b/Xomper/Features/Profile/ProfileView.swift
@@ -210,10 +210,8 @@ struct ProfileView: View {
     // MARK: - Navigation
 
     private func navigateToLeague(_ league: League) {
-        Task {
-            await leagueStore.switchToLeague(id: league.leagueId)
-            navStore.select(.standings, router: router)
-        }
+        // Push a read-only overview — does not mutate `myLeague`.
+        router.navigate(to: .leagueOverview(leagueId: league.leagueId))
     }
 }
 

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -355,6 +355,9 @@ struct MainShell: View {
                     message: "We couldn't load this player's details."
                 )
             }
+
+        case .leagueOverview(let leagueId):
+            LeagueOverviewView(leagueId: leagueId, router: router)
         }
     }
 

--- a/Xomper/Navigation/AppRouter.swift
+++ b/Xomper/Navigation/AppRouter.swift
@@ -15,6 +15,10 @@ enum AppRoute: Hashable {
     case search
     case settings
     case playerDetail(playerId: String)
+    /// Browse another league at high level (standings + basic info). Used
+    /// when the user taps a non-home league in profile or search. The
+    /// view fetches its own data — does NOT mutate `LeagueStore.myLeague`.
+    case leagueOverview(leagueId: String)
 }
 
 /// Owns the inner `NavigationStack` path inside `MainShell`. The drawer


### PR DESCRIPTION
Restores the ability to view other leagues after PR #45 disabled global league switching.

## Behavior
- Tap a non-home league in **profile** → push read-only overview
- Tap a league in **search results** → push read-only overview
- Home league (CLT) **never changes** — tray destinations stay anchored

## What the overview shows
- League name + season + team count + Dynasty pill
- "Browsing — your home league is unchanged" caption
- Standings (rank · avatar · team name · @username · W-L · PF)
- Loading / error / empty states

## How it stays clean
`LeagueOverviewView` fetches league + rosters + users on its own via `SleeperAPIClient` directly. It does **not**:
- mutate `LeagueStore.myLeague`
- mutate `LeagueStore.currentLeague` (still kept around for legacy reasons)
- alter any tray destination's data

`switchToLeague` no longer has callers — it's now an unused no-op stub. Cleanup PR can delete it later.

## Test plan
- [ ] Profile → tap "Chris Berman Memorial" → overview pushes; back button returns to profile; CLT tray still shows CLT
- [ ] Search a league → tap → overview pushes
- [ ] Standings lists all teams with correct records
- [ ] Build clean under Swift 6 strict concurrency