### PR TITLE
feat: payouts page — projected earnings with category breakdown

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		2F09FBAE23D8109C931D63A9 /* XomperTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBB5433786555EDDBC896C7 /* XomperTheme.swift */; };
 		2F50FD9BC26550139DAD2E96 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F510E2F428E107F1AD75CD /* Config.swift */; };
 		2F60B09D13BABD5E49B3DCBF /* MainShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A254D17EF062523E09C9D4 /* MainShell.swift */; };
+		31CFADD9ECC5AC0D09B24BCF /* PayoutsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3443191E5EED3E2888F8757 /* PayoutsView.swift */; };
 		366C0075FA9F4ABA1C88C1A9 /* Championship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18383A0375F5728A9E3FE065 /* Championship.swift */; };
 		368D96609CAF02430F340657 /* MatchupHistoryBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A3969B9E9E60F0C59D83C9 /* MatchupHistoryBrowserView.swift */; };
 		3B1DDBCA7B19B8703FAF717E /* DrawerScrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D921732971689E8096F9549 /* DrawerScrim.swift */; };
@@ -33,6 +34,7 @@
 		3E5A98150356BEB75FD87145 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = 72178EB48829A7D249085476 /* Supabase */; };
 		40C507B6FB2EF2A7E647AA3C /* TeamStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36A01820FD0F6643BBF8511D /* TeamStore.swift */; };
 		427F23653F78A52108C55692 /* XomperLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3B178733D5AF9EB7DA7189 /* XomperLoader.swift */; };
+		4A321187068EEBA8C4E75EFE /* PayoutProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E3BE36BCEA1A7722157C37 /* PayoutProjection.swift */; };
 		4B629DB100C96EB68A6A9A41 /* SearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323F422F2D0E1C2BA5D46C0A /* SearchResults.swift */; };
 		4DB9374CF45A69E97C02FC94 /* PlayerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC44D14381C74E97D8AF868F /* PlayerDetailView.swift */; };
 		4E0CAC9964BF3F2B59EDD844 /* DraftHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A789B8D49FA4430886626289 /* DraftHistory.swift */; };
@@ -64,6 +66,7 @@
 		817EEBDA82021E74A830E1B3 /* DrawerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3E9ADC138A5F405E59389C /* DrawerView.swift */; };
 		83E71E429B2F8B4B7AEBAB96 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD0F6820960B354EAB3E89D /* LoadingView.swift */; };
 		86412A35609319AF08D413D3 /* TaxiSquadStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6387E34B6FA70159F3F9D80A /* TaxiSquadStore.swift */; };
+		8C2ABA833D6AB1C5A3017BDA /* LeaguePayouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AC494E7D11CB94A2FD56EA /* LeaguePayouts.swift */; };
 		8C67D3AAFE5A0A124BDE5F1A /* AppRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EABD25CAB8BF973C4709720 /* AppRouter.swift */; };
 		8E8B3EC17A43676ACA176FC3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6F2D6E80C100927C4C20FAD7 /* Assets.xcassets */; };
 		901F54CB41785D269CC63160 /* WorldCupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E1C6D5A18697DE79586C1B /* WorldCupStore.swift */; };
@@ -137,6 +140,7 @@
 		42C8A3FA617E9FEB48852C45 /* Profile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
 		42F46A0AAE61A4E963BB15B0 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		43685B0C212A644C0EF202E5 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		43AC494E7D11CB94A2FD56EA /* LeaguePayouts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaguePayouts.swift; sourceTree = "<group>"; };
 		43E1C6D5A18697DE79586C1B /* WorldCupStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupStore.swift; sourceTree = "<group>"; };
 		44F83A5F997AF6E13C98660E /* WorldCupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupView.swift; sourceTree = "<group>"; };
 		45B52D5FD69B62417928B713 /* MatchupHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupHistory.swift; sourceTree = "<group>"; };
@@ -207,6 +211,7 @@
 		E6A47FD1CF3BE7AE0B940DEC /* StandingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsView.swift; sourceTree = "<group>"; };
 		E70E04168BDBA7D3372BB605 /* TrayDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayDestination.swift; sourceTree = "<group>"; };
 		E767CD5492176E84C2092B0F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		E7E3BE36BCEA1A7722157C37 /* PayoutProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayoutProjection.swift; sourceTree = "<group>"; };
 		E7F510E2F428E107F1AD75CD /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		E969C4A894017F9D0072CCFA /* WorldCup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCup.swift; sourceTree = "<group>"; };
 		ECC70812B3E7E07BA6658A54 /* AvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
@@ -214,6 +219,7 @@
 		F013CD37874EFB0FA1CB4261 /* HistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryStore.swift; sourceTree = "<group>"; };
 		F1E7D0FD804723AC6A3E4298 /* HeaderBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderBar.swift; sourceTree = "<group>"; };
 		F2452A5AEC270BE14CC085E1 /* URL+Sleeper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Sleeper.swift"; sourceTree = "<group>"; };
+		F3443191E5EED3E2888F8757 /* PayoutsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayoutsView.swift; sourceTree = "<group>"; };
 		F4A254D17EF062523E09C9D4 /* MainShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainShell.swift; sourceTree = "<group>"; };
 		F51CC9357B13AB7ADD9C8586 /* TeamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamView.swift; sourceTree = "<group>"; };
 		F6F606D0624D23D47A171D26 /* SearchResultGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultGroup.swift; sourceTree = "<group>"; };
@@ -284,6 +290,7 @@
 				7DEC053904198785F4461D4A /* Home */,
 				47014533E72495E9E9DC8F74 /* League */,
 				2D1CA584D084FE022DC6401D /* MatchupHistory */,
+				374AF06666E690518BB92FAE /* Payouts */,
 				18DB797ECD581E0649842AFC /* Profile */,
 				CF0EB2B68A2AB44A16E88FB9 /* Shared */,
 				FFD6BDBF7A1FAEFC60A31509 /* Shell */,
@@ -301,6 +308,14 @@
 				DF491605034E9F8C00BC0572 /* MatchupHistoryView.swift */,
 			);
 			path = MatchupHistory;
+			sourceTree = "<group>";
+		};
+		374AF06666E690518BB92FAE /* Payouts */ = {
+			isa = PBXGroup;
+			children = (
+				F3443191E5EED3E2888F8757 /* PayoutsView.swift */,
+			);
+			path = Payouts;
 			sourceTree = "<group>";
 		};
 		390D24DCB17100460C0E682A /* Auth */ = {
@@ -406,9 +421,11 @@
 				7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */,
 				A789B8D49FA4430886626289 /* DraftHistory.swift */,
 				FD88B55D96BD7C519B6B65B6 /* League.swift */,
+				43AC494E7D11CB94A2FD56EA /* LeaguePayouts.swift */,
 				C83EF3C6C93199CF3FCBAE42 /* Matchup.swift */,
 				45B52D5FD69B62417928B713 /* MatchupHistory.swift */,
 				E1E5A60EE78F668F02CF63C0 /* NflState.swift */,
+				E7E3BE36BCEA1A7722157C37 /* PayoutProjection.swift */,
 				22A99CAA9B57C1A0144DCA22 /* Player.swift */,
 				67C24A12080AD428D5A40A7E /* PlayerSeasonStats.swift */,
 				BE87151F7F5AAB8F12F98B91 /* PlayerValue.swift */,
@@ -684,6 +701,7 @@
 				063FCD6AA342CA5D64ED79ED /* HistoryStore.swift in Sources */,
 				114998283E6705D075ED2CA7 /* League.swift in Sources */,
 				CEC2B1D5D34F80BFB3444C6F /* LeagueOverviewView.swift in Sources */,
+				8C2ABA833D6AB1C5A3017BDA /* LeaguePayouts.swift in Sources */,
 				724482308D102AFA35AB4017 /* LeagueStore.swift in Sources */,
 				83E71E429B2F8B4B7AEBAB96 /* LoadingView.swift in Sources */,
 				A4D93DF4C02A8DE6C695CE4D /* LoginView.swift in Sources */,
@@ -699,6 +717,8 @@
 				021A039E220940CD2E12304A /* NavigationStore.swift in Sources */,
 				7E34464209AAF9EC6801191A /* NflState.swift in Sources */,
 				CF4CEF4E2FE7A891950A2E17 /* NflStateStore.swift in Sources */,
+				4A321187068EEBA8C4E75EFE /* PayoutProjection.swift in Sources */,
+				31CFADD9ECC5AC0D09B24BCF /* PayoutsView.swift in Sources */,
 				C9D656F4702A3483BB8E970C /* Player.swift in Sources */,
 				4DB9374CF45A69E97C02FC94 /* PlayerDetailView.swift in Sources */,
 				93D8C8E352B60752D37FD0FF /* PlayerSeasonStats.swift in Sources */,

--- a/Xomper/Core/Models/LeaguePayouts.swift
+++ b/Xomper/Core/Models/LeaguePayouts.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// Configurable payout / side-pot structure for a league. Drives the
+/// PayoutsView projection. Hardcoded defaults live in
+/// `LeaguePayouts.charlotteDynastyDefault`; future iteration moves
+/// this into Supabase (`league_payouts` table).
+struct LeaguePayouts: Sendable {
+    let categories: [LeaguePayoutCategory]
+
+    /// Sum of all season-long category amounts (for "if I win every
+    /// pot, I make $X" comparisons).
+    var totalUpside: Double {
+        categories.map(\.maxAmount).reduce(0, +)
+    }
+
+    static let charlotteDynastyDefault = LeaguePayouts(categories: [
+        LeaguePayoutCategory(
+            id: "champion",
+            label: "Champion",
+            kind: .champion,
+            amount: 750
+        ),
+        LeaguePayoutCategory(
+            id: "runner_up",
+            label: "Runner-Up",
+            kind: .runnerUp,
+            amount: 250
+        ),
+        LeaguePayoutCategory(
+            id: "third_place",
+            label: "3rd Place",
+            kind: .thirdPlace,
+            amount: 100
+        ),
+        LeaguePayoutCategory(
+            id: "season_high_pf",
+            label: "Highest Season Points",
+            kind: .seasonHighPF,
+            amount: 100
+        ),
+        LeaguePayoutCategory(
+            id: "weekly_high",
+            label: "Weekly High Scorer",
+            kind: .weeklyHighScore,
+            amount: 25  // per week won
+        ),
+        // Position MVPs — scaffolded but not yet computed. Need per-
+        // player weekly points from /league/{id}/matchups/{week}; will
+        // light up when PlayerPointsStore + aggregation lands.
+        LeaguePayoutCategory(
+            id: "qb_mvp",
+            label: "QB MVP",
+            kind: .positionMVP("QB"),
+            amount: 50
+        ),
+        LeaguePayoutCategory(
+            id: "rb_mvp",
+            label: "RB MVP",
+            kind: .positionMVP("RB"),
+            amount: 50
+        ),
+        LeaguePayoutCategory(
+            id: "wr_mvp",
+            label: "WR MVP",
+            kind: .positionMVP("WR"),
+            amount: 50
+        ),
+        LeaguePayoutCategory(
+            id: "te_mvp",
+            label: "TE MVP",
+            kind: .positionMVP("TE"),
+            amount: 50
+        ),
+    ])
+}
+
+struct LeaguePayoutCategory: Sendable, Identifiable, Hashable {
+    let id: String
+    let label: String
+    let kind: Kind
+    /// Dollar amount paid out for this category. For weekly-high this
+    /// is the per-week payout; multiply by weeks-won to get total.
+    let amount: Double
+
+    enum Kind: Sendable, Hashable {
+        case champion
+        case runnerUp
+        case thirdPlace
+        case seasonHighPF
+        /// Per-week winner; tally weeks won × amount.
+        case weeklyHighScore
+        /// Top-scoring player at the given position across the regular
+        /// season. Needs per-week player_points aggregation; v1 leaves
+        /// this as "coming soon" pending PlayerPointsStore.
+        case positionMVP(String)
+    }
+
+    /// Maximum the category could ever pay out for one manager. For
+    /// per-week categories assumes a 14-week regular season.
+    var maxAmount: Double {
+        switch kind {
+        case .weeklyHighScore: amount * 14
+        default: amount
+        }
+    }
+}

--- a/Xomper/Core/Models/PayoutProjection.swift
+++ b/Xomper/Core/Models/PayoutProjection.swift
@@ -1,0 +1,272 @@
+import Foundation
+
+/// Per-category projection: who's currently leading, how the signed-in
+/// user stands, and the dollar amount on the line. Built fresh on
+/// each PayoutsView render via `PayoutCalculator`.
+struct PayoutProjection: Sendable, Identifiable {
+    let category: LeaguePayoutCategory
+    let leader: LeaderRef?
+    let userPlacement: UserPlacement
+    /// Dollar amount the signed-in user is currently projected to win
+    /// in this category. Zero if not leading (single-winner pots) or
+    /// if the user has no qualifying weeks (weekly high).
+    let projectedAmount: Double
+    /// Optional ranked list — drives the drill-down screen later. Nil
+    /// when the category data isn't available (e.g. position MVP
+    /// before PlayerPointsStore lands).
+    let standings: [StandingsRow]?
+    /// User-visible reason this category is unresolved or unavailable.
+    let unavailableReason: String?
+
+    var id: String { category.id }
+
+    struct LeaderRef: Sendable, Hashable {
+        let userId: String
+        let teamName: String
+        let displayValue: String
+    }
+
+    struct StandingsRow: Sendable, Identifiable, Hashable {
+        let userId: String
+        let teamName: String
+        let value: Double
+        let displayValue: String
+        var id: String { userId }
+    }
+
+    enum UserPlacement: Sendable, Hashable {
+        case leading
+        case tied(otherCount: Int)
+        case behind(by: String)
+        case won(amount: Double)  // category settled
+        case notApplicable
+        case pending
+    }
+}
+
+@MainActor
+enum PayoutCalculator {
+
+    /// Builds projections for every configured category. Pure
+    /// derivation from the existing stores — no network. Categories
+    /// the data doesn't support (position MVPs without per-player
+    /// scoring) come back with `unavailableReason` set.
+    static func project(
+        payouts: LeaguePayouts,
+        standings: [StandingsTeam],
+        matchupHistory: [MatchupHistoryRecord],
+        winnersBracket: [PlayoffBracketMatch]?,
+        userId: String?
+    ) -> [PayoutProjection] {
+        payouts.categories.map { category in
+            switch category.kind {
+            case .champion:
+                bracketPlacement(category: category, placement: 1, winnersBracket: winnersBracket, standings: standings, userId: userId)
+            case .runnerUp:
+                bracketPlacement(category: category, placement: 2, winnersBracket: winnersBracket, standings: standings, userId: userId)
+            case .thirdPlace:
+                bracketPlacement(category: category, placement: 3, winnersBracket: winnersBracket, standings: standings, userId: userId)
+            case .seasonHighPF:
+                seasonHighPF(category: category, standings: standings, userId: userId)
+            case .weeklyHighScore:
+                weeklyHigh(category: category, matchupHistory: matchupHistory, standings: standings, userId: userId)
+            case .positionMVP(let pos):
+                PayoutProjection(
+                    category: category,
+                    leader: nil,
+                    userPlacement: .pending,
+                    projectedAmount: 0,
+                    standings: nil,
+                    unavailableReason: "Per-player weekly scoring not yet wired (\(pos) MVP)."
+                )
+            }
+        }
+    }
+
+    // MARK: - Champion / runner-up / 3rd
+
+    private static func bracketPlacement(
+        category: LeaguePayoutCategory,
+        placement: Int,
+        winnersBracket: [PlayoffBracketMatch]?,
+        standings: [StandingsTeam],
+        userId: String?
+    ) -> PayoutProjection {
+        guard let bracket = winnersBracket,
+              let placementMatch = bracket.first(where: { $0.placement == placement }) else {
+            return PayoutProjection(
+                category: category,
+                leader: nil,
+                userPlacement: .pending,
+                projectedAmount: 0,
+                standings: nil,
+                unavailableReason: "Bracket not yet decided."
+            )
+        }
+
+        let winnerRosterId: Int? = {
+            switch placement {
+            case 1, 3: return placementMatch.winnerRosterId
+            case 2:    return placementMatch.team1RosterId == placementMatch.winnerRosterId
+                              ? placementMatch.team2RosterId
+                              : placementMatch.team1RosterId
+            default: return nil
+            }
+        }()
+
+        guard let rid = winnerRosterId,
+              let team = standings.first(where: { $0.rosterId == rid }) else {
+            return PayoutProjection(
+                category: category,
+                leader: nil,
+                userPlacement: .pending,
+                projectedAmount: 0,
+                standings: nil,
+                unavailableReason: "Bracket placement match still in progress."
+            )
+        }
+
+        let isMine = team.userId == userId
+        return PayoutProjection(
+            category: category,
+            leader: .init(userId: team.userId, teamName: team.teamName, displayValue: ""),
+            userPlacement: isMine ? .won(amount: category.amount) : .behind(by: ""),
+            projectedAmount: isMine ? category.amount : 0,
+            standings: nil,
+            unavailableReason: nil
+        )
+    }
+
+    // MARK: - Season high PF
+
+    private static func seasonHighPF(
+        category: LeaguePayoutCategory,
+        standings: [StandingsTeam],
+        userId: String?
+    ) -> PayoutProjection {
+        let sorted = standings.sorted(by: { $0.fpts > $1.fpts })
+        guard let top = sorted.first else {
+            return PayoutProjection(
+                category: category,
+                leader: nil,
+                userPlacement: .pending,
+                projectedAmount: 0,
+                standings: [],
+                unavailableReason: nil
+            )
+        }
+
+        let rows = sorted.map { team in
+            PayoutProjection.StandingsRow(
+                userId: team.userId,
+                teamName: team.teamName,
+                value: team.fpts,
+                displayValue: String(format: "%.1f", team.fpts)
+            )
+        }
+
+        let mine = sorted.first { $0.userId == userId }
+        let placement: PayoutProjection.UserPlacement = {
+            guard let mine else { return .notApplicable }
+            if mine.userId == top.userId {
+                let secondPlace = sorted.dropFirst().first
+                let lead = (secondPlace?.fpts).map { mine.fpts - $0 } ?? 0
+                return lead < 0.05 ? .tied(otherCount: 1) : .leading
+            }
+            let gap = top.fpts - mine.fpts
+            return .behind(by: String(format: "%.1f pts", gap))
+        }()
+
+        let isLeading = mine?.userId == top.userId
+        return PayoutProjection(
+            category: category,
+            leader: .init(
+                userId: top.userId,
+                teamName: top.teamName,
+                displayValue: String(format: "%.1f PF", top.fpts)
+            ),
+            userPlacement: placement,
+            projectedAmount: isLeading ? category.amount : 0,
+            standings: rows,
+            unavailableReason: nil
+        )
+    }
+
+    // MARK: - Weekly high
+
+    private static func weeklyHigh(
+        category: LeaguePayoutCategory,
+        matchupHistory: [MatchupHistoryRecord],
+        standings: [StandingsTeam],
+        userId: String?
+    ) -> PayoutProjection {
+        // Only count regular-season weeks (isPlayoff == false) and
+        // skip preseason/empty-score weeks.
+        let regular = matchupHistory.filter { !$0.isPlayoff && ($0.teamAPoints > 0 || $0.teamBPoints > 0) }
+        var byWeek: [Int: [MatchupHistoryRecord]] = [:]
+        for record in regular {
+            byWeek[record.week, default: []].append(record)
+        }
+
+        var weeksWonByUser: [String: Int] = [:]
+        for (_, records) in byWeek {
+            // For each week, find the single highest score across all
+            // teams (counting both sides of every matchup).
+            var bestUser: String?
+            var bestPts: Double = 0
+            var ties = 0
+            for record in records {
+                if record.teamAPoints > bestPts {
+                    bestPts = record.teamAPoints
+                    bestUser = record.teamAUserId
+                    ties = 0
+                } else if abs(record.teamAPoints - bestPts) < 0.05 {
+                    ties += 1
+                }
+                if record.teamBPoints > bestPts {
+                    bestPts = record.teamBPoints
+                    bestUser = record.teamBUserId
+                    ties = 0
+                } else if abs(record.teamBPoints - bestPts) < 0.05 {
+                    ties += 1
+                }
+            }
+            // Skip ties — no single winner for the week
+            if let bestUser, ties == 0 {
+                weeksWonByUser[bestUser, default: 0] += 1
+            }
+        }
+
+        let rows = standings.map { team in
+            PayoutProjection.StandingsRow(
+                userId: team.userId,
+                teamName: team.teamName,
+                value: Double(weeksWonByUser[team.userId] ?? 0),
+                displayValue: "\(weeksWonByUser[team.userId] ?? 0) wks"
+            )
+        }
+        .sorted(by: { $0.value > $1.value })
+
+        let mineWeeks = userId.flatMap { weeksWonByUser[$0] } ?? 0
+        let topWeeks = rows.first?.value ?? 0
+        let leaderRow = rows.first
+
+        let placement: PayoutProjection.UserPlacement = {
+            guard userId != nil else { return .notApplicable }
+            if mineWeeks == 0 { return .behind(by: "0 wks") }
+            if Double(mineWeeks) == topWeeks { return .leading }
+            return .behind(by: "\(Int(topWeeks) - mineWeeks) wks")
+        }()
+
+        return PayoutProjection(
+            category: category,
+            leader: leaderRow.map { .init(userId: $0.userId, teamName: $0.teamName, displayValue: $0.displayValue) },
+            userPlacement: placement,
+            // Each weekly win pays the per-week amount, regardless of
+            // overall standing — running tally for the user.
+            projectedAmount: Double(mineWeeks) * category.amount,
+            standings: rows,
+            unavailableReason: nil
+        )
+    }
+}

--- a/Xomper/Features/Payouts/PayoutsView.swift
+++ b/Xomper/Features/Payouts/PayoutsView.swift
@@ -1,0 +1,292 @@
+import SwiftUI
+
+/// Projects the signed-in user's current payout total based on the
+/// hardcoded `LeaguePayouts.charlotteDynastyDefault` structure +
+/// derived stats (champion bracket, season-high PF, weekly-high tally).
+/// Categories that need data we don't yet aggregate (position MVPs)
+/// render as "Coming soon" rows so the structure is visible.
+struct PayoutsView: View {
+    var leagueStore: LeagueStore
+    var historyStore: HistoryStore
+    var authStore: AuthStore
+
+    private let payouts: LeaguePayouts = .charlotteDynastyDefault
+
+    @State private var selectedDrillDown: PayoutProjection?
+
+    var body: some View {
+        Group {
+            if leagueStore.myLeagueRosters.isEmpty {
+                LoadingView(message: "Loading league...")
+            } else {
+                content
+            }
+        }
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .task(id: leagueStore.myLeague?.leagueId) {
+            await ensureLoaded()
+        }
+        .refreshable {
+            await reload()
+        }
+        .sheet(item: $selectedDrillDown) { projection in
+            NavigationStack {
+                PayoutDrillDownView(projection: projection, userId: authStore.sleeperUserId)
+            }
+            .presentationDetents([.medium, .large])
+        }
+    }
+
+    // MARK: - Content
+
+    private var content: some View {
+        let standings = computedStandings
+        let projections = PayoutCalculator.project(
+            payouts: payouts,
+            standings: standings,
+            matchupHistory: historyStore.matchupHistory,
+            winnersBracket: leagueStore.winnersBracket,
+            userId: authStore.sleeperUserId
+        )
+        let projected = projections.map(\.projectedAmount).reduce(0, +)
+        let upside = payouts.totalUpside
+
+        return ScrollView {
+            VStack(spacing: XomperTheme.Spacing.md) {
+                summaryCard(projected: projected, upside: upside)
+
+                ForEach(projections) { projection in
+                    Button {
+                        if projection.standings != nil {
+                            selectedDrillDown = projection
+                        }
+                    } label: {
+                        projectionRow(projection)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(projection.standings == nil)
+                }
+            }
+            .padding(.horizontal, XomperTheme.Spacing.md)
+            .padding(.vertical, XomperTheme.Spacing.sm)
+        }
+    }
+
+    // MARK: - Summary card
+
+    private func summaryCard(projected: Double, upside: Double) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            Text("Projected payout")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(XomperColors.textMuted)
+                .textCase(.uppercase)
+                .tracking(0.5)
+
+            Text(currency(projected))
+                .font(.system(size: 44, weight: .bold, design: .rounded))
+                .foregroundStyle(XomperColors.championGold)
+                .monospacedDigit()
+
+            Text("Max possible: \(currency(upside))")
+                .font(.caption)
+                .foregroundStyle(XomperColors.textSecondary)
+
+            Text("Based on current league data + the hardcoded payout structure. Tap any settled category for the full breakdown.")
+                .font(.caption2)
+                .foregroundStyle(XomperColors.textMuted)
+                .padding(.top, XomperTheme.Spacing.xs)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.4), lineWidth: 1)
+        )
+    }
+
+    // MARK: - Projection row
+
+    private func projectionRow(_ projection: PayoutProjection) -> some View {
+        HStack(spacing: XomperTheme.Spacing.md) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(projection.category.label)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(XomperColors.textPrimary)
+
+                if let reason = projection.unavailableReason {
+                    Text(reason)
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .lineLimit(2)
+                } else if let leader = projection.leader {
+                    Text("Leader: \(leader.teamName)\(leader.displayValue.isEmpty ? "" : " · \(leader.displayValue)")")
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textSecondary)
+                        .lineLimit(1)
+                }
+
+                placementBadge(projection)
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 4) {
+                Text(currency(projection.projectedAmount))
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(projection.projectedAmount > 0 ? XomperColors.championGold : XomperColors.textMuted)
+                    .monospacedDigit()
+
+                Text("of \(currency(projection.category.maxAmount))")
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.textMuted)
+
+                if projection.standings != nil {
+                    Image(systemName: "chevron.right")
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                }
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .opacity(projection.unavailableReason == nil ? 1.0 : 0.65)
+    }
+
+    @ViewBuilder
+    private func placementBadge(_ projection: PayoutProjection) -> some View {
+        switch projection.userPlacement {
+        case .leading:
+            badge("Leading", fg: XomperColors.bgDark, bg: XomperColors.championGold)
+        case .tied(let other):
+            badge("Tied with \(other)", fg: XomperColors.bgDark, bg: XomperColors.successGreen)
+        case .behind(let by):
+            if by.isEmpty {
+                badge("Behind", fg: XomperColors.textSecondary, bg: XomperColors.surfaceLight.opacity(0.4))
+            } else {
+                badge("Behind by \(by)", fg: XomperColors.textSecondary, bg: XomperColors.surfaceLight.opacity(0.4))
+            }
+        case .won:
+            badge("Won", fg: XomperColors.bgDark, bg: XomperColors.successGreen)
+        case .pending:
+            badge("Pending", fg: XomperColors.textMuted, bg: XomperColors.surfaceLight.opacity(0.3))
+        case .notApplicable:
+            EmptyView()
+        }
+    }
+
+    private func badge(_ text: String, fg: Color, bg: Color) -> some View {
+        Text(text)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(fg)
+            .padding(.horizontal, XomperTheme.Spacing.sm)
+            .padding(.vertical, 2)
+            .background(bg)
+            .clipShape(Capsule())
+    }
+
+    // MARK: - Data
+
+    private var computedStandings: [StandingsTeam] {
+        guard let league = leagueStore.myLeague else { return [] }
+        return StandingsBuilder.buildStandings(
+            rosters: leagueStore.myLeagueRosters,
+            users: leagueStore.myLeagueUsers,
+            league: league
+        )
+    }
+
+    private func ensureLoaded() async {
+        if leagueStore.leagueChain.isEmpty,
+           let leagueId = leagueStore.myLeague?.leagueId {
+            await leagueStore.loadLeagueChain(startingFrom: leagueId)
+        }
+        if historyStore.matchupHistory.isEmpty, !leagueStore.leagueChain.isEmpty {
+            await historyStore.loadMatchupHistory(chain: leagueStore.leagueChain)
+        }
+        if leagueStore.winnersBracket == nil,
+           let leagueId = leagueStore.myLeague?.leagueId {
+            await leagueStore.fetchBrackets(leagueId: leagueId)
+        }
+    }
+
+    private func reload() async {
+        historyStore.reset()
+        await ensureLoaded()
+    }
+
+    private func currency(_ amount: Double) -> String {
+        if amount.truncatingRemainder(dividingBy: 1) == 0 {
+            return "$\(Int(amount))"
+        }
+        return String(format: "$%.0f", amount)
+    }
+}
+
+// MARK: - Drill-down
+
+private struct PayoutDrillDownView: View {
+    let projection: PayoutProjection
+    let userId: String?
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
+                Text(projection.category.label)
+                    .font(.title2.weight(.bold))
+                    .foregroundStyle(XomperColors.textPrimary)
+
+                if let standings = projection.standings, !standings.isEmpty {
+                    ForEach(Array(standings.enumerated()), id: \.offset) { idx, row in
+                        drillRow(rank: idx + 1, row: row)
+                    }
+                } else {
+                    Text("No data yet.")
+                        .font(.subheadline)
+                        .foregroundStyle(XomperColors.textMuted)
+                }
+            }
+            .padding(XomperTheme.Spacing.md)
+        }
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .navigationTitle(projection.category.label)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Close") { dismiss() }
+                    .foregroundStyle(XomperColors.championGold)
+            }
+        }
+    }
+
+    private func drillRow(rank: Int, row: PayoutProjection.StandingsRow) -> some View {
+        let isMine = row.userId == userId
+        return HStack {
+            Text("\(rank)")
+                .font(.subheadline.weight(.bold))
+                .foregroundStyle(rank == 1 ? XomperColors.championGold : XomperColors.textMuted)
+                .frame(width: 24, alignment: .leading)
+
+            Text(row.teamName)
+                .font(.subheadline.weight(isMine ? .bold : .regular))
+                .foregroundStyle(isMine ? XomperColors.championGold : XomperColors.textPrimary)
+                .lineLimit(1)
+
+            Spacer()
+
+            Text(row.displayValue)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(XomperColors.textPrimary)
+                .monospacedDigit()
+        }
+        .padding(.horizontal, XomperTheme.Spacing.md)
+        .padding(.vertical, XomperTheme.Spacing.sm)
+        .background(isMine ? XomperColors.championGold.opacity(0.12) : XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+    }
+}

--- a/Xomper/Features/Shell/DrawerView.swift
+++ b/Xomper/Features/Shell/DrawerView.swift
@@ -33,8 +33,8 @@ struct DrawerView: View {
             entries: [.myTeam, .taxiSquad, .teamAnalyzer]
         ),
         TraySection(
-            title: "Rules",
-            entries: [.rulebook, .scoring, .leagueSettings, .ruleProposals]
+            title: "League",
+            entries: [.payouts, .rulebook, .scoring, .leagueSettings, .ruleProposals]
         ),
     ]
 

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -186,6 +186,13 @@ struct MainShell: View {
                     valuesStore: valuesStore
                 )
 
+            case .payouts:
+                PayoutsView(
+                    leagueStore: leagueStore,
+                    historyStore: historyStore,
+                    authStore: authStore
+                )
+
             case .rulebook:
                 rulesPage(.rulebook)
 

--- a/Xomper/Features/Shell/TrayDestination.swift
+++ b/Xomper/Features/Shell/TrayDestination.swift
@@ -23,6 +23,7 @@ enum TrayDestination: Hashable {
     case scoring
     case leagueSettings
     case ruleProposals
+    case payouts
     case profile
     case settings
 
@@ -43,6 +44,7 @@ enum TrayDestination: Hashable {
         case .scoring:        "Scoring"
         case .leagueSettings: "League Settings"
         case .ruleProposals:  "Rule Proposals"
+        case .payouts:        "Payouts"
         case .profile:        "Profile"
         case .settings:       "Settings"
         }
@@ -64,6 +66,7 @@ enum TrayDestination: Hashable {
         case .scoring:        "function"
         case .leagueSettings: "slider.horizontal.3"
         case .ruleProposals:  "checkmark.bubble.fill"
+        case .payouts:        "dollarsign.circle.fill"
         case .profile:        "person.crop.circle.fill"
         case .settings:       "gearshape.fill"
         }


### PR DESCRIPTION
Implements #56 v1.

## What you'll see
New tray entry **League → Payouts** showing:

- Big champion-gold **Projected payout** total at the top + max possible
- Per-category cards (Champion, Runner-Up, 3rd Place, Highest Season Points, Weekly High Scorer, position MVPs)
- Each card: leader + placement badge (Leading / Tied / Behind by N / Won / Pending) + projected \$
- Tap any settled category → modal with full standings ranked, your row highlighted in gold

## What computes
- **Champion/Runner-Up/3rd Place** — from \`PlayoffBracketMatch.placement\` once bracket settles
- **Highest Season Points** — from \`standings.fpts\`
- **Weekly High Scorer** — tallies your wins across regular-season weeks (excluding ties), running total = wins × per-week amount

## What's scaffolded but pending
- **Position MVPs (QB / RB / WR / TE)** — need per-player weekly points from \`/league/{id}/matchups/{week}\`. Currently render as "Coming soon" rows with disabled tap. v2 PR adds the aggregation.

## Configuring your league's payouts
Edit \`LeaguePayouts.charlotteDynastyDefault\` in \`LeaguePayouts.swift\` to match your real dollar amounts. v3 moves this to a Supabase \`league_payouts\` table.

## Test plan
- [ ] Drawer → League → Payouts loads
- [ ] Header shows projected \$ + max possible
- [ ] Each category card renders with correct leader + your placement
- [ ] Tap a settled category → standings sheet, your row highlighted
- [ ] Pull-to-refresh recomputes
- [ ] Build clean under Swift 6 strict concurrency