### PR TITLE
fix: denser cards + standings reactive landing load

### DIFF
--- a/Xomper/Core/Theme/XomperTheme.swift
+++ b/Xomper/Core/Theme/XomperTheme.swift
@@ -72,9 +72,12 @@ enum XomperTheme {
 // MARK: - Card Style Modifier
 
 struct XomperCardModifier: ViewModifier {
+    let compact: Bool
+
     func body(content: Content) -> some View {
         content
-            .padding(20)
+            .padding(.horizontal, compact ? 12 : 14)
+            .padding(.vertical, compact ? 8 : 12)
             .background(XomperColors.bgCard)
             .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
             .xomperShadow(.sm)
@@ -82,7 +85,16 @@ struct XomperCardModifier: ViewModifier {
 }
 
 extension View {
+    /// Default card style — tighter than the legacy 20pt padding so a
+    /// scrollable list of cards is denser and more like a content
+    /// browser than a stack of full-screen tiles.
     func xomperCard() -> some View {
-        modifier(XomperCardModifier())
+        modifier(XomperCardModifier(compact: false))
+    }
+
+    /// Even tighter card for high-density rows (search results,
+    /// inline lists). Use when a row is more "list item" than "card".
+    func xomperCompactCard() -> some View {
+        modifier(XomperCardModifier(compact: true))
     }
 }

--- a/Xomper/Features/League/StandingsView.swift
+++ b/Xomper/Features/League/StandingsView.swift
@@ -12,27 +12,48 @@ struct StandingsView: View {
     @State private var hasDivisions = false
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: XomperTheme.Spacing.md) {
-                if hasDivisions {
-                    viewModeToggle
-                }
+        Group {
+            if standings.isEmpty && (leagueStore.isLoading || leagueStore.myLeagueRosters.isEmpty) {
+                LoadingView(message: "Loading standings...")
+            } else if standings.isEmpty {
+                EmptyStateView(
+                    icon: "list.number",
+                    title: "Standings Not Loaded",
+                    message: "Pull to refresh to load the latest standings."
+                )
+            } else {
+                ScrollView {
+                    VStack(spacing: XomperTheme.Spacing.md) {
+                        if hasDivisions {
+                            viewModeToggle
+                        }
 
-                switch viewMode {
-                case .league:
-                    leagueStandingsView
-                case .division:
-                    divisionStandingsView
+                        switch viewMode {
+                        case .league:
+                            leagueStandingsView
+                        case .division:
+                            divisionStandingsView
+                        }
+                    }
+                    .padding(.horizontal, XomperTheme.Spacing.md)
+                    .padding(.vertical, XomperTheme.Spacing.sm)
                 }
             }
-            .padding(.horizontal, XomperTheme.Spacing.md)
-            .padding(.vertical, XomperTheme.Spacing.sm)
         }
         .background(XomperColors.bgDark)
         .refreshable {
             await refreshStandings()
         }
-        .onAppear {
+        // Rebuild whenever the home league or its rosters/users land —
+        // covers the bootstrap-vs-mount race where StandingsView is the
+        // landing destination and Phase 2 hasn't resolved yet.
+        .task(id: leagueStore.myLeague?.leagueId) {
+            buildStandings()
+        }
+        .onChange(of: leagueStore.myLeagueRosters.count) { _, _ in
+            buildStandings()
+        }
+        .onChange(of: leagueStore.myLeagueUsers.count) { _, _ in
             buildStandings()
         }
     }


### PR DESCRIPTION
Two complaints rolled into one PR.

## 1. Cards too tall to scroll comfortably
\`xomperCard\` padding cut from a flat 20pt to 14h/12v. Adds \`xomperCompactCard\` (8h/12v) for high-density rows. Touch targets stay above the 44pt min via the contained content; the surrounding chrome just shrinks.

## 2. Standings empty on landing
\`onAppear → buildStandings\` ran once before bootstrap resolved \`myLeague\`. After Phase 2 anchored CLT DYNASTY, the standings stayed empty until manual refresh.

Now:
- \`.task(id: leagueStore.myLeague?.leagueId)\` rebuilds on league resolution
- \`.onChange\` of \`myLeagueRosters\` / \`myLeagueUsers\` count rebuilds when their fetches return
- Top-level switch shows \`LoadingView\` while still loading, an actionable empty state if loaded-but-empty, and standings content when ready

## Test plan
- [ ] Cold launch lands on Standings → loading spinner → standings populate without manual refresh
- [ ] Cards across all destinations look denser
- [ ] No regressions on other card-using views