### PR TITLE
fix: scroll/tap gestures no longer race with edge-drag drawer opener

### DIFF
--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -64,8 +64,22 @@ struct MainShell: View {
                 displayName: resolvedDisplayName,
                 email: authStore.session?.user.email
             )
+
+            // Edge-swipe-to-open hit area. Confined to a 20pt strip on
+            // the leading edge so the drag gesture doesn't race with
+            // scroll/tap gestures across the whole content area. Only
+            // active when the drawer is closed and the user is at the
+            // root of the nav stack — otherwise the system swipe-to-pop
+            // and inner scrolls take precedence.
+            if !navStore.isDrawerOpen && router.path.count == 0 {
+                Color.clear
+                    .frame(width: 20)
+                    .frame(maxHeight: .infinity)
+                    .contentShape(Rectangle())
+                    .gesture(edgeDragGesture)
+                    .accessibilityHidden(true)
+            }
         }
-        .gesture(edgeDragGesture)
         .task {
             await bootstrapPhase1()
             seasonStore.bootstrap(currentSeason: nflStateStore.currentSeason)


### PR DESCRIPTION
## Bug
Scrolling the app was unreliable — scroll attempts often fired as taps on rows underneath. Root cause: `MainShell` attached its drawer edge-drag gesture to the entire ZStack via `.gesture(edgeDragGesture)`, which made SwiftUI evaluate that gesture against every touch on every screen.

## Fix
Confine the edge-drag to a 20pt leading strip (Color.clear hit area) that only appears when the drawer is closed and we're at the root of the nav stack. Inside that strip, the drag opens the drawer; everywhere else, scrolls and taps fall through normally.

20pt mirrors iOS's native edge-swipe width. Avatar tap remains the primary way to open the drawer.

## Test plan
- [ ] Scrolling Standings/Matchups/etc. is smooth, no accidental taps
- [ ] Edge-swipe from the leading 20pt still opens the drawer at root
- [ ] Edge-swipe is disabled inside pushed views (system swipe-to-pop wins)
- [ ] Avatar tap still opens drawer always