### PR TITLE
fix: draft pick decode bug + matchup history tap detail + qualification pill width

### DIFF
--- a/Xomper/Core/Models/Draft.swift
+++ b/Xomper/Core/Models/Draft.swift
@@ -89,7 +89,12 @@ struct DraftMetadata: Codable, Sendable {
 struct DraftPick: Codable, Identifiable, Sendable {
     let playerId: String
     let pickedBy: String?
-    let rosterId: String?
+    /// Sleeper returns this as an Int (e.g. `9`), NOT a String. Decoding
+    /// it as `String?` made the whole picks-array decode throw silently
+    /// — that's why "No Draft History" was rendering even though the
+    /// 2025 draft is complete and 60 picks exist on Sleeper. Same class
+    /// of bug as Player.depthChartPosition (#44).
+    let rosterId: Int?
     let round: Int
     let draftSlot: Int
     let pickNo: Int
@@ -109,6 +114,44 @@ struct DraftPick: Codable, Identifiable, Sendable {
         case metadata
         case isKeeper = "is_keeper"
         case draftId = "draft_id"
+    }
+
+    /// Lenient decoder — same defense applied to Player after #44.
+    /// Mismatched field types degrade to nil instead of taking down
+    /// the whole array.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.playerId = try c.decode(String.self, forKey: .playerId)
+        self.pickedBy = try? c.decodeIfPresent(String.self, forKey: .pickedBy)
+        self.rosterId = try? c.decodeIfPresent(Int.self, forKey: .rosterId)
+        self.round = (try? c.decode(Int.self, forKey: .round)) ?? 0
+        self.draftSlot = (try? c.decode(Int.self, forKey: .draftSlot)) ?? 0
+        self.pickNo = (try? c.decode(Int.self, forKey: .pickNo)) ?? 0
+        self.metadata = try? c.decodeIfPresent(DraftPickMetadata.self, forKey: .metadata)
+        self.isKeeper = try? c.decodeIfPresent(Bool.self, forKey: .isKeeper)
+        self.draftId = try? c.decodeIfPresent(String.self, forKey: .draftId)
+    }
+
+    init(
+        playerId: String,
+        pickedBy: String? = nil,
+        rosterId: Int? = nil,
+        round: Int,
+        draftSlot: Int,
+        pickNo: Int,
+        metadata: DraftPickMetadata? = nil,
+        isKeeper: Bool? = nil,
+        draftId: String? = nil
+    ) {
+        self.playerId = playerId
+        self.pickedBy = pickedBy
+        self.rosterId = rosterId
+        self.round = round
+        self.draftSlot = draftSlot
+        self.pickNo = pickNo
+        self.metadata = metadata
+        self.isKeeper = isKeeper
+        self.draftId = draftId
     }
 }
 

--- a/Xomper/Core/Stores/HistoryStore.swift
+++ b/Xomper/Core/Stores/HistoryStore.swift
@@ -469,7 +469,7 @@ final class HistoryStore {
 
             for pick in picks {
                 // Resolve user from roster data
-                let roster = rosters.first { String($0.rosterId) == pick.rosterId }
+                let roster = rosters.first { $0.rosterId == pick.rosterId }
                 let user = users.first { $0.userId == (pick.pickedBy ?? roster?.ownerId) }
 
                 let playerName = [
@@ -491,7 +491,7 @@ final class HistoryStore {
                     playerPosition: pick.metadata?.position ?? "",
                     playerTeam: pick.metadata?.team ?? "",
                     pickedByUserId: pick.pickedBy ?? roster?.ownerId ?? "",
-                    pickedByRosterId: Int(pick.rosterId ?? "0") ?? 0,
+                    pickedByRosterId: pick.rosterId ?? 0,
                     pickedByUsername: user?.username ?? "",
                     pickedByTeamName: user?.teamName ?? "",
                     isKeeper: pick.isKeeper ?? false

--- a/Xomper/Features/League/WorldCupView.swift
+++ b/Xomper/Features/League/WorldCupView.swift
@@ -196,12 +196,15 @@ private struct WorldCupDivisionSection: View {
                     .font(.caption2)
                     .fontWeight(.heavy)
                     .tracking(1)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
             }
             .foregroundStyle(XomperColors.championGold)
-            .padding(.horizontal, XomperTheme.Spacing.sm)
+            .padding(.horizontal, XomperTheme.Spacing.md)
             .padding(.vertical, XomperTheme.Spacing.xs)
             .background(XomperColors.championGold.opacity(0.12))
             .clipShape(Capsule())
+            .layoutPriority(1)
 
             Rectangle()
                 .fill(XomperColors.championGold.opacity(0.4))

--- a/Xomper/Features/MatchupHistory/MatchupHistoryBrowserView.swift
+++ b/Xomper/Features/MatchupHistory/MatchupHistoryBrowserView.swift
@@ -11,11 +11,12 @@ import SwiftUI
 struct MatchupHistoryBrowserView: View {
     var leagueStore: LeagueStore
     var historyStore: HistoryStore
+    var playerStore: PlayerStore
 
     @Environment(\.selectedSeason) private var seasonStore: SeasonStore?
 
     @State private var expandedWeeks: Set<Int> = []
-    @State private var selectedDetail: WeekMatchupDetailKey?
+    @State private var selectedRecord: MatchupHistoryRecord?
 
     var body: some View {
         Group {
@@ -41,6 +42,15 @@ struct MatchupHistoryBrowserView: View {
         }
         .refreshable {
             await reload()
+        }
+        .sheet(item: $selectedRecord) { record in
+            NavigationStack {
+                MatchupDetailView(
+                    record: record,
+                    historyStore: historyStore,
+                    playerStore: playerStore
+                )
+            }
         }
     }
 
@@ -114,34 +124,39 @@ struct MatchupHistoryBrowserView: View {
         let bothScoreless = record.teamAPoints == 0 && record.teamBPoints == 0
 
         return Button {
-            selectedDetail = WeekMatchupDetailKey(
-                leagueId: record.leagueId,
-                week: record.week,
-                matchupId: record.matchupId
-            )
+            selectedRecord = record
         } label: {
-            HStack(spacing: XomperTheme.Spacing.md) {
-                teamColumn(
-                    name: record.teamATeamName.isEmpty ? record.teamAUsername : record.teamATeamName,
-                    points: record.teamAPoints,
-                    isWinner: aWin,
-                    showOutcome: !bothScoreless
-                )
+            VStack(spacing: 0) {
+                if let placement = placementLabel(for: record) {
+                    Text(placement)
+                        .font(.caption2.weight(.heavy))
+                        .tracking(0.5)
+                        .foregroundStyle(XomperColors.championGold)
+                        .padding(.bottom, 2)
+                }
+                HStack(spacing: XomperTheme.Spacing.md) {
+                    teamColumn(
+                        name: record.teamATeamName.isEmpty ? record.teamAUsername : record.teamATeamName,
+                        points: record.teamAPoints,
+                        isWinner: aWin,
+                        showOutcome: !bothScoreless
+                    )
 
-                Text("vs")
-                    .font(.caption2)
-                    .foregroundStyle(XomperColors.textMuted)
+                    Text("vs")
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
 
-                teamColumn(
-                    name: record.teamBTeamName.isEmpty ? record.teamBUsername : record.teamBTeamName,
-                    points: record.teamBPoints,
-                    isWinner: bWin,
-                    showOutcome: !bothScoreless
-                )
+                    teamColumn(
+                        name: record.teamBTeamName.isEmpty ? record.teamBUsername : record.teamBTeamName,
+                        points: record.teamBPoints,
+                        isWinner: bWin,
+                        showOutcome: !bothScoreless
+                    )
 
-                Image(systemName: "chevron.right")
-                    .font(.caption)
-                    .foregroundStyle(XomperColors.textMuted)
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(XomperColors.textMuted)
+                }
             }
             .padding(.horizontal, XomperTheme.Spacing.md)
             .padding(.vertical, XomperTheme.Spacing.sm)
@@ -149,6 +164,17 @@ struct MatchupHistoryBrowserView: View {
             .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md, style: .continuous))
         }
         .buttonStyle(.plain)
+    }
+
+    /// Surface a "CHAMPIONSHIP" / "3RD PLACE" / "PLAYOFFS" tag on
+    /// matchup rows so users can see at a glance which games were for
+    /// placement. The week-16/17 split + isChampionship/isPlayoff are
+    /// inherited from how `HistoryStore.convertMatchupResults` flags
+    /// records.
+    private func placementLabel(for record: MatchupHistoryRecord) -> String? {
+        if record.isChampionship { return "CHAMPIONSHIP" }
+        if record.isPlayoff { return "PLAYOFFS · WEEK \(record.week)" }
+        return nil
     }
 
     private func teamColumn(name: String, points: Double, isWinner: Bool, showOutcome: Bool) -> some View {
@@ -247,9 +273,3 @@ private struct WeekBundle: Identifiable {
     var id: Int { week }
 }
 
-private struct WeekMatchupDetailKey: Identifiable, Hashable {
-    let leagueId: String
-    let week: Int
-    let matchupId: Int
-    var id: String { "\(leagueId)-\(week)-\(matchupId)" }
-}

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -151,7 +151,8 @@ struct MainShell: View {
             case .matchupHistory:
                 MatchupHistoryBrowserView(
                     leagueStore: leagueStore,
-                    historyStore: historyStore
+                    historyStore: historyStore,
+                    playerStore: playerStore
                 )
 
             case .worldCup:


### PR DESCRIPTION
Bundles the three immediate items + a product touch from the latest QA pass.

## 1. Draft history finally loads — same bug as #44 but for picks
\`DraftPick.rosterId\` was \`String?\` but Sleeper returns it as an Int. Strict JSONDecoder threw on every pick → fetchDraftPicks succeeded but the decode failed → \`continue\` skipped every draft → \`draftHistory\` empty → "No Draft History" forever.

Verified directly:
\`\`\`
GET /draft/1181789700187090945/picks → 60 picks, all with int roster_id
\`\`\`

Fix: \`rosterId: Int?\`, lenient \`init(from:)\` wrapping every optional in \`try?\` (mirroring the Player decoder hardening), updated HistoryStore call sites.

## 2. Matchup history rows are tappable
Browser had a stub key type for the detail sheet but no sheet wired. Now \`.sheet(item: $selectedRecord)\` opens the existing \`MatchupDetailView\` for each tapped row.

Each row also gets a placement tag — "**CHAMPIONSHIP**" or "**PLAYOFFS · WEEK N**" — so the user can spot which games were for placement (via the existing isChampionship / isPlayoff flags on the record).

\`playerStore\` wired through so the detail can resolve player lineups.

## 3. "QUALIFICATION LINE" pill no longer chops onto two lines
Caption2 + tracking + heavy weight squeezed the text onto two lines. \`lineLimit(1)\` + \`fixedSize(horizontal: true)\` + \`layoutPriority(1)\` + bumped horizontal padding so the pill always renders on one line, the gold rules clip cleanly on either side.

## Test plan
- [ ] Draft History 2025 → renders the full draft (60 picks, 5 rounds)
- [ ] Matchup History → tap any row → detail sheet opens with player lineups
- [ ] Playoff/championship rows show their placement tag in gold
- [ ] World Cup qualification pill renders on one line

## Filed but not in this PR
- #56 — projected payouts page
- #57 — reverse-HPP draft order rule
- #58 — team analyzer + KTC values

Year-by-year toggle on Matchup History — already exists via the F5 SeasonStore picker in HeaderBar. Confirm it's visible on the .matchupHistory destination.