### PR TITLE
feat: per-season fantasy averages on PlayerDetailView

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		8E8B3EC17A43676ACA176FC3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6F2D6E80C100927C4C20FAD7 /* Assets.xcassets */; };
 		901F54CB41785D269CC63160 /* WorldCupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E1C6D5A18697DE79586C1B /* WorldCupStore.swift */; };
 		9134D2C8A8737083C9FB8F7F /* ClinchCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3728C5F6BEF61FE509A3EA32 /* ClinchCalculator.swift */; };
+		93D8C8E352B60752D37FD0FF /* PlayerSeasonStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C24A12080AD428D5A40A7E /* PlayerSeasonStats.swift */; };
 		95DE1C46E20BF6910D4E5447 /* TrayItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E4EC7FDB93C47A9EE601BA3 /* TrayItem.swift */; };
 		98F895FBCECB23325658339C /* StandingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A47FD1CF3BE7AE0B940DEC /* StandingsView.swift */; };
 		9D9E8D2C4A8A0C623AC1EF0D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E767CD5492176E84C2092B0F /* AppDelegate.swift */; };
@@ -146,6 +147,7 @@
 		6387E34B6FA70159F3F9D80A /* TaxiSquadStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiSquadStore.swift; sourceTree = "<group>"; };
 		6504EE31A645398C41BC2ED1 /* EnvironmentValues+Season.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+Season.swift"; sourceTree = "<group>"; };
 		669A80C2A9F46A0C4612388C /* Double+Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Formatting.swift"; sourceTree = "<group>"; };
+		67C24A12080AD428D5A40A7E /* PlayerSeasonStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerSeasonStats.swift; sourceTree = "<group>"; };
 		6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayoffBracket.swift; sourceTree = "<group>"; };
 		6F2C7D74B3584D53CE601054 /* MatchupDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupDetailView.swift; sourceTree = "<group>"; };
 		6F2D6E80C100927C4C20FAD7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -388,6 +390,7 @@
 				45B52D5FD69B62417928B713 /* MatchupHistory.swift */,
 				E1E5A60EE78F668F02CF63C0 /* NflState.swift */,
 				22A99CAA9B57C1A0144DCA22 /* Player.swift */,
+				67C24A12080AD428D5A40A7E /* PlayerSeasonStats.swift */,
 				6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */,
 				42C8A3FA617E9FEB48852C45 /* Profile.swift */,
 				AE543CB2E49335ADD02E8000 /* Roster.swift */,
@@ -674,6 +677,7 @@
 				CF4CEF4E2FE7A891950A2E17 /* NflStateStore.swift in Sources */,
 				C9D656F4702A3483BB8E970C /* Player.swift in Sources */,
 				4DB9374CF45A69E97C02FC94 /* PlayerDetailView.swift in Sources */,
+				93D8C8E352B60752D37FD0FF /* PlayerSeasonStats.swift in Sources */,
 				FCD03562C1879183A5DC02E2 /* PlayerStore.swift in Sources */,
 				F201A3A40D624F6AAA0C0CC1 /* PlayoffBracket.swift in Sources */,
 				CB47F51AA46AEBC59183C449 /* PlayoffBracketView.swift in Sources */,

--- a/Xomper/Core/Models/PlayerSeasonStats.swift
+++ b/Xomper/Core/Models/PlayerSeasonStats.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Per-player aggregate stats for a single NFL regular season, decoded
+/// from Sleeper's `/stats/nfl/regular/{season}` endpoint. Only the
+/// fantasy-relevant fields are modeled — Sleeper returns dozens of
+/// raw stats fields per player; the lenient decoder ignores the rest.
+struct PlayerSeasonStats: Codable, Sendable {
+    /// Games played in the season.
+    let gamesPlayed: Int?
+    /// Total fantasy points (PPR scoring).
+    let pointsPPR: Double?
+    /// Total fantasy points (Half-PPR scoring).
+    let pointsHalfPPR: Double?
+    /// Total fantasy points (Standard / non-PPR scoring).
+    let pointsStandard: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case gamesPlayed = "gp"
+        case pointsPPR = "pts_ppr"
+        case pointsHalfPPR = "pts_half_ppr"
+        case pointsStandard = "pts_std"
+    }
+
+    /// Tolerant decoder — some players' entries omit fields entirely
+    /// (rookies with no games, defensive players with no fantasy
+    /// scoring). Treat any missing/malformed field as nil.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.gamesPlayed = try? c.decodeIfPresent(Int.self, forKey: .gamesPlayed)
+        self.pointsPPR = try? c.decodeIfPresent(Double.self, forKey: .pointsPPR)
+        self.pointsHalfPPR = try? c.decodeIfPresent(Double.self, forKey: .pointsHalfPPR)
+        self.pointsStandard = try? c.decodeIfPresent(Double.self, forKey: .pointsStandard)
+    }
+
+    /// PPR points per game played, or nil if no games or no points.
+    var avgPointsPPR: Double? {
+        guard let gp = gamesPlayed, gp > 0, let pts = pointsPPR else { return nil }
+        return pts / Double(gp)
+    }
+
+    /// Half-PPR points per game played, or nil if no games or no points.
+    var avgPointsHalfPPR: Double? {
+        guard let gp = gamesPlayed, gp > 0, let pts = pointsHalfPPR else { return nil }
+        return pts / Double(gp)
+    }
+}

--- a/Xomper/Core/Networking/SleeperAPIClient.swift
+++ b/Xomper/Core/Networking/SleeperAPIClient.swift
@@ -18,6 +18,7 @@ protocol SleeperAPIClientProtocol: Sendable {
     func fetchNflState() async throws -> NflState
     func fetchAllPlayers() async throws -> [String: Player]
     func fetchAllPlayersRaw(etag: String?) async throws -> PlayerFetchResult
+    func fetchPlayerSeasonStats(season: String) async throws -> [String: PlayerSeasonStats]
 }
 
 // MARK: - Player Fetch Result
@@ -129,6 +130,10 @@ final class SleeperAPIClient: SleeperAPIClientProtocol {
 
     func fetchAllPlayers() async throws -> [String: Player] {
         try await get("/players/nfl")
+    }
+
+    func fetchPlayerSeasonStats(season: String) async throws -> [String: PlayerSeasonStats] {
+        try await get("/stats/nfl/regular/\(season)")
     }
 
     func fetchAllPlayersRaw(etag: String?) async throws -> PlayerFetchResult {

--- a/Xomper/Core/Stores/PlayerStore.swift
+++ b/Xomper/Core/Stores/PlayerStore.swift
@@ -7,6 +7,12 @@ final class PlayerStore {
     private(set) var isLoading = false
     private(set) var error: Error?
 
+    /// Per-season stat cache keyed by season string (e.g. "2025"). Lazily
+    /// populated on first request so PlayerDetailView can render avg
+    /// fantasy points without forcing a 5MB download on app launch.
+    private(set) var seasonStats: [String: [String: PlayerSeasonStats]] = [:]
+    private(set) var loadingSeasons: Set<String> = []
+
     private let apiClient: SleeperAPIClientProtocol
     private let cacheURL: URL
     private let etagKey = "PlayerStore.etag"
@@ -76,6 +82,34 @@ final class PlayerStore {
 
     func player(for id: String) -> Player? {
         players[id]
+    }
+
+    /// Lazily fetches and caches per-season fantasy stats. No-op if
+    /// already cached or already in flight. Errors are swallowed
+    /// silently — calling sites can render `nil` averages on failure
+    /// without breaking the rest of the player view.
+    func loadSeasonStats(_ season: String) async {
+        let trimmed = season.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty,
+              seasonStats[trimmed] == nil,
+              !loadingSeasons.contains(trimmed) else { return }
+
+        loadingSeasons.insert(trimmed)
+        defer { loadingSeasons.remove(trimmed) }
+
+        do {
+            let stats = try await apiClient.fetchPlayerSeasonStats(season: trimmed)
+            seasonStats[trimmed] = stats
+        } catch {
+            // Non-fatal — stats just won't render for this season.
+        }
+    }
+
+    /// Direct accessor for a single player's stats in a single season.
+    /// Returns nil when the season hasn't been loaded yet OR when the
+    /// player has no recorded stats for that season.
+    func stats(for playerId: String, season: String) -> PlayerSeasonStats? {
+        seasonStats[season]?[playerId]
     }
 
     func search(query: String, limit: Int = 25) -> [Player] {

--- a/Xomper/Features/DraftHistory/DraftHistoryView.swift
+++ b/Xomper/Features/DraftHistory/DraftHistoryView.swift
@@ -37,7 +37,7 @@ struct DraftHistoryView: View {
             await loadDraftHistory()
         }
         .sheet(item: $selectedPlayer) { player in
-            PlayerDetailView(player: player)
+            PlayerDetailView(player: player, playerStore: playerStore)
         }
     }
 

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -358,7 +358,11 @@ struct MainShell: View {
 
         case .playerDetail(let playerId):
             if let player = playerStore.player(for: playerId) {
-                PlayerDetailView(player: player)
+                PlayerDetailView(
+                    player: player,
+                    playerStore: playerStore,
+                    currentSeason: nflStateStore.nflState?.season
+                )
             } else {
                 EmptyStateView(
                     icon: "person.fill",

--- a/Xomper/Features/Team/PlayerDetailView.swift
+++ b/Xomper/Features/Team/PlayerDetailView.swift
@@ -2,11 +2,24 @@ import SwiftUI
 
 struct PlayerDetailView: View {
     let player: Player
+    var playerStore: PlayerStore? = nil
+    var currentSeason: String? = nil
 
     @Environment(\.dismiss) private var dismiss
 
     private var teamColor: NFLTeamColor {
         NFLTeamColors.color(for: player.displayTeam)
+    }
+
+    /// Seasons to fetch + render in the Fantasy Production section.
+    /// Falls back to the two most recent calendar years when no
+    /// `currentSeason` was provided.
+    private var seasonsForStats: [String] {
+        if let s = currentSeason, let yr = Int(s) {
+            return ["\(yr)", "\(yr - 1)"]
+        }
+        let year = Calendar.current.component(.year, from: Date())
+        return ["\(year)", "\(year - 1)"]
     }
 
     var body: some View {
@@ -22,6 +35,12 @@ struct PlayerDetailView: View {
             dismissButton
         }
         .accessibilityElement(children: .contain)
+        .task(id: player.playerId) {
+            guard let store = playerStore else { return }
+            for season in seasonsForStats {
+                await store.loadSeasonStats(season)
+            }
+        }
     }
 }
 
@@ -104,6 +123,8 @@ private extension PlayerDetailView {
 private extension PlayerDetailView {
     var infoGrid: some View {
         VStack(spacing: XomperTheme.Spacing.md) {
+            fantasySection
+
             if hasPhysicalInfo {
                 sectionHeader("Physical")
                 LazyVGrid(columns: gridColumns, spacing: XomperTheme.Spacing.sm) {
@@ -149,6 +170,51 @@ private extension PlayerDetailView {
 
     var gridColumns: [GridItem] {
         [GridItem(.flexible()), GridItem(.flexible())]
+    }
+
+    /// "Fantasy Production" section. Renders avg PPR points per game
+    /// for this season + last season when stats are available. Hidden
+    /// entirely when no `playerStore` was provided OR when neither
+    /// season has any data for this player.
+    @ViewBuilder
+    var fantasySection: some View {
+        if let store = playerStore {
+            let seasons = seasonsForStats
+            let entries: [(season: String, stats: PlayerSeasonStats)] = seasons.compactMap { s in
+                if let stats = store.stats(for: player.playerId, season: s) {
+                    return (season: s, stats: stats)
+                }
+                return nil
+            }
+
+            if !entries.isEmpty {
+                sectionHeader("Fantasy Production")
+                LazyVGrid(columns: gridColumns, spacing: XomperTheme.Spacing.sm) {
+                    ForEach(entries, id: \.season) { entry in
+                        statCell(
+                            label: "\(entry.season) PPR avg",
+                            value: averageString(entry.stats.avgPointsPPR),
+                            valueColor: XomperColors.championGold
+                        )
+                        statCell(
+                            label: "\(entry.season) games",
+                            value: entry.stats.gamesPlayed.map { "\($0)" } ?? "—"
+                        )
+                    }
+                }
+            } else if seasons.contains(where: { store.loadingSeasons.contains($0) }) {
+                sectionHeader("Fantasy Production")
+                ProgressView()
+                    .tint(XomperColors.championGold)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, XomperTheme.Spacing.md)
+            }
+        }
+    }
+
+    private func averageString(_ value: Double?) -> String {
+        guard let value else { return "—" }
+        return String(format: "%.1f", value)
     }
 
     var hasPhysicalInfo: Bool {

--- a/Xomper/Features/Team/TeamView.swift
+++ b/Xomper/Features/Team/TeamView.swift
@@ -65,7 +65,7 @@ struct TeamView: View {
         }
         .background(XomperColors.bgDark)
         .sheet(item: $selectedPlayer) { player in
-            PlayerDetailView(player: player)
+            PlayerDetailView(player: player, playerStore: playerStore)
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
         }


### PR DESCRIPTION
Closes the "on player view, can we see current season/past season average points" ask.

## What's new
A **Fantasy Production** section on the player detail view, rendering avg PPR points/game for this season + last season + games played per season. Gold accent, 2-column grid above the existing Physical / Background / Status sections.

## Implementation
- New \`PlayerSeasonStats\` model decoding Sleeper's \`/stats/nfl/regular/{season}\` response
- New \`SleeperAPIClient.fetchPlayerSeasonStats(season:)\`
- \`PlayerStore\` gains \`seasonStats\` cache + \`loadSeasonStats(_:)\` (lazy, idempotent)
- \`PlayerDetailView\` takes optional \`playerStore\` + \`currentSeason\` params, fetches both seasons on appear, hides the whole section if neither has data

## Notes
- The \`/stats\` endpoint is ~5MB; first open of any player detail triggers the fetch, then it's cached for the rest of the session
- Hidden gracefully for rookies / preseason / inactive players
- Backwards-compatible — older callsites that don't pass \`playerStore\` just don't render the new section

## Test plan
- [ ] Open Team → tap a player → "Fantasy Production" section shows 2025 + 2024 PPR avg
- [ ] Open Search → tap a player → same section
- [ ] Open a rookie or preseason player → section hidden