### PR TITLE
fix: show season picker on Matchup History

### DIFF
--- a/Xomper/Features/Shell/HeaderBar.swift
+++ b/Xomper/Features/Shell/HeaderBar.swift
@@ -27,6 +27,7 @@ struct HeaderBar: View {
     private static let seasonScopedDestinations: Set<TrayDestination> = [
         .matchups,
         .draftHistory,
+        .matchupHistory,
     ]
 
     var body: some View {


### PR DESCRIPTION
Year-by-year toggle was missing on the `.matchupHistory` destination. `HeaderBar.seasonScopedDestinations` now includes `.matchupHistory` alongside `.matchups` and `.draftHistory`. The browser view already reads from the env, just needed the picker rendered. One-line fix.