### PR TITLE
feat: position MVP payouts (started-only points)

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		08251EFB3181B634553CDCE1 /* TaxiSquadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57940AEB84889A20016648F2 /* TaxiSquadView.swift */; };
 		0C2B77E0A46ECE55AE8CE46F /* DivisionBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B670A3A0762D22FB3202E1E /* DivisionBadge.swift */; };
 		114998283E6705D075ED2CA7 /* League.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD88B55D96BD7C519B6B65B6 /* League.swift */; };
+		11EFE5DD5C1D6DE5056597BB /* PlayerPointsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36829F2AD0FD089788B9CE1 /* PlayerPointsStore.swift */; };
 		133F58C70F4FA02676079E9A /* RulesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FDC8A9B02A2BFD83398D04F /* RulesStore.swift */; };
 		143F0C4F56D88430BDC07B2A /* SeasonPickerBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD5AF5657020E1DBB5CB8886 /* SeasonPickerBar.swift */; };
 		16F47DD114B2470F88D007A5 /* MatchupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8521885A7FF4C6910DFBF549 /* MatchupsView.swift */; };
@@ -199,6 +200,7 @@
 		C9382BCB18DFEB416A50A039 /* RulesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesView.swift; sourceTree = "<group>"; };
 		CC3F6B5022E8151683A45F4F /* PlayerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerStore.swift; sourceTree = "<group>"; };
 		CEAEC7A4917990425085AE71 /* PushNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationManager.swift; sourceTree = "<group>"; };
+		D36829F2AD0FD089788B9CE1 /* PlayerPointsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerPointsStore.swift; sourceTree = "<group>"; };
 		D7F3F1A18F4EEC5A3F81FD28 /* SeasonStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonStore.swift; sourceTree = "<group>"; };
 		DB1FE16B5220928685DCF19E /* SleeperAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleeperAPIClient.swift; sourceTree = "<group>"; };
 		DBD0F6820960B354EAB3E89D /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
@@ -502,6 +504,7 @@
 				F013CD37874EFB0FA1CB4261 /* HistoryStore.swift */,
 				56BB91320E3D5EBE1F777838 /* LeagueStore.swift */,
 				94E125AD2AA5212D0EB4C13A /* NflStateStore.swift */,
+				D36829F2AD0FD089788B9CE1 /* PlayerPointsStore.swift */,
 				CC3F6B5022E8151683A45F4F /* PlayerStore.swift */,
 				5CE99E9B095120FB6636FC8A /* PlayerValuesStore.swift */,
 				5FDC8A9B02A2BFD83398D04F /* RulesStore.swift */,
@@ -721,6 +724,7 @@
 				31CFADD9ECC5AC0D09B24BCF /* PayoutsView.swift in Sources */,
 				C9D656F4702A3483BB8E970C /* Player.swift in Sources */,
 				4DB9374CF45A69E97C02FC94 /* PlayerDetailView.swift in Sources */,
+				11EFE5DD5C1D6DE5056597BB /* PlayerPointsStore.swift in Sources */,
 				93D8C8E352B60752D37FD0FF /* PlayerSeasonStats.swift in Sources */,
 				FCD03562C1879183A5DC02E2 /* PlayerStore.swift in Sources */,
 				BE71F196BAB7D9E78BE94A9D /* PlayerValue.swift in Sources */,

--- a/Xomper/Core/Models/PayoutProjection.swift
+++ b/Xomper/Core/Models/PayoutProjection.swift
@@ -56,6 +56,9 @@ enum PayoutCalculator {
         standings: [StandingsTeam],
         matchupHistory: [MatchupHistoryRecord],
         winnersBracket: [PlayoffBracketMatch]?,
+        rosters: [Roster],
+        playerStore: PlayerStore,
+        playerPointsStore: PlayerPointsStore,
         userId: String?
     ) -> [PayoutProjection] {
         payouts.categories.map { category in
@@ -71,16 +74,136 @@ enum PayoutCalculator {
             case .weeklyHighScore:
                 weeklyHigh(category: category, matchupHistory: matchupHistory, standings: standings, userId: userId)
             case .positionMVP(let pos):
-                PayoutProjection(
+                positionMVP(
                     category: category,
-                    leader: nil,
-                    userPlacement: .pending,
-                    projectedAmount: 0,
-                    standings: nil,
-                    unavailableReason: "Per-player weekly scoring not yet wired (\(pos) MVP)."
+                    position: pos,
+                    rosters: rosters,
+                    standings: standings,
+                    playerStore: playerStore,
+                    playerPointsStore: playerPointsStore,
+                    userId: userId
                 )
             }
         }
+    }
+
+    // MARK: - Position MVP
+
+    /// "MVP" is the single PLAYER at the given position with the most
+    /// season starter-points. Owner of that player at the time of
+    /// computation wins the pot.
+    ///
+    /// Importantly, only points scored while STARTING count toward
+    /// the total — the owner had to play them. PlayerPointsStore
+    /// already enforces this by aggregating from `starters_points`
+    /// only (bench points are ignored).
+    private static func positionMVP(
+        category: LeaguePayoutCategory,
+        position: String,
+        rosters: [Roster],
+        standings: [StandingsTeam],
+        playerStore: PlayerStore,
+        playerPointsStore: PlayerPointsStore,
+        userId: String?
+    ) -> PayoutProjection {
+        guard playerPointsStore.hasData else {
+            return PayoutProjection(
+                category: category,
+                leader: nil,
+                userPlacement: .pending,
+                projectedAmount: 0,
+                standings: nil,
+                unavailableReason: "Per-player weekly scoring still loading…"
+            )
+        }
+
+        // Filter PlayerPointsStore to players currently rostered in
+        // this league at the target position. A player who's been
+        // dropped or is on another league's roster doesn't qualify.
+        let standingsByRosterId = Dictionary(uniqueKeysWithValues: standings.map { ($0.rosterId, $0) })
+        var rows: [PayoutProjection.StandingsRow] = []
+        var bestUserId: String?
+        var bestRosterId: Int?
+        var bestPlayerId: String?
+        var bestTotal: Double = 0
+        var bestPlayerLabel: String = ""
+
+        for roster in rosters {
+            guard let rosterTeam = standingsByRosterId[roster.rosterId] else { continue }
+            // Walk every player on this roster (starters + bench +
+            // taxi + reserve — the points cache already accounts for
+            // who actually started which week).
+            for pid in roster.players ?? [] {
+                let pts = playerPointsStore.points(for: pid)
+                guard pts > 0 else { continue }
+                let pos = playerStore.player(for: pid)?.displayPosition ?? ""
+                guard pos == position else { continue }
+
+                if pts > bestTotal {
+                    bestTotal = pts
+                    bestUserId = rosterTeam.userId
+                    bestRosterId = roster.rosterId
+                    bestPlayerId = pid
+                    let player = playerStore.player(for: pid)
+                    bestPlayerLabel = player?.fullDisplayName ?? "Player #\(pid)"
+                }
+
+                // Aggregate per-team totals at this position for the
+                // drill-down view (sum a manager's full position room,
+                // not just the MVP player).
+                if let row = rows.firstIndex(where: { $0.userId == rosterTeam.userId }) {
+                    let updated = rows[row]
+                    rows[row] = PayoutProjection.StandingsRow(
+                        userId: updated.userId,
+                        teamName: updated.teamName,
+                        value: updated.value + pts,
+                        displayValue: String(format: "%.1f", updated.value + pts)
+                    )
+                } else {
+                    rows.append(PayoutProjection.StandingsRow(
+                        userId: rosterTeam.userId,
+                        teamName: rosterTeam.teamName,
+                        value: pts,
+                        displayValue: String(format: "%.1f", pts)
+                    ))
+                }
+            }
+        }
+
+        // Sort drill-down rows by per-team total points at this
+        // position (descending) so the manager whose lineup leans on
+        // the MVP can see who's catching up.
+        rows.sort { $0.value > $1.value }
+
+        guard let bestUserId, let bestRosterId else {
+            return PayoutProjection(
+                category: category,
+                leader: nil,
+                userPlacement: .behind(by: ""),
+                projectedAmount: 0,
+                standings: rows.isEmpty ? nil : rows,
+                unavailableReason: nil
+            )
+        }
+        _ = bestRosterId  // owner roster captured for future drill-in
+        _ = bestPlayerId
+
+        let leaderTeam = standingsByRosterId.values.first { $0.userId == bestUserId }
+        let isMine = bestUserId == userId
+        let leaderDisplay = "\(bestPlayerLabel) · \(String(format: "%.1f", bestTotal)) pts"
+
+        return PayoutProjection(
+            category: category,
+            leader: PayoutProjection.LeaderRef(
+                userId: bestUserId,
+                teamName: leaderTeam?.teamName ?? "Unknown",
+                displayValue: leaderDisplay
+            ),
+            userPlacement: isMine ? .leading : .behind(by: ""),
+            projectedAmount: isMine ? category.amount : 0,
+            standings: rows,
+            unavailableReason: nil
+        )
     }
 
     // MARK: - Champion / runner-up / 3rd

--- a/Xomper/Core/Stores/PlayerPointsStore.swift
+++ b/Xomper/Core/Stores/PlayerPointsStore.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Per-player season totals from STARTING lineups only. Drives the
+/// position-MVP payout categories — a player only counts toward their
+/// position MVP when their owner actually started them in a given
+/// week (bench points don't count).
+///
+/// Lazy-loaded: PayoutsView triggers `loadRegularSeason` on appear,
+/// hits `/league/{id}/matchups/{week}` for each regular-season week
+/// not yet fetched, walks each matchup's parallel `starters` /
+/// `starters_points` arrays, and accumulates points by player ID.
+///
+/// Cache key is (leagueId, weeksFetched). Weeks that fail to fetch
+/// are simply skipped on this run; they'll be retried next time the
+/// view appears.
+@Observable
+@MainActor
+final class PlayerPointsStore {
+
+    /// player_id → season starter-points total (regular season only).
+    private(set) var seasonStarterPoints: [String: Double] = [:]
+
+    /// (leagueId, week) we've already aggregated. Resets when
+    /// `reset()` is called (e.g. league switch).
+    private(set) var fetched: Set<String> = []
+
+    private(set) var isLoading = false
+    private(set) var error: Error?
+
+    private let apiClient: SleeperAPIClientProtocol
+
+    init(apiClient: SleeperAPIClientProtocol = SleeperAPIClient()) {
+        self.apiClient = apiClient
+    }
+
+    /// Walks every regular-season week (1 through `regularSeasonLastWeek`)
+    /// for the given league chain. Reads from the head league (current
+    /// season). Multi-season chain walking can be added later if MVP
+    /// pots ever need to span multiple years; for now MVP is per-season.
+    func loadRegularSeason(
+        leagueId: String,
+        regularSeasonLastWeek: Int
+    ) async {
+        guard !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+        error = nil
+
+        var totals = seasonStarterPoints
+        for week in 1...max(regularSeasonLastWeek, 1) {
+            let key = cacheKey(leagueId: leagueId, week: week)
+            if fetched.contains(key) { continue }
+            do {
+                let matchups = try await apiClient.fetchLeagueMatchups(leagueId, week: week)
+                for matchup in matchups {
+                    guard let starters = matchup.starters,
+                          let starterPoints = matchup.startersPoints else { continue }
+                    let count = min(starters.count, starterPoints.count)
+                    for i in 0..<count {
+                        let pid = starters[i]
+                        let pts = starterPoints[i]
+                        // Skip empty slots ("0" is Sleeper's null marker)
+                        // and zero-point starts that fall on a bye week
+                        // — they didn't actually contribute.
+                        guard !pid.isEmpty, pid != "0" else { continue }
+                        totals[pid, default: 0] += pts
+                    }
+                }
+                fetched.insert(key)
+            } catch {
+                // Non-fatal — try the rest of the season; surface only
+                // if every week failed.
+                self.error = error
+            }
+        }
+        seasonStarterPoints = totals
+    }
+
+    func points(for playerId: String) -> Double {
+        seasonStarterPoints[playerId] ?? 0
+    }
+
+    var hasData: Bool {
+        !seasonStarterPoints.isEmpty
+    }
+
+    func reset() {
+        seasonStarterPoints = [:]
+        fetched = []
+        error = nil
+    }
+
+    private func cacheKey(leagueId: String, week: Int) -> String {
+        "\(leagueId)#\(week)"
+    }
+}

--- a/Xomper/Features/Payouts/PayoutsView.swift
+++ b/Xomper/Features/Payouts/PayoutsView.swift
@@ -8,6 +8,8 @@ import SwiftUI
 struct PayoutsView: View {
     var leagueStore: LeagueStore
     var historyStore: HistoryStore
+    var playerStore: PlayerStore
+    var playerPointsStore: PlayerPointsStore
     var authStore: AuthStore
 
     private let payouts: LeaguePayouts = .charlotteDynastyDefault
@@ -46,6 +48,9 @@ struct PayoutsView: View {
             standings: standings,
             matchupHistory: historyStore.matchupHistory,
             winnersBracket: leagueStore.winnersBracket,
+            rosters: leagueStore.myLeagueRosters,
+            playerStore: playerStore,
+            playerPointsStore: playerPointsStore,
             userId: authStore.sleeperUserId
         )
         let projected = projections.map(\.projectedAmount).reduce(0, +)
@@ -210,6 +215,29 @@ struct PayoutsView: View {
            let leagueId = leagueStore.myLeague?.leagueId {
             await leagueStore.fetchBrackets(leagueId: leagueId)
         }
+        // Per-player starter-points aggregation for position MVPs.
+        // 14 weeks × ~12 matchups each — fits comfortably in a single
+        // background pass; cached on the store so re-entering the view
+        // doesn't re-fetch.
+        if !playerPointsStore.hasData,
+           let leagueId = leagueStore.myLeague?.leagueId {
+            await playerPointsStore.loadRegularSeason(
+                leagueId: leagueId,
+                regularSeasonLastWeek: regularSeasonLastWeek
+            )
+        }
+    }
+
+    /// Final regular-season week. Derived from `playoff_week_start - 1`
+    /// when available; falls back to 14 (the typical NFL fantasy
+    /// regular season).
+    private var regularSeasonLastWeek: Int {
+        guard let value = leagueStore.myLeague?.settings?.additionalSettings?["playoff_week_start"] else {
+            return 14
+        }
+        if let i = value.intValue { return max(i - 1, 1) }
+        if let d = value.doubleValue { return max(Int(d) - 1, 1) }
+        return 14
     }
 
     private func reload() async {

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -29,6 +29,7 @@ struct MainShell: View {
     @State private var router = AppRouter()
     @State private var seasonStore = SeasonStore()
     @State private var valuesStore = PlayerValuesStore()
+    @State private var playerPointsStore = PlayerPointsStore()
 
     // MARK: - Body
 
@@ -190,6 +191,8 @@ struct MainShell: View {
                 PayoutsView(
                     leagueStore: leagueStore,
                     historyStore: historyStore,
+                    playerStore: playerStore,
+                    playerPointsStore: playerPointsStore,
                     authStore: authStore
                 )
 


### PR DESCRIPTION
v2 follow-up to #56 / PR #65. Lights up the QB / RB / WR / TE MVP rows that were previously "Coming soon".

## Key constraint enforced
> "User had to play them to get credit for their points that week."

Points only count toward MVP when the player was **started**. \`PlayerPointsStore\` enforces this at the data layer — it aggregates exclusively from each matchup's \`starters_points\` array (parallel to \`starters\`). Bench points are never counted.

## New: \`PlayerPointsStore\`
- Lazy-loaded once per session per league
- Walks every regular-season week (1 through \`playoff_week_start - 1\`) of \`/league/{id}/matchups/{week}\`
- Per-week cache key — re-entering Payouts is instant after the first load

## \`PayoutCalculator.positionMVP\`
- Filters to **currently rostered** players at the target position (drops/trades disqualify)
- MVP = single player with the highest season starter-points total at the position
- Current owner of that player wins the pot
- Drill-down rows show per-team aggregate at the position (sum across every starter the manager rostered there) so you can see who's chasing
- "Pending" state surfaced while the per-week fetch runs

## Wiring
- \`PlayerPointsStore\` lives on MainShell as \`@State\`
- \`PayoutsView\` takes \`playerStore + playerPointsStore\`
- \`ensureLoaded\` fires \`loadRegularSeason\` after league chain resolves
- \`regularSeasonLastWeek\` derived from \`playoff_week_start - 1\` (defaults to 14)

## Perf note
14 weeks × ~12 matchups = ~14 sequential GETs on first open, ~5-15s depending on network. All cached for the session.

## Test plan
- [ ] Open Payouts after fresh launch → QB / RB / WR / TE MVP rows go from "loading" → resolved with leader + their MVP player + score
- [ ] If you own the MVP player, your row says "Leading" and projected \$ matches the category amount
- [ ] Tap any MVP row → drill-down shows per-team position totals descending
- [ ] Trading the MVP away (or dropping them) demotes the projection — owner check is current
- [ ] Build clean under Swift 6 strict concurrency