### PR TITLE
feat: team analyzer — hexagon chart of position values + comparison

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		556BA960B3DFFACAB2F3DFA6 /* EnvironmentValues+Season.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6504EE31A645398C41BC2ED1 /* EnvironmentValues+Season.swift */; };
 		578172B9CCF7AD92CB66821E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D61F12E32D7C81FCA8F8CE /* ContentView.swift */; };
 		57C17293587E8DBED9A14970 /* TradedPick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F49969EE42BDE6462664021 /* TradedPick.swift */; };
+		58FD67DB9B137F1A8BE50521 /* TeamAnalyzerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8098F78566BB324ACC70FB94 /* TeamAnalyzerView.swift */; };
 		6010F16122E110BA50642611 /* CareerStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD43D54AB620DABD559F8A40 /* CareerStats.swift */; };
 		602B6E0F6BCF1DA7E3D75F07 /* AuthStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */; };
 		60FB3A9B54EAB11F015C1828 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC24A8748C940FC57B142AFF /* ErrorView.swift */; };
@@ -75,12 +76,16 @@
 		A28A24923C27CF0929ED97E1 /* Double+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669A80C2A9F46A0C4612388C /* Double+Formatting.swift */; };
 		A379F9D71FE84EC4F3A2499C /* SearchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C5F37100E6EBB467EBFE1C /* SearchStore.swift */; };
 		A4D93DF4C02A8DE6C695CE4D /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E94170F987E8EFE5C566B9B /* LoginView.swift */; };
+		B24D5DBDDF4C163FCAB52689 /* TeamAnalysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC09DFF48D9AAFEF0A286BAD /* TeamAnalysis.swift */; };
+		B309CAE3F00F954918C09554 /* PlayerValuesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE99E9B095120FB6636FC8A /* PlayerValuesStore.swift */; };
 		B48B9F6061A67CFC74A096CC /* StandingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957EE31D25CFE325633622D4 /* StandingsStore.swift */; };
 		B7EB06298BFBF6AC76ABF53E /* TeamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51CC9357B13AB7ADD9C8586 /* TeamView.swift */; };
 		BB91E92DC29E6ECA5E1F0DEC /* SeasonStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F3F1A18F4EEC5A3F81FD28 /* SeasonStore.swift */; };
 		BBBE8D43F297A49A915AA789 /* WorldCupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F83A5F997AF6E13C98660E /* WorldCupView.swift */; };
 		BDD14CA33B905F7A31910B1D /* SupabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10CD226D313FDD91E4037D8E /* SupabaseManager.swift */; };
+		BE71F196BAB7D9E78BE94A9D /* PlayerValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE87151F7F5AAB8F12F98B91 /* PlayerValue.swift */; };
 		C1D86EAE02F0D6EA70291876 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC70812B3E7E07BA6658A54 /* AvatarView.swift */; };
+		C21992E2FA476C65D8D23BA8 /* HexagonChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 501B8FD2B915B3BD6568F42C /* HexagonChartView.swift */; };
 		C381DCE8472D2F88B04FCBDA /* CareerStatsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CFD764A2BA7FF93B318A7F /* CareerStatsSection.swift */; };
 		C9D656F4702A3483BB8E970C /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A99CAA9B57C1A0144DCA22 /* Player.swift */; };
 		CB47F51AA46AEBC59183C449 /* PlayoffBracketView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581D4F6F3EB8FC0547F49927 /* PlayoffBracketView.swift */; };
@@ -136,11 +141,13 @@
 		44F83A5F997AF6E13C98660E /* WorldCupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupView.swift; sourceTree = "<group>"; };
 		45B52D5FD69B62417928B713 /* MatchupHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupHistory.swift; sourceTree = "<group>"; };
 		460030AF84E8D0E83D8F5896 /* Xomper.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Xomper.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		501B8FD2B915B3BD6568F42C /* HexagonChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HexagonChartView.swift; sourceTree = "<group>"; };
 		536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthStore.swift; sourceTree = "<group>"; };
 		558164667DF7D89C4DF2F32E /* MyProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyProfileView.swift; sourceTree = "<group>"; };
 		56BB91320E3D5EBE1F777838 /* LeagueStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeagueStore.swift; sourceTree = "<group>"; };
 		57940AEB84889A20016648F2 /* TaxiSquadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiSquadView.swift; sourceTree = "<group>"; };
 		581D4F6F3EB8FC0547F49927 /* PlayoffBracketView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayoffBracketView.swift; sourceTree = "<group>"; };
+		5CE99E9B095120FB6636FC8A /* PlayerValuesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerValuesStore.swift; sourceTree = "<group>"; };
 		5EABD25CAB8BF973C4709720 /* AppRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRouter.swift; sourceTree = "<group>"; };
 		5FDC8A9B02A2BFD83398D04F /* RulesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesStore.swift; sourceTree = "<group>"; };
 		62948D0A455E7CE99B15CB75 /* UserStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStore.swift; sourceTree = "<group>"; };
@@ -153,6 +160,7 @@
 		6F2D6E80C100927C4C20FAD7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		72CFD764A2BA7FF93B318A7F /* CareerStatsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareerStatsSection.swift; sourceTree = "<group>"; };
 		7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Draft.swift; sourceTree = "<group>"; };
+		8098F78566BB324ACC70FB94 /* TeamAnalyzerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamAnalyzerView.swift; sourceTree = "<group>"; };
 		840D50097382434B0D123ACB /* NavigationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStore.swift; sourceTree = "<group>"; };
 		8521885A7FF4C6910DFBF549 /* MatchupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupsView.swift; sourceTree = "<group>"; };
 		89FC018282A1F1D8B2FD1B60 /* XomperAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperAPIClient.swift; sourceTree = "<group>"; };
@@ -179,6 +187,7 @@
 		BB5E661424C55F695BF96281 /* AuthGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthGateView.swift; sourceTree = "<group>"; };
 		BC44D14381C74E97D8AF868F /* PlayerDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerDetailView.swift; sourceTree = "<group>"; };
 		BD2908776CDAC0CACB28B4B1 /* TrophyCaseCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrophyCaseCard.swift; sourceTree = "<group>"; };
+		BE87151F7F5AAB8F12F98B91 /* PlayerValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerValue.swift; sourceTree = "<group>"; };
 		C1CD5644F6F8376CA86092AF /* Xomper.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Xomper.entitlements; sourceTree = "<group>"; };
 		C3AFC2ADE424F95E3121BF22 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		C82B0FEAAB9BC80BA0801E98 /* XomperColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperColors.swift; sourceTree = "<group>"; };
@@ -208,6 +217,7 @@
 		F4A254D17EF062523E09C9D4 /* MainShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainShell.swift; sourceTree = "<group>"; };
 		F51CC9357B13AB7ADD9C8586 /* TeamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamView.swift; sourceTree = "<group>"; };
 		F6F606D0624D23D47A171D26 /* SearchResultGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultGroup.swift; sourceTree = "<group>"; };
+		FC09DFF48D9AAFEF0A286BAD /* TeamAnalysis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamAnalysis.swift; sourceTree = "<group>"; };
 		FD5AF5657020E1DBB5CB8886 /* SeasonPickerBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonPickerBar.swift; sourceTree = "<group>"; };
 		FD88B55D96BD7C519B6B65B6 /* League.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = League.swift; sourceTree = "<group>"; };
 		FF3FE7B1A468AA2569D95B20 /* TrayProfileCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayProfileCard.swift; sourceTree = "<group>"; };
@@ -279,6 +289,7 @@
 				FFD6BDBF7A1FAEFC60A31509 /* Shell */,
 				6901B56E6449F5FCF4E986E7 /* TaxiSquad */,
 				3E62B7EC555EA6961ADE3151 /* Team */,
+				6C903B9D928F907691888954 /* TeamAnalyzer */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -351,6 +362,15 @@
 			path = TaxiSquad;
 			sourceTree = "<group>";
 		};
+		6C903B9D928F907691888954 /* TeamAnalyzer */ = {
+			isa = PBXGroup;
+			children = (
+				501B8FD2B915B3BD6568F42C /* HexagonChartView.swift */,
+				8098F78566BB324ACC70FB94 /* TeamAnalyzerView.swift */,
+			);
+			path = TeamAnalyzer;
+			sourceTree = "<group>";
+		};
 		6FCB5AB805D7BDEE3A200785 /* Config */ = {
 			isa = PBXGroup;
 			children = (
@@ -391,12 +411,14 @@
 				E1E5A60EE78F668F02CF63C0 /* NflState.swift */,
 				22A99CAA9B57C1A0144DCA22 /* Player.swift */,
 				67C24A12080AD428D5A40A7E /* PlayerSeasonStats.swift */,
+				BE87151F7F5AAB8F12F98B91 /* PlayerValue.swift */,
 				6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */,
 				42C8A3FA617E9FEB48852C45 /* Profile.swift */,
 				AE543CB2E49335ADD02E8000 /* Roster.swift */,
 				9B7C85CB880ABD7D373E49A6 /* RuleProposal.swift */,
 				B29D510D87CD290AE7F76FBF /* StandingsTeam.swift */,
 				A2DA1B65780757E6CC78CD61 /* TaxiSquadPlayer.swift */,
+				FC09DFF48D9AAFEF0A286BAD /* TeamAnalysis.swift */,
 				9F49969EE42BDE6462664021 /* TradedPick.swift */,
 				3747C6FC769C117588F8A93E /* WhitelistedLeague.swift */,
 				E969C4A894017F9D0072CCFA /* WorldCup.swift */,
@@ -464,6 +486,7 @@
 				56BB91320E3D5EBE1F777838 /* LeagueStore.swift */,
 				94E125AD2AA5212D0EB4C13A /* NflStateStore.swift */,
 				CC3F6B5022E8151683A45F4F /* PlayerStore.swift */,
+				5CE99E9B095120FB6636FC8A /* PlayerValuesStore.swift */,
 				5FDC8A9B02A2BFD83398D04F /* RulesStore.swift */,
 				E0C5F37100E6EBB467EBFE1C /* SearchStore.swift */,
 				D7F3F1A18F4EEC5A3F81FD28 /* SeasonStore.swift */,
@@ -657,6 +680,7 @@
 				556BA960B3DFFACAB2F3DFA6 /* EnvironmentValues+Season.swift in Sources */,
 				60FB3A9B54EAB11F015C1828 /* ErrorView.swift in Sources */,
 				EDDACB3FFB20E468D9D9D67D /* HeaderBar.swift in Sources */,
+				C21992E2FA476C65D8D23BA8 /* HexagonChartView.swift in Sources */,
 				063FCD6AA342CA5D64ED79ED /* HistoryStore.swift in Sources */,
 				114998283E6705D075ED2CA7 /* League.swift in Sources */,
 				CEC2B1D5D34F80BFB3444C6F /* LeagueOverviewView.swift in Sources */,
@@ -679,6 +703,8 @@
 				4DB9374CF45A69E97C02FC94 /* PlayerDetailView.swift in Sources */,
 				93D8C8E352B60752D37FD0FF /* PlayerSeasonStats.swift in Sources */,
 				FCD03562C1879183A5DC02E2 /* PlayerStore.swift in Sources */,
+				BE71F196BAB7D9E78BE94A9D /* PlayerValue.swift in Sources */,
+				B309CAE3F00F954918C09554 /* PlayerValuesStore.swift in Sources */,
 				F201A3A40D624F6AAA0C0CC1 /* PlayoffBracket.swift in Sources */,
 				CB47F51AA46AEBC59183C449 /* PlayoffBracketView.swift in Sources */,
 				6C89029D05AEE66FB2315616 /* Profile.swift in Sources */,
@@ -706,6 +732,8 @@
 				86412A35609319AF08D413D3 /* TaxiSquadStore.swift in Sources */,
 				08251EFB3181B634553CDCE1 /* TaxiSquadView.swift in Sources */,
 				D7A95C32621E03E2AAB37327 /* TaxiStealConfirmView.swift in Sources */,
+				B24D5DBDDF4C163FCAB52689 /* TeamAnalysis.swift in Sources */,
+				58FD67DB9B137F1A8BE50521 /* TeamAnalyzerView.swift in Sources */,
 				40C507B6FB2EF2A7E647AA3C /* TeamStore.swift in Sources */,
 				B7EB06298BFBF6AC76ABF53E /* TeamView.swift in Sources */,
 				57C17293587E8DBED9A14970 /* TradedPick.swift in Sources */,

--- a/Xomper/Core/Models/PlayerValue.swift
+++ b/Xomper/Core/Models/PlayerValue.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Dynasty-superflex value for a single player, sourced from
+/// FantasyCalc's public values API. We only model the fields we
+/// actually consume on iOS — the response carries dozens of fields
+/// per player; the lenient decoder ignores the rest.
+///
+/// Keyed by Sleeper player ID at the store level so it joins cleanly
+/// against `roster.players` / `starters` / `taxi` / `reserve`.
+struct PlayerValue: Codable, Sendable {
+    /// Sleeper player ID. Matches `Player.playerId`.
+    let sleeperId: String?
+    /// Dynasty value (0..~10000 — Josh Allen ≈ 10000 at peak).
+    let value: Int
+    /// Position the value was computed against (QB/RB/WR/TE).
+    let position: String?
+    /// Overall rank across all positions for the league format.
+    let overallRank: Int?
+    /// Position rank.
+    let positionRank: Int?
+    /// 30-day value trend (positive = rising).
+    let trend30Day: Int?
+
+    enum TopLevelKeys: String, CodingKey {
+        case player
+        case value
+        case overallRank
+        case positionRank
+        case trend30Day
+    }
+
+    enum PlayerKeys: String, CodingKey {
+        case sleeperId
+        case position
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: TopLevelKeys.self)
+        let player = try? c.nestedContainer(keyedBy: PlayerKeys.self, forKey: .player)
+        self.sleeperId = try? player?.decodeIfPresent(String.self, forKey: .sleeperId)
+        self.position = try? player?.decodeIfPresent(String.self, forKey: .position)
+        self.value = (try? c.decode(Int.self, forKey: .value)) ?? 0
+        self.overallRank = try? c.decodeIfPresent(Int.self, forKey: .overallRank)
+        self.positionRank = try? c.decodeIfPresent(Int.self, forKey: .positionRank)
+        self.trend30Day = try? c.decodeIfPresent(Int.self, forKey: .trend30Day)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        // Encoding is unused (we only decode from FantasyCalc) — provide
+        // a stub so Codable conformance is satisfied.
+        var c = encoder.container(keyedBy: TopLevelKeys.self)
+        try c.encode(value, forKey: .value)
+        try c.encodeIfPresent(overallRank, forKey: .overallRank)
+        try c.encodeIfPresent(positionRank, forKey: .positionRank)
+        try c.encodeIfPresent(trend30Day, forKey: .trend30Day)
+    }
+}

--- a/Xomper/Core/Models/TeamAnalysis.swift
+++ b/Xomper/Core/Models/TeamAnalysis.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+/// Per-team aggregate of dynasty value broken down by position group +
+/// roster slot. Drives the hexagon chart on TeamAnalyzerView.
+///
+/// Values are summed across the team's roster (starters + bench +
+/// taxi + reserve). Position is resolved via `Player.displayPosition`
+/// from the global `PlayerStore` — so accuracy depends on player
+/// data being loaded.
+struct TeamAnalysis: Sendable, Hashable {
+    let rosterId: Int
+    let teamName: String
+    let userId: String
+    let avatarId: String?
+
+    /// Sum of dynasty values per position group. Six axes for the
+    /// hexagon chart.
+    let qbValue: Int
+    let rbValue: Int
+    let wrValue: Int
+    let teValue: Int
+    /// Players on bench (not in starters / taxi / reserve).
+    let benchValue: Int
+    /// Players on taxi squad.
+    let taxiValue: Int
+
+    var totalValue: Int {
+        qbValue + rbValue + wrValue + teValue + benchValue + taxiValue
+    }
+
+    /// Returns the values in the canonical hexagon order so the chart
+    /// view can iterate without remembering keys.
+    var hexAxes: [HexAxis] {
+        [
+            HexAxis(label: "QB", value: qbValue),
+            HexAxis(label: "RB", value: rbValue),
+            HexAxis(label: "WR", value: wrValue),
+            HexAxis(label: "TE", value: teValue),
+            HexAxis(label: "Bench", value: benchValue),
+            HexAxis(label: "Taxi", value: taxiValue),
+        ]
+    }
+
+    struct HexAxis: Sendable, Hashable {
+        let label: String
+        let value: Int
+    }
+}
+
+@MainActor
+enum TeamAnalysisBuilder {
+
+    /// Builds analyses for every roster in the league. Players with
+    /// unknown positions or no value contribute zero — surfaced as a
+    /// "Uncategorized" warning on the view if the gap is large.
+    static func build(
+        rosters: [Roster],
+        users: [SleeperUser],
+        playerStore: PlayerStore,
+        valuesStore: PlayerValuesStore
+    ) -> [TeamAnalysis] {
+        let userById: [String: SleeperUser] = Dictionary(
+            uniqueKeysWithValues: users.compactMap { user -> (String, SleeperUser)? in
+                guard let uid = user.userId else { return nil }
+                return (uid, user)
+            }
+        )
+
+        return rosters.map { roster in
+            let starters = Set(roster.starters ?? [])
+            let taxi = Set(roster.taxi ?? [])
+            let reserve = Set(roster.reserve ?? [])
+            let allRostered = roster.players ?? []
+
+            var qb = 0, rb = 0, wr = 0, te = 0
+            var bench = 0, taxiSum = 0
+
+            for pid in allRostered {
+                let value = valuesStore.value(for: pid)
+                guard value > 0 else { continue }
+
+                if taxi.contains(pid) {
+                    taxiSum += value
+                    continue  // taxi never counts toward starter buckets
+                }
+
+                let pos = playerStore.player(for: pid)?.displayPosition
+                    ?? valuesStore.position(for: pid)
+                    ?? "?"
+
+                let onBench = !starters.contains(pid) && !reserve.contains(pid)
+
+                switch pos {
+                case "QB":
+                    if onBench { bench += value } else { qb += value }
+                case "RB":
+                    if onBench { bench += value } else { rb += value }
+                case "WR":
+                    if onBench { bench += value } else { wr += value }
+                case "TE":
+                    if onBench { bench += value } else { te += value }
+                default:
+                    // FLEX-eligible / unknown — treat as bench when
+                    // not in a fixed slot. Avoids polluting position
+                    // axes with mis-positioned values.
+                    bench += value
+                }
+            }
+
+            let owner = roster.ownerId.flatMap { userById[$0] }
+            let teamName = owner?.teamName
+                ?? owner?.resolvedDisplayName
+                ?? "Roster #\(roster.rosterId)"
+
+            return TeamAnalysis(
+                rosterId: roster.rosterId,
+                teamName: teamName,
+                userId: roster.ownerId ?? "",
+                avatarId: owner?.avatar,
+                qbValue: qb,
+                rbValue: rb,
+                wrValue: wr,
+                teValue: te,
+                benchValue: bench,
+                taxiValue: taxiSum
+            )
+        }
+    }
+
+    /// League-wide max per axis. The chart normalizes each team's
+    /// polygon vertices against these so the outer ring = "best in
+    /// league at this position" and a team's filled shape shows
+    /// relative strength at a glance.
+    static func axisMaxes(_ teams: [TeamAnalysis]) -> [String: Int] {
+        var max: [String: Int] = [
+            "QB": 0, "RB": 0, "WR": 0, "TE": 0, "Bench": 0, "Taxi": 0
+        ]
+        for team in teams {
+            for axis in team.hexAxes {
+                if axis.value > (max[axis.label] ?? 0) {
+                    max[axis.label] = axis.value
+                }
+            }
+        }
+        return max
+    }
+}

--- a/Xomper/Core/Stores/PlayerValuesStore.swift
+++ b/Xomper/Core/Stores/PlayerValuesStore.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Fetches + caches dynasty superflex player values from FantasyCalc.
+/// Single fetch per app session; ~458 players returned, ~50KB payload.
+/// No backend round-trip in v1 — direct API call.
+///
+/// Future: move behind the Xomper API gateway with daily-cron
+/// caching so we don't hit FantasyCalc per-user. For now this is
+/// fine for a 12-person league.
+@Observable
+@MainActor
+final class PlayerValuesStore {
+    /// Sleeper player ID → dynasty value. Empty until first load.
+    private(set) var valuesById: [String: Int] = [:]
+    private(set) var positionsById: [String: String] = [:]
+    private(set) var isLoading = false
+    private(set) var error: Error?
+    private(set) var lastLoadedAt: Date?
+
+    /// FantasyCalc query: dynasty, 2-QB (superflex), 12-team, full PPR.
+    /// Closest publicly-available proxy for our league's TE-premium
+    /// scoring; FantasyCalc doesn't expose a TE+ toggle in the URL but
+    /// the values track close enough for relative team comparison.
+    private let endpoint = URL(string: "https://api.fantasycalc.com/values/current?isDynasty=true&numQbs=2&numTeams=12&ppr=1")!
+
+    /// Fetch values from FantasyCalc unless they were loaded within
+    /// the last 12 hours (values move slowly in dynasty — daily refresh
+    /// is plenty). `forceRefresh` bypasses the freshness check.
+    func loadValues(forceRefresh: Bool = false) async {
+        guard !isLoading else { return }
+        if !forceRefresh,
+           let last = lastLoadedAt,
+           Date().timeIntervalSince(last) < 12 * 60 * 60,
+           !valuesById.isEmpty {
+            return
+        }
+
+        isLoading = true
+        defer { isLoading = false }
+        error = nil
+
+        do {
+            let (data, response) = try await URLSession.shared.data(from: endpoint)
+            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+                throw URLError(.badServerResponse)
+            }
+            let decoded = try JSONDecoder().decode([PlayerValue].self, from: data)
+
+            var byId: [String: Int] = [:]
+            var posById: [String: String] = [:]
+            byId.reserveCapacity(decoded.count)
+            posById.reserveCapacity(decoded.count)
+            for entry in decoded {
+                guard let sid = entry.sleeperId, !sid.isEmpty else { continue }
+                byId[sid] = entry.value
+                if let pos = entry.position { posById[sid] = pos }
+            }
+            self.valuesById = byId
+            self.positionsById = posById
+            self.lastLoadedAt = Date()
+        } catch {
+            self.error = error
+        }
+    }
+
+    func value(for playerId: String) -> Int {
+        valuesById[playerId] ?? 0
+    }
+
+    func position(for playerId: String) -> String? {
+        positionsById[playerId]
+    }
+
+    var hasValues: Bool {
+        !valuesById.isEmpty
+    }
+}

--- a/Xomper/Features/Shell/DrawerView.swift
+++ b/Xomper/Features/Shell/DrawerView.swift
@@ -30,7 +30,7 @@ struct DrawerView: View {
         ),
         TraySection(
             title: "Roster",
-            entries: [.myTeam, .taxiSquad]
+            entries: [.myTeam, .taxiSquad, .teamAnalyzer]
         ),
         TraySection(
             title: "Rules",

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -28,6 +28,7 @@ struct MainShell: View {
     @State private var navStore = NavigationStore()
     @State private var router = AppRouter()
     @State private var seasonStore = SeasonStore()
+    @State private var valuesStore = PlayerValuesStore()
 
     // MARK: - Body
 
@@ -175,6 +176,14 @@ struct MainShell: View {
                     playerStore: playerStore,
                     authStore: authStore,
                     taxiSquadStore: taxiSquadStore
+                )
+
+            case .teamAnalyzer:
+                TeamAnalyzerView(
+                    leagueStore: leagueStore,
+                    playerStore: playerStore,
+                    authStore: authStore,
+                    valuesStore: valuesStore
                 )
 
             case .rulebook:

--- a/Xomper/Features/Shell/TrayDestination.swift
+++ b/Xomper/Features/Shell/TrayDestination.swift
@@ -18,6 +18,7 @@ enum TrayDestination: Hashable {
     case worldCup
     case myTeam
     case taxiSquad
+    case teamAnalyzer
     case rulebook
     case scoring
     case leagueSettings
@@ -37,6 +38,7 @@ enum TrayDestination: Hashable {
         case .worldCup:       "World Cup"
         case .myTeam:         "My Team"
         case .taxiSquad:      "Taxi Squad"
+        case .teamAnalyzer:   "Team Analyzer"
         case .rulebook:       "Rulebook"
         case .scoring:        "Scoring"
         case .leagueSettings: "League Settings"
@@ -57,6 +59,7 @@ enum TrayDestination: Hashable {
         case .worldCup:       "globe.americas.fill"
         case .myTeam:         "person.crop.square.fill"
         case .taxiSquad:      "bus.fill"
+        case .teamAnalyzer:   "chart.dots.scatter"
         case .rulebook:       "book.fill"
         case .scoring:        "function"
         case .leagueSettings: "slider.horizontal.3"

--- a/Xomper/Features/TeamAnalyzer/HexagonChartView.swift
+++ b/Xomper/Features/TeamAnalyzer/HexagonChartView.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+/// Custom Path-based radar chart with 6 axes (QB / RB / WR / TE /
+/// Bench / Taxi). SwiftUI Charts (iOS 17) doesn't ship a polar chart
+/// type, so this is a Canvas-driven render. Two polygons can be drawn
+/// at once for opponent comparison; the second one overlays in a
+/// translucent contrasting color.
+struct HexagonChartView: View {
+    /// Primary team's per-axis values, in canonical order
+    /// (QB, RB, WR, TE, Bench, Taxi).
+    let primary: [TeamAnalysis.HexAxis]
+    /// Optional comparison team. When nil, only the primary polygon
+    /// renders.
+    let comparison: [TeamAnalysis.HexAxis]?
+    /// League-wide max per axis label, used to normalize each polygon
+    /// vertex against. Falls back to local max when an axis isn't in
+    /// the dictionary.
+    let axisMaxes: [String: Int]
+
+    /// Axis label color treatment.
+    private let primaryColor = XomperColors.championGold
+    private let comparisonColor = Color.cyan
+
+    var body: some View {
+        GeometryReader { geo in
+            let size = min(geo.size.width, geo.size.height)
+            let center = CGPoint(x: geo.size.width / 2, y: size / 2)
+            let radius = size / 2 * 0.78  // leave room for labels
+
+            ZStack {
+                gridPolygons(center: center, radius: radius)
+                axisLines(center: center, radius: radius)
+
+                if let comparison {
+                    polygon(
+                        for: comparison,
+                        center: center,
+                        radius: radius,
+                        color: comparisonColor
+                    )
+                }
+                polygon(
+                    for: primary,
+                    center: center,
+                    radius: radius,
+                    color: primaryColor
+                )
+
+                axisLabels(center: center, radius: radius)
+            }
+            .frame(width: geo.size.width, height: size)
+        }
+        .frame(maxWidth: .infinity, minHeight: 320)
+    }
+
+    // MARK: - Grid
+
+    private func gridPolygons(center: CGPoint, radius: CGFloat) -> some View {
+        Canvas { ctx, _ in
+            let levels: [CGFloat] = [0.25, 0.5, 0.75, 1.0]
+            for level in levels {
+                let path = hexPath(center: center, radius: radius * level)
+                ctx.stroke(
+                    path,
+                    with: .color(XomperColors.surfaceLight.opacity(0.35)),
+                    lineWidth: level == 1.0 ? 1.5 : 1.0
+                )
+            }
+        }
+    }
+
+    private func axisLines(center: CGPoint, radius: CGFloat) -> some View {
+        Canvas { ctx, _ in
+            for i in 0..<6 {
+                var path = Path()
+                path.move(to: center)
+                path.addLine(to: vertex(center: center, radius: radius, index: i))
+                ctx.stroke(
+                    path,
+                    with: .color(XomperColors.surfaceLight.opacity(0.25)),
+                    lineWidth: 1
+                )
+            }
+        }
+    }
+
+    // MARK: - Team polygon
+
+    private func polygon(
+        for axes: [TeamAnalysis.HexAxis],
+        center: CGPoint,
+        radius: CGFloat,
+        color: Color
+    ) -> some View {
+        let points: [CGPoint] = axes.enumerated().map { idx, axis in
+            let max = axisMaxes[axis.label] ?? axis.value
+            let normalized = max > 0 ? CGFloat(axis.value) / CGFloat(max) : 0
+            let r = radius * normalized
+            return vertex(center: center, radius: r, index: idx)
+        }
+        return Canvas { ctx, _ in
+            var path = Path()
+            for (i, p) in points.enumerated() {
+                if i == 0 { path.move(to: p) } else { path.addLine(to: p) }
+            }
+            path.closeSubpath()
+            ctx.fill(path, with: .color(color.opacity(0.28)))
+            ctx.stroke(path, with: .color(color), lineWidth: 2)
+
+            for p in points {
+                let dot = Path(ellipseIn: CGRect(x: p.x - 3, y: p.y - 3, width: 6, height: 6))
+                ctx.fill(dot, with: .color(color))
+            }
+        }
+    }
+
+    // MARK: - Labels
+
+    private func axisLabels(center: CGPoint, radius: CGFloat) -> some View {
+        ZStack {
+            ForEach(Array(primary.enumerated()), id: \.offset) { idx, axis in
+                let labelRadius = radius * 1.18
+                let p = vertex(center: center, radius: labelRadius, index: idx)
+                Text(axis.label)
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(XomperColors.textSecondary)
+                    .position(x: p.x, y: p.y)
+            }
+        }
+    }
+
+    // MARK: - Geometry helpers
+
+    /// Vertex i of a hexagon, starting from straight up (12 o'clock)
+    /// and rotating clockwise. -π/2 puts axis 0 at top.
+    private func vertex(center: CGPoint, radius: CGFloat, index: Int) -> CGPoint {
+        let angle = (CGFloat(index) * .pi / 3) - (.pi / 2)
+        return CGPoint(
+            x: center.x + radius * cos(angle),
+            y: center.y + radius * sin(angle)
+        )
+    }
+
+    private func hexPath(center: CGPoint, radius: CGFloat) -> Path {
+        var path = Path()
+        for i in 0..<6 {
+            let p = vertex(center: center, radius: radius, index: i)
+            if i == 0 { path.move(to: p) } else { path.addLine(to: p) }
+        }
+        path.closeSubpath()
+        return path
+    }
+}

--- a/Xomper/Features/TeamAnalyzer/TeamAnalyzerView.swift
+++ b/Xomper/Features/TeamAnalyzer/TeamAnalyzerView.swift
@@ -1,0 +1,254 @@
+import SwiftUI
+
+/// Hexagon-chart team analyzer. Shows the user's home-league team's
+/// dynasty value broken down by position group, optionally overlaid
+/// with another team in the league for side-by-side comparison.
+///
+/// Sources:
+/// - `PlayerValuesStore` — FantasyCalc dynasty superflex values
+/// - `LeagueStore.myLeagueRosters / myLeagueUsers` — anchored to home
+/// - `PlayerStore.player(for:)` — position resolution
+struct TeamAnalyzerView: View {
+    var leagueStore: LeagueStore
+    var playerStore: PlayerStore
+    var authStore: AuthStore
+    var valuesStore: PlayerValuesStore
+
+    @State private var comparisonRosterId: Int?
+
+    var body: some View {
+        Group {
+            if !valuesStore.hasValues && valuesStore.isLoading {
+                LoadingView(message: "Fetching player values...")
+            } else if let error = valuesStore.error, !valuesStore.hasValues {
+                ErrorView(message: error.localizedDescription) {
+                    Task { await valuesStore.loadValues(forceRefresh: true) }
+                }
+            } else if !valuesStore.hasValues {
+                EmptyStateView(
+                    icon: "chart.dots.scatter",
+                    title: "Values Not Loaded",
+                    message: "Pull to refresh to load dynasty values."
+                )
+            } else if leagueStore.myLeagueRosters.isEmpty {
+                LoadingView(message: "Loading league...")
+            } else {
+                content
+            }
+        }
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .task {
+            await valuesStore.loadValues()
+        }
+        .refreshable {
+            await valuesStore.loadValues(forceRefresh: true)
+        }
+    }
+
+    // MARK: - Content
+
+    private var content: some View {
+        let analyses = TeamAnalysisBuilder.build(
+            rosters: leagueStore.myLeagueRosters,
+            users: leagueStore.myLeagueUsers,
+            playerStore: playerStore,
+            valuesStore: valuesStore
+        )
+        let myAnalysis = primaryAnalysis(in: analyses)
+        let comparison = analyses.first { $0.rosterId == comparisonRosterId }
+        let axisMaxes = TeamAnalysisBuilder.axisMaxes(analyses)
+
+        return ScrollView {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.lg) {
+                if let myAnalysis {
+                    headerCard(my: myAnalysis, opp: comparison)
+                    HexagonChartView(
+                        primary: myAnalysis.hexAxes,
+                        comparison: comparison?.hexAxes,
+                        axisMaxes: axisMaxes
+                    )
+                    .padding(.horizontal, XomperTheme.Spacing.md)
+
+                    legend(my: myAnalysis, opp: comparison)
+                    breakdownGrid(my: myAnalysis, opp: comparison, maxes: axisMaxes)
+
+                    comparisonPicker(
+                        analyses: analyses,
+                        excludingRosterId: myAnalysis.rosterId
+                    )
+                } else {
+                    EmptyStateView(
+                        icon: "person.crop.square",
+                        title: "Team Not Found",
+                        message: "Could not resolve your team in this league."
+                    )
+                }
+            }
+            .padding(.bottom, XomperTheme.Spacing.xl)
+        }
+    }
+
+    private func primaryAnalysis(in analyses: [TeamAnalysis]) -> TeamAnalysis? {
+        guard let userId = authStore.sleeperUserId else { return analyses.first }
+        return analyses.first { $0.userId == userId } ?? analyses.first
+    }
+
+    // MARK: - Header
+
+    private func headerCard(my: TeamAnalysis, opp: TeamAnalysis?) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            Text("Team Analyzer")
+                .font(.title2.weight(.bold))
+                .foregroundStyle(XomperColors.textPrimary)
+
+            Text(opp == nil
+                ? "Your roster, valued by position group."
+                : "Comparing your team vs \(opp!.teamName)."
+            )
+            .font(.subheadline)
+            .foregroundStyle(XomperColors.textSecondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    // MARK: - Legend
+
+    private func legend(my: TeamAnalysis, opp: TeamAnalysis?) -> some View {
+        HStack(spacing: XomperTheme.Spacing.lg) {
+            legendChip(color: XomperColors.championGold, label: my.teamName)
+            if let opp {
+                legendChip(color: .cyan, label: opp.teamName)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    private func legendChip(color: Color, label: String) -> some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            Circle()
+                .fill(color)
+                .frame(width: 10, height: 10)
+            Text(label)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(XomperColors.textPrimary)
+                .lineLimit(1)
+        }
+    }
+
+    // MARK: - Breakdown grid
+
+    private func breakdownGrid(
+        my: TeamAnalysis,
+        opp: TeamAnalysis?,
+        maxes: [String: Int]
+    ) -> some View {
+        VStack(spacing: XomperTheme.Spacing.xs) {
+            ForEach(Array(my.hexAxes.enumerated()), id: \.offset) { idx, axis in
+                let oppValue = opp?.hexAxes[idx].value
+                breakdownRow(
+                    label: axis.label,
+                    myValue: axis.value,
+                    oppValue: oppValue,
+                    leagueMax: maxes[axis.label] ?? axis.value
+                )
+            }
+            Divider().background(XomperColors.surfaceLight.opacity(0.4))
+            HStack {
+                Text("Total roster value")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(XomperColors.textSecondary)
+                Spacer()
+                Text("\(my.totalValue)")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+                    .monospacedDigit()
+                if let opp {
+                    Text("vs \(opp.totalValue)")
+                        .font(.subheadline)
+                        .foregroundStyle(XomperColors.textSecondary)
+                        .monospacedDigit()
+                }
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    private func breakdownRow(label: String, myValue: Int, oppValue: Int?, leagueMax: Int) -> some View {
+        HStack(spacing: XomperTheme.Spacing.sm) {
+            Text(label)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(XomperColors.textPrimary)
+                .frame(width: 60, alignment: .leading)
+
+            ProgressView(
+                value: leagueMax > 0 ? Double(myValue) / Double(leagueMax) : 0
+            )
+            .tint(XomperColors.championGold)
+            .frame(maxWidth: .infinity)
+
+            Text("\(myValue)")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(XomperColors.textPrimary)
+                .monospacedDigit()
+                .frame(width: 50, alignment: .trailing)
+
+            if let oppValue {
+                Text("\(oppValue)")
+                    .font(.caption)
+                    .foregroundStyle(.cyan)
+                    .monospacedDigit()
+                    .frame(width: 50, alignment: .trailing)
+            }
+        }
+    }
+
+    // MARK: - Comparison picker
+
+    private func comparisonPicker(analyses: [TeamAnalysis], excludingRosterId: Int) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            Text("Compare against")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(XomperColors.textSecondary)
+                .padding(.horizontal, XomperTheme.Spacing.md)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: XomperTheme.Spacing.xs) {
+                    comparisonChip(label: "None", isSelected: comparisonRosterId == nil) {
+                        comparisonRosterId = nil
+                    }
+                    ForEach(analyses, id: \.rosterId) { team in
+                        if team.rosterId != excludingRosterId {
+                            comparisonChip(
+                                label: team.teamName,
+                                isSelected: comparisonRosterId == team.rosterId
+                            ) {
+                                comparisonRosterId = team.rosterId
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal, XomperTheme.Spacing.md)
+            }
+        }
+    }
+
+    private func comparisonChip(label: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(isSelected ? XomperColors.bgDark : XomperColors.textSecondary)
+                .lineLimit(1)
+                .padding(.horizontal, XomperTheme.Spacing.md)
+                .padding(.vertical, XomperTheme.Spacing.xs)
+                .background(isSelected ? Color.cyan : XomperColors.surfaceLight.opacity(0.4))
+                .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}


### PR DESCRIPTION
Implements #58. Visualizes dynasty roster strength by position group, with side-by-side comparison against any other team in the league.

## Data
- **FantasyCalc** dynasty-superflex values (~458 players) fetched once per session, 12-hour freshness. No backend round-trip in v1 — direct API call from the iOS app. Filed as a future cron-job in #58 if usage grows.
- Dynasty-superflex query: \`isDynasty=true&numQbs=2&numTeams=12&ppr=1\`. FantasyCalc doesn't expose a TE+ toggle; values track close enough for relative team comparison in this league format.

## UI
- **Hexagon chart** with 6 axes: QB / RB / WR / TE / Bench / Taxi. Custom Path/Canvas render (SwiftUI Charts has no polar chart in iOS 17). Concentric grid rings at 25/50/75/100%, your team filled in champion gold, opponent in cyan.
- **Per-axis breakdown** with progress bars normalized to league-best. Each row shows your value, opponent value, and your relative strength.
- **Comparison picker**: horizontal-scroll chip strip. Tap a team → overlay; "None" clears.
- **Total roster value** footer.

Position resolution prefers \`PlayerStore.displayPosition\`, falls back to FantasyCalc's position field. Players in taxi never count toward starter buckets.

## Tray destination
\`Roster → My Team / Taxi Squad / **Team Analyzer**\`

## Test plan
- [ ] Tray → Team Analyzer → loads, hexagon renders for your CLT roster
- [ ] Tap a comparison chip → opponent's polygon overlays in cyan
- [ ] Pull to refresh → re-fetches FantasyCalc values
- [ ] Build clean under Swift 6 strict concurrency

## Out of scope
- Backend caching for FantasyCalc (low priority for 12-team league)
- Live draft integration (separate epic, this is the foundation)