### PR TITLE
feat: playoff player lineups + draft board grid view

### DIFF
--- a/Xomper/Features/DraftHistory/DraftHistoryView.swift
+++ b/Xomper/Features/DraftHistory/DraftHistoryView.swift
@@ -9,6 +9,7 @@ struct DraftHistoryView: View {
     @Environment(\.selectedSeason) private var seasonStore: SeasonStore?
 
     @State private var filterMode: PickFilter = .all
+    @State private var viewMode: DraftViewMode = .rounds
     @State private var selectedPlayer: Player?
 
     private var currentSeason: String {
@@ -44,19 +45,64 @@ struct DraftHistoryView: View {
     // MARK: - Content
 
     private var draftContent: some View {
-        ScrollView {
-            VStack(spacing: XomperTheme.Spacing.md) {
-                filterPicker
-                roundsList
+        VStack(spacing: 0) {
+            controlsBar
+
+            switch viewMode {
+            case .rounds:
+                ScrollView {
+                    VStack(spacing: XomperTheme.Spacing.md) {
+                        roundsList
+                    }
+                    .padding(.horizontal, XomperTheme.Spacing.md)
+                    .padding(.vertical, XomperTheme.Spacing.sm)
+                }
+                .refreshable {
+                    historyStore.reset()
+                    await loadDraftHistory()
+                }
+            case .board:
+                draftBoard
             }
-            .padding(.horizontal, XomperTheme.Spacing.md)
-            .padding(.vertical, XomperTheme.Spacing.sm)
         }
         .background(XomperColors.bgDark)
-        .refreshable {
-            historyStore.reset()
-            await loadDraftHistory()
+    }
+
+    // MARK: - Controls bar (filter + view-mode toggle)
+
+    private var controlsBar: some View {
+        HStack(alignment: .center, spacing: XomperTheme.Spacing.sm) {
+            filterPicker
+
+            Spacer(minLength: 0)
+
+            HStack(spacing: 0) {
+                ForEach(DraftViewMode.allCases) { mode in
+                    Button {
+                        let g = UIImpactFeedbackGenerator(style: .light)
+                        g.impactOccurred()
+                        withAnimation(XomperTheme.defaultAnimation) {
+                            viewMode = mode
+                        }
+                    } label: {
+                        Image(systemName: mode.systemImage)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(viewMode == mode ? XomperColors.bgDark : XomperColors.textSecondary)
+                            .frame(width: 36, height: 30)
+                            .background(viewMode == mode ? XomperColors.championGold : Color.clear)
+                            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(mode.label)
+                    .accessibilityAddTraits(viewMode == mode ? .isSelected : [])
+                }
+            }
+            .padding(2)
+            .background(XomperColors.surfaceLight.opacity(0.4))
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md + 2))
         }
+        .padding(.horizontal, XomperTheme.Spacing.md)
+        .padding(.vertical, XomperTheme.Spacing.sm)
     }
 
     // MARK: - Filter Picker
@@ -74,6 +120,142 @@ struct DraftHistoryView: View {
                 }
             }
             Spacer()
+        }
+    }
+
+    // MARK: - Draft Board (snake / linear grid)
+
+    /// Snake-style draft board. Columns = draft slots (1...N), rows =
+    /// rounds. Each pick lives at its (round, draft_slot) cell. Sleeper
+    /// already records `draft_slot` correctly for both linear and
+    /// snake drafts (snake's "reverse" rounds reuse the team's anchor
+    /// slot), so a single grid layout works for either.
+    /// Horizontal-scrollable since 12 columns is too wide for portrait.
+    private var draftBoard: some View {
+        let picks = historyStore.draftPicksByRound(forSeason: currentSeason)
+            .flatMap(\.picks)
+        let slots = Array(1...max(slotCount(picks), 1))
+        let roundsByNum: [Int: [DraftHistoryRecord]] = Dictionary(grouping: picks) { $0.round }
+        let sortedRounds = roundsByNum.keys.sorted()
+
+        return ScrollView([.horizontal, .vertical], showsIndicators: false) {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+                slotHeaderRow(slots: slots)
+                ForEach(sortedRounds, id: \.self) { round in
+                    boardRoundRow(
+                        round: round,
+                        slots: slots,
+                        picks: roundsByNum[round] ?? []
+                    )
+                }
+            }
+            .padding(.horizontal, XomperTheme.Spacing.md)
+            .padding(.vertical, XomperTheme.Spacing.sm)
+        }
+        .refreshable {
+            historyStore.reset()
+            await loadDraftHistory()
+        }
+    }
+
+    private func slotCount(_ picks: [DraftHistoryRecord]) -> Int {
+        picks.map(\.draftSlot).max() ?? 12
+    }
+
+    private func slotHeaderRow(slots: [Int]) -> some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            // Round-number gutter
+            Text("R")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(XomperColors.textMuted)
+                .frame(width: 22)
+
+            ForEach(slots, id: \.self) { slot in
+                Text("\(slot)")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(XomperColors.textMuted)
+                    .frame(width: boardCellWidth, alignment: .center)
+            }
+        }
+    }
+
+    private func boardRoundRow(round: Int, slots: [Int], picks: [DraftHistoryRecord]) -> some View {
+        let bySlot = Dictionary(uniqueKeysWithValues: picks.map { ($0.draftSlot, $0) })
+        return HStack(spacing: XomperTheme.Spacing.xs) {
+            Text("\(round)")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(XomperColors.championGold)
+                .frame(width: 22)
+
+            ForEach(slots, id: \.self) { slot in
+                if let pick = bySlot[slot] {
+                    boardPickCell(pick)
+                } else {
+                    boardEmptyCell()
+                }
+            }
+        }
+    }
+
+    private var boardCellWidth: CGFloat { 78 }
+    private var boardCellHeight: CGFloat { 64 }
+
+    private func boardPickCell(_ pick: DraftHistoryRecord) -> some View {
+        Button {
+            selectPlayer(pick.playerId)
+        } label: {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(pick.playerName.isEmpty ? "—" : pick.playerName)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.7)
+
+                HStack(spacing: 3) {
+                    Text(pick.playerPosition)
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(XomperColors.bgDark)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(positionColor(pick.playerPosition))
+                        .clipShape(RoundedRectangle(cornerRadius: 3))
+                    if !pick.playerTeam.isEmpty {
+                        Text(pick.playerTeam)
+                            .font(.caption2)
+                            .foregroundStyle(XomperColors.textSecondary)
+                    }
+                }
+
+                Text("#\(pick.pickNo)")
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.textMuted)
+            }
+            .frame(width: boardCellWidth, height: boardCellHeight, alignment: .topLeading)
+            .padding(6)
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(
+            "Round \(pick.round), pick \(pick.pickNo). \(pick.playerName), \(pick.playerPosition), \(pick.playerTeam)."
+        )
+    }
+
+    private func boardEmptyCell() -> some View {
+        RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md)
+            .fill(XomperColors.surfaceLight.opacity(0.2))
+            .frame(width: boardCellWidth, height: boardCellHeight)
+    }
+
+    private func positionColor(_ pos: String) -> Color {
+        switch pos.uppercased() {
+        case "QB": return Color(red: 0.95, green: 0.30, blue: 0.42)
+        case "RB": return Color(red: 0.20, green: 0.80, blue: 0.50)
+        case "WR": return Color(red: 0.30, green: 0.55, blue: 0.95)
+        case "TE": return Color(red: 0.95, green: 0.65, blue: 0.20)
+        case "K":  return Color(red: 0.65, green: 0.55, blue: 0.85)
+        case "DEF","DST": return Color(red: 0.55, green: 0.55, blue: 0.55)
+        default: return XomperColors.surfaceLight
         }
     }
 
@@ -379,6 +561,29 @@ private struct DraftPickCard: View {
             desc += ", keeper"
         }
         return desc
+    }
+}
+
+// MARK: - View Mode
+
+enum DraftViewMode: String, CaseIterable, Identifiable {
+    case rounds
+    case board
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .rounds: "Rounds list"
+        case .board: "Draft board grid"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .rounds: "list.bullet"
+        case .board: "square.grid.3x3.fill"
+        }
     }
 }
 

--- a/Xomper/Features/League/PlayoffBracketView.swift
+++ b/Xomper/Features/League/PlayoffBracketView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct PlayoffBracketView: View {
     var leagueStore: LeagueStore
+    var historyStore: HistoryStore
+    var playerStore: PlayerStore
 
     @State private var standings: [StandingsTeam] = []
     @State private var bracketType: BracketType = .winners
@@ -61,7 +63,10 @@ struct PlayoffBracketView: View {
                     match: match,
                     standings: standings,
                     leagueId: leagueStore.myLeague?.leagueId,
-                    playoffWeekStart: playoffWeekStart
+                    playoffWeekStart: playoffWeekStart,
+                    season: leagueStore.myLeague?.season,
+                    historyStore: historyStore,
+                    playerStore: playerStore
                 )
             }
             .presentationDetents([.medium, .large])
@@ -520,12 +525,16 @@ private struct BracketMatchDetailSheet: View {
     let standings: [StandingsTeam]
     let leagueId: String?
     let playoffWeekStart: Int?
+    let season: String?
+    var historyStore: HistoryStore
+    var playerStore: PlayerStore
 
     @Environment(\.dismiss) private var dismiss
 
     @State private var team1Points: Double?
     @State private var team2Points: Double?
     @State private var isLoadingScores = false
+    @State private var matchupId: Int?
 
     private let apiClient: SleeperAPIClientProtocol = SleeperAPIClient()
 
@@ -604,6 +613,25 @@ private struct BracketMatchDetailSheet: View {
                 Text("Week \(week)")
                     .font(.caption)
                     .foregroundStyle(XomperColors.textMuted)
+            }
+
+            if let lineupRecord = derivedLineupRecord() {
+                NavigationLink {
+                    MatchupDetailView(
+                        record: lineupRecord,
+                        historyStore: historyStore,
+                        playerStore: playerStore
+                    )
+                } label: {
+                    Label("View Player Lineups", systemImage: "list.bullet.rectangle")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(XomperColors.bgDark)
+                        .padding(.horizontal, XomperTheme.Spacing.lg)
+                        .padding(.vertical, XomperTheme.Spacing.sm)
+                        .background(XomperColors.championGold)
+                        .clipShape(Capsule())
+                }
+                .accessibilityHint("Opens player lineups and per-player points for this matchup")
             }
 
             Spacer()
@@ -697,6 +725,47 @@ private struct BracketMatchDetailSheet: View {
         .opacity(isLoser ? 0.6 : 1.0)
     }
 
+    /// Synthesize a `MatchupHistoryRecord` for this bracket match so
+    /// `MatchupDetailView` can render player-level lineups + points.
+    /// Returns nil until both teams' roster data and the matchup_id are
+    /// resolved via the loadScores fetch. The record is ad-hoc — not
+    /// stored anywhere — and is purely a vehicle for the detail view's
+    /// existing fetch flow (it calls historyStore.fetchRawMatchups(
+    /// leagueId:week:) using these fields).
+    private func derivedLineupRecord() -> MatchupHistoryRecord? {
+        guard let leagueId,
+              let week = matchWeek,
+              let mid = matchupId,
+              let r1 = match.team1RosterId,
+              let r2 = match.team2RosterId,
+              let team1 = standings.first(where: { $0.rosterId == r1 }),
+              let team2 = standings.first(where: { $0.rosterId == r2 }) else {
+            return nil
+        }
+
+        return MatchupHistoryRecord(
+            leagueId: leagueId,
+            season: season ?? "",
+            week: week,
+            matchupId: mid,
+            teamARosterId: r1,
+            teamAUserId: team1.userId,
+            teamAUsername: team1.username,
+            teamATeamName: team1.teamName,
+            teamAPoints: team1Points ?? 0,
+            teamBRosterId: r2,
+            teamBUserId: team2.userId,
+            teamBUsername: team2.username,
+            teamBTeamName: team2.teamName,
+            teamBPoints: team2Points ?? 0,
+            winnerRosterId: match.winnerRosterId,
+            isPlayoff: true,
+            isChampionship: match.placement == 1,
+            teamADivision: 0,
+            teamBDivision: 0
+        )
+    }
+
     private func loadScores() async {
         guard let leagueId, let week = matchWeek,
               let r1 = match.team1RosterId, let r2 = match.team2RosterId else { return }
@@ -711,7 +780,7 @@ private struct BracketMatchDetailSheet: View {
                 guard let mid = m.matchupId else { continue }
                 grouped[mid, default: []].append(m)
             }
-            for (_, pair) in grouped where pair.count >= 2 {
+            for (mid, pair) in grouped where pair.count >= 2 {
                 let rids = pair.map(\.rosterId)
                 if rids.contains(r1) && rids.contains(r2) {
                     if let t1 = pair.first(where: { $0.rosterId == r1 }) {
@@ -720,6 +789,7 @@ private struct BracketMatchDetailSheet: View {
                     if let t2 = pair.first(where: { $0.rosterId == r2 }) {
                         team2Points = t2.resolvedPoints
                     }
+                    matchupId = mid
                     return
                 }
             }
@@ -780,7 +850,11 @@ private struct BracketRound {
 
 #Preview {
     NavigationStack {
-        PlayoffBracketView(leagueStore: LeagueStore())
+        PlayoffBracketView(
+            leagueStore: LeagueStore(),
+            historyStore: HistoryStore(),
+            playerStore: PlayerStore()
+        )
     }
     .preferredColorScheme(.dark)
 }

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -138,7 +138,11 @@ struct MainShell: View {
                 )
 
             case .playoffs:
-                PlayoffBracketView(leagueStore: leagueStore)
+                PlayoffBracketView(
+                    leagueStore: leagueStore,
+                    historyStore: historyStore,
+                    playerStore: playerStore
+                )
 
             case .draftHistory:
                 DraftHistoryView(


### PR DESCRIPTION
Both items from the user's prioritized list.

## 1. Playoff player lineups
The bracket detail sheet now has a gold **"View Player Lineups"** button (when the match has played and scores are resolved). Tapping it pushes \`MatchupDetailView\` inside the sheet's \`NavigationStack\` — same view used elsewhere — by synthesizing a \`MatchupHistoryRecord\` from the bracket match's rosters + week + captured \`matchup_id\`.

\`PlayoffBracketView\` gains \`historyStore\` + \`playerStore\` params (threaded through MainShell).

## 2. Draft board grid view
\`DraftHistoryView\` gains a list/grid toggle in the controls bar. Grid mode renders a snake-style **draft board**:
- Columns = draft slots (1–12)
- Rows = rounds
- Each cell = player name + position pill (color-coded) + NFL team + pick #
- Round-number gutter on the left
- Horizontal + vertical scroll for portrait fit
- Tap any cell → PlayerDetailView

Sleeper's \`draft_slot\` is correct for both linear and snake drafts, so one layout handles either type.

## Out of scope
- Pre-draft 2026 board (showing the upcoming draft order with empty cells) — separate piece, needs the upcoming-draft to be surfaced even when picks list is empty.

## Test plan
- [ ] Playoffs → tap any played match → "View Player Lineups" capsule → MatchupDetailView pushes with player breakdowns
- [ ] Draft History → toggle to grid → 5 rounds × 12 slots, color-coded position pills
- [ ] Tap a draft cell → PlayerDetailView
- [ ] Switch back to List view → existing layout still works