### PR TITLE
feat: reverse-HPP rookie draft order projection

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		61EBC3AC052763EAAC807AC9 /* WorldCup.swift in Sources */ = {isa = PBXBuildFile; fileRef = E969C4A894017F9D0072CCFA /* WorldCup.swift */; };
 		65444EF8D83F3582CE2FC023 /* TrophyCaseSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B94B6AD01FF1F85D81B5A5DE /* TrophyCaseSection.swift */; };
 		65DC95B6907B22347616C3D7 /* SleeperAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1FE16B5220928685DCF19E /* SleeperAPIClient.swift */; };
+		6BC002C5DD7EF547F82CA860 /* DraftOrderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9ED150F995299D37368EDC3 /* DraftOrderView.swift */; };
 		6C89029D05AEE66FB2315616 /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C8A3FA617E9FEB48852C45 /* Profile.swift */; };
 		724482308D102AFA35AB4017 /* LeagueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56BB91320E3D5EBE1F777838 /* LeagueStore.swift */; };
 		72FF7B4516B2DCDAE4683B9D /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83A8FEFFD8FA91F498D03A0 /* EmptyStateView.swift */; };
@@ -107,6 +108,7 @@
 		F201A3A40D624F6AAA0C0CC1 /* PlayoffBracket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */; };
 		F57132F0D80EAB60AC0E07F3 /* WhitelistedLeague.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747C6FC769C117588F8A93E /* WhitelistedLeague.swift */; };
 		F5AD059EF52A068C469AFB6E /* URL+Sleeper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2452A5AEC270BE14CC085E1 /* URL+Sleeper.swift */; };
+		F66FCFE7466291137B314370 /* HighestPossibleLineup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 765C03E7E4268373F28754DC /* HighestPossibleLineup.swift */; };
 		F7E0A8B9AECD0291527E0D0E /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F46A0AAE61A4E963BB15B0 /* SearchView.swift */; };
 		FAE7847413A293EF8CE9090C /* NFLTeamColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DF8F2FE857C55AFB1C1205 /* NFLTeamColors.swift */; };
 		FCD03562C1879183A5DC02E2 /* PlayerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3F6B5022E8151683A45F4F /* PlayerStore.swift */; };
@@ -164,6 +166,7 @@
 		6F2C7D74B3584D53CE601054 /* MatchupDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupDetailView.swift; sourceTree = "<group>"; };
 		6F2D6E80C100927C4C20FAD7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		72CFD764A2BA7FF93B318A7F /* CareerStatsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareerStatsSection.swift; sourceTree = "<group>"; };
+		765C03E7E4268373F28754DC /* HighestPossibleLineup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighestPossibleLineup.swift; sourceTree = "<group>"; };
 		7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Draft.swift; sourceTree = "<group>"; };
 		8098F78566BB324ACC70FB94 /* TeamAnalyzerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamAnalyzerView.swift; sourceTree = "<group>"; };
 		840D50097382434B0D123ACB /* NavigationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStore.swift; sourceTree = "<group>"; };
@@ -216,6 +219,7 @@
 		E7E3BE36BCEA1A7722157C37 /* PayoutProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayoutProjection.swift; sourceTree = "<group>"; };
 		E7F510E2F428E107F1AD75CD /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		E969C4A894017F9D0072CCFA /* WorldCup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCup.swift; sourceTree = "<group>"; };
+		E9ED150F995299D37368EDC3 /* DraftOrderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftOrderView.swift; sourceTree = "<group>"; };
 		ECC70812B3E7E07BA6658A54 /* AvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
 		ED3E9ADC138A5F405E59389C /* DrawerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerView.swift; sourceTree = "<group>"; };
 		F013CD37874EFB0FA1CB4261 /* HistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryStore.swift; sourceTree = "<group>"; };
@@ -289,6 +293,7 @@
 			children = (
 				390D24DCB17100460C0E682A /* Auth */,
 				EB7304EC920FBEC53F6E4CEB /* DraftHistory */,
+				680358FA986CFA519A36A85D /* DraftOrder */,
 				7DEC053904198785F4461D4A /* Home */,
 				47014533E72495E9E9DC8F74 /* League */,
 				2D1CA584D084FE022DC6401D /* MatchupHistory */,
@@ -370,6 +375,14 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		680358FA986CFA519A36A85D /* DraftOrder */ = {
+			isa = PBXGroup;
+			children = (
+				E9ED150F995299D37368EDC3 /* DraftOrderView.swift */,
+			);
+			path = DraftOrder;
+			sourceTree = "<group>";
+		};
 		6901B56E6449F5FCF4E986E7 /* TaxiSquad */ = {
 			isa = PBXGroup;
 			children = (
@@ -422,6 +435,7 @@
 				18383A0375F5728A9E3FE065 /* Championship.swift */,
 				7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */,
 				A789B8D49FA4430886626289 /* DraftHistory.swift */,
+				765C03E7E4268373F28754DC /* HighestPossibleLineup.swift */,
 				FD88B55D96BD7C519B6B65B6 /* League.swift */,
 				43AC494E7D11CB94A2FD56EA /* LeaguePayouts.swift */,
 				C83EF3C6C93199CF3FCBAE42 /* Matchup.swift */,
@@ -694,6 +708,7 @@
 				1C4049A62CC4A443AC38E464 /* Draft.swift in Sources */,
 				4E0CAC9964BF3F2B59EDD844 /* DraftHistory.swift in Sources */,
 				3B67875F822BE9AA9BD052EF /* DraftHistoryView.swift in Sources */,
+				6BC002C5DD7EF547F82CA860 /* DraftOrderView.swift in Sources */,
 				3B1DDBCA7B19B8703FAF717E /* DrawerScrim.swift in Sources */,
 				817EEBDA82021E74A830E1B3 /* DrawerView.swift in Sources */,
 				72FF7B4516B2DCDAE4683B9D /* EmptyStateView.swift in Sources */,
@@ -701,6 +716,7 @@
 				60FB3A9B54EAB11F015C1828 /* ErrorView.swift in Sources */,
 				EDDACB3FFB20E468D9D9D67D /* HeaderBar.swift in Sources */,
 				C21992E2FA476C65D8D23BA8 /* HexagonChartView.swift in Sources */,
+				F66FCFE7466291137B314370 /* HighestPossibleLineup.swift in Sources */,
 				063FCD6AA342CA5D64ED79ED /* HistoryStore.swift in Sources */,
 				114998283E6705D075ED2CA7 /* League.swift in Sources */,
 				CEC2B1D5D34F80BFB3444C6F /* LeagueOverviewView.swift in Sources */,

--- a/Xomper/Core/Models/HighestPossibleLineup.swift
+++ b/Xomper/Core/Models/HighestPossibleLineup.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// Computes "Highest Possible Points" (HPP) per team per week — the
+/// maximum points a team's roster *could have scored* given the slot
+/// configuration and the actual points each rostered player scored.
+///
+/// Used by #57's reverse-HPP draft order rule: managers who set bad
+/// lineups have their actual points but a higher HPP, while managers
+/// who maximized their starts have actual ≈ HPP. Sorting non-playoff
+/// teams by HPP ascending rewards effort over tanking.
+///
+/// Algorithm: greedy assignment with slots sorted by restrictiveness
+/// (specific positions before flex slots). Optimal for the standard
+/// fantasy slot config; not exhaustive search but matches what
+/// every fantasy "perfect lineup" tool does.
+@MainActor
+enum HighestPossibleCalculator {
+
+    /// Slot labels Sleeper uses that DON'T count toward the active
+    /// lineup — bench, IR, taxi, reserve.
+    private static let nonStartingSlots: Set<String> = ["BN", "IR", "RES", "TAXI"]
+
+    /// Slot label → set of position labels eligible for that slot.
+    /// Covers Sleeper's full slot vocabulary across formats.
+    private static let slotEligibility: [String: Set<String>] = [
+        "QB":           ["QB"],
+        "RB":           ["RB"],
+        "WR":           ["WR"],
+        "TE":           ["TE"],
+        "K":            ["K"],
+        "DEF":          ["DEF"],
+        "DST":          ["DEF"],
+        "FLEX":         ["RB", "WR", "TE"],
+        "REC_FLEX":     ["WR", "TE"],
+        "WRRB_FLEX":    ["RB", "WR"],
+        "WRRB_WT":      ["RB", "WR", "TE"],
+        "SUPER_FLEX":   ["QB", "RB", "WR", "TE"],
+        "SUPER FLEX":   ["QB", "RB", "WR", "TE"],
+        "Q/W/R/T":      ["QB", "RB", "WR", "TE"],
+        "IDP_FLEX":     ["DL", "LB", "DB"],
+        "DL":           ["DL", "DE", "DT"],
+        "LB":           ["LB", "ILB", "OLB"],
+        "DB":           ["DB", "CB", "S", "FS", "SS"],
+    ]
+
+    /// HPP for a single roster across the regular season. Returns 0
+    /// if no per-week data has been fetched yet.
+    static func seasonHPP(
+        rosterId: Int,
+        rosterPositions: [String],
+        playerPointsStore: PlayerPointsStore,
+        playerStore: PlayerStore,
+        regularSeasonLastWeek: Int
+    ) -> Double {
+        var total: Double = 0
+        for week in 1...max(regularSeasonLastWeek, 1) {
+            let key = "\(week)-\(rosterId)"
+            guard let weekPoints = playerPointsStore.weeklyRosterPoints[key],
+                  !weekPoints.isEmpty else { continue }
+            total += optimalLineupPoints(
+                playerPoints: weekPoints,
+                rosterPositions: rosterPositions,
+                playerStore: playerStore
+            )
+        }
+        return total
+    }
+
+    /// Optimal lineup points for a single week given:
+    /// - `playerPoints`: every rostered player's score that week
+    /// - `rosterPositions`: the league's slot config from
+    ///   `league.rosterPositions` (e.g. ["QB", "RB", "RB", "WR",
+    ///   "WR", "TE", "FLEX", "SUPER_FLEX", "BN", "BN", ...])
+    /// - `playerStore`: position lookup
+    static func optimalLineupPoints(
+        playerPoints: [String: Double],
+        rosterPositions: [String],
+        playerStore: PlayerStore
+    ) -> Double {
+        // 1. Filter to active starting slots
+        let activeSlots = rosterPositions.filter { !nonStartingSlots.contains($0) }
+        guard !activeSlots.isEmpty else { return 0 }
+
+        // 2. Resolve each slot's eligibility set
+        let slots: [(slot: String, eligible: Set<String>)] = activeSlots.map { slot in
+            (slot, slotEligibility[slot] ?? [slot])
+        }
+
+        // 3. Build candidate list — only players we have positions for
+        struct Candidate {
+            let id: String
+            let pos: String
+            let pts: Double
+        }
+        let candidates: [Candidate] = playerPoints.compactMap { pid, pts in
+            guard let pos = playerStore.player(for: pid)?.displayPosition else { return nil }
+            return Candidate(id: pid, pos: pos, pts: pts)
+        }
+
+        // 4. Sort slots by restrictiveness ascending (specific
+        //    positions filled before flexes — greedy is optimal in
+        //    this ordering for the standard fantasy slot lattice).
+        let orderedSlots = slots.sorted { $0.eligible.count < $1.eligible.count }
+
+        // 5. Greedy: each slot grabs the highest-scoring eligible
+        //    unassigned candidate.
+        var used: Set<String> = []
+        var total: Double = 0
+        for slotEntry in orderedSlots {
+            let pick = candidates
+                .filter { !used.contains($0.id) && slotEntry.eligible.contains($0.pos) }
+                .max(by: { $0.pts < $1.pts })
+            if let pick {
+                used.insert(pick.id)
+                total += pick.pts
+            }
+        }
+        return total
+    }
+}

--- a/Xomper/Core/Stores/PlayerPointsStore.swift
+++ b/Xomper/Core/Stores/PlayerPointsStore.swift
@@ -20,6 +20,12 @@ final class PlayerPointsStore {
     /// player_id → season starter-points total (regular season only).
     private(set) var seasonStarterPoints: [String: Double] = [:]
 
+    /// "(week)-(rosterId)" → [player_id: points scored that week].
+    /// Captures the FULL roster (starters + bench) so the
+    /// HighestPossibleCalculator can re-pick an optimal lineup
+    /// independent of what was actually started.
+    private(set) var weeklyRosterPoints: [String: [String: Double]] = [:]
+
     /// (leagueId, week) we've already aggregated. Resets when
     /// `reset()` is called (e.g. league switch).
     private(set) var fetched: Set<String> = []
@@ -53,17 +59,29 @@ final class PlayerPointsStore {
             do {
                 let matchups = try await apiClient.fetchLeagueMatchups(leagueId, week: week)
                 for matchup in matchups {
-                    guard let starters = matchup.starters,
-                          let starterPoints = matchup.startersPoints else { continue }
-                    let count = min(starters.count, starterPoints.count)
-                    for i in 0..<count {
-                        let pid = starters[i]
-                        let pts = starterPoints[i]
-                        // Skip empty slots ("0" is Sleeper's null marker)
-                        // and zero-point starts that fall on a bye week
-                        // — they didn't actually contribute.
-                        guard !pid.isEmpty, pid != "0" else { continue }
-                        totals[pid, default: 0] += pts
+                    // Starter aggregation (drives Position MVPs)
+                    if let starters = matchup.starters,
+                       let starterPoints = matchup.startersPoints {
+                        let count = min(starters.count, starterPoints.count)
+                        for i in 0..<count {
+                            let pid = starters[i]
+                            let pts = starterPoints[i]
+                            guard !pid.isEmpty, pid != "0" else { continue }
+                            totals[pid, default: 0] += pts
+                        }
+                    }
+
+                    // Per-week per-roster full-roster points (drives
+                    // Highest Possible Points calc for #57 draft order)
+                    if let players = matchup.players,
+                       let pp = matchup.playersPoints {
+                        var rosterScores: [String: Double] = [:]
+                        for pid in players {
+                            guard !pid.isEmpty, pid != "0" else { continue }
+                            if let pts = pp[pid] { rosterScores[pid] = pts }
+                        }
+                        let rosterKey = "\(week)-\(matchup.rosterId)"
+                        weeklyRosterPoints[rosterKey] = rosterScores
                     }
                 }
                 fetched.insert(key)

--- a/Xomper/Features/DraftOrder/DraftOrderView.swift
+++ b/Xomper/Features/DraftOrder/DraftOrderView.swift
@@ -1,0 +1,254 @@
+import SwiftUI
+
+/// Projected draft order for next year's rookie draft, using the
+/// reverse-HPP rule: non-playoff teams pick in ascending order of
+/// season Highest Possible Points. Playoff teams pick at the back
+/// of round 1, ordered by (eventual) playoff finish.
+///
+/// Rationale (per league rule discussion in #57):
+/// - Punishes managers who tank by setting bad lineups (high HPP +
+///   low actual = first pick under old rules → top pick of next
+///   year's class).
+/// - Rewards managers who maximized their starts but ran into
+///   bad luck (low HPP, low actual = they tried; they get the
+///   higher pick).
+struct DraftOrderView: View {
+    var leagueStore: LeagueStore
+    var playerStore: PlayerStore
+    var playerPointsStore: PlayerPointsStore
+
+    var body: some View {
+        Group {
+            if leagueStore.myLeagueRosters.isEmpty {
+                LoadingView(message: "Loading league…")
+            } else if !playerPointsStore.hasData {
+                if playerPointsStore.isLoading {
+                    LoadingView(message: "Computing perfect-lineup totals…")
+                } else {
+                    EmptyStateView(
+                        icon: "list.number",
+                        title: "Draft Order Pending",
+                        message: "Per-week data not yet aggregated. Pull to refresh."
+                    )
+                }
+            } else {
+                content
+            }
+        }
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .task(id: leagueStore.myLeague?.leagueId) {
+            await ensureLoaded()
+        }
+        .refreshable {
+            await ensureLoaded()
+        }
+    }
+
+    // MARK: - Content
+
+    private var content: some View {
+        let projection = compute()
+
+        return ScrollView {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
+                explainerCard
+
+                if !projection.nonPlayoffOrder.isEmpty {
+                    sectionHeader("Reverse-HPP order (picks 1–\(projection.nonPlayoffOrder.count))")
+                    ForEach(Array(projection.nonPlayoffOrder.enumerated()), id: \.offset) { idx, entry in
+                        row(rank: idx + 1, entry: entry, isPlayoff: false)
+                    }
+                }
+
+                if !projection.playoffOrder.isEmpty {
+                    sectionHeader(
+                        "Playoff teams (picks "
+                        + "\(projection.nonPlayoffOrder.count + 1)–"
+                        + "\(projection.nonPlayoffOrder.count + projection.playoffOrder.count))"
+                    )
+                    ForEach(Array(projection.playoffOrder.enumerated()), id: \.offset) { idx, entry in
+                        row(
+                            rank: projection.nonPlayoffOrder.count + idx + 1,
+                            entry: entry,
+                            isPlayoff: true
+                        )
+                    }
+                }
+            }
+            .padding(.horizontal, XomperTheme.Spacing.md)
+            .padding(.vertical, XomperTheme.Spacing.sm)
+        }
+    }
+
+    // MARK: - Explainer
+
+    private var explainerCard: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            Text("Reverse-HPP draft order")
+                .font(.subheadline.weight(.bold))
+                .foregroundStyle(XomperColors.championGold)
+
+            Text("Non-playoff teams pick in ascending order of season Highest Possible Points (perfect-lineup score). Playoff teams pick at the back, ordered by playoff finish.")
+                .font(.caption)
+                .foregroundStyle(XomperColors.textSecondary)
+
+            Text("HPP credits a team for the points they could have scored if they'd started their best lineup each week. Set bad lineups → high HPP / low wins → late pick. Maximized starts but unlucky → low HPP → early pick.")
+                .font(.caption2)
+                .foregroundStyle(XomperColors.textMuted)
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    private func sectionHeader(_ text: String) -> some View {
+        Text(text)
+            .font(.caption.weight(.bold))
+            .textCase(.uppercase)
+            .tracking(0.5)
+            .foregroundStyle(XomperColors.textMuted)
+            .padding(.top, XomperTheme.Spacing.sm)
+    }
+
+    // MARK: - Row
+
+    private func row(rank: Int, entry: DraftOrderProjection.Entry, isPlayoff: Bool) -> some View {
+        HStack(spacing: XomperTheme.Spacing.md) {
+            Text("\(rank)")
+                .font(.title3.weight(.bold))
+                .foregroundStyle(rank == 1 ? XomperColors.championGold : XomperColors.textSecondary)
+                .frame(width: 36, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entry.teamName)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .lineLimit(1)
+
+                HStack(spacing: XomperTheme.Spacing.sm) {
+                    Text(entry.recordLabel)
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .monospacedDigit()
+                    Text(entry.actualPFLabel)
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .monospacedDigit()
+                    if isPlayoff {
+                        Text("PLAYOFFS")
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(XomperColors.bgDark)
+                            .padding(.horizontal, XomperTheme.Spacing.xs)
+                            .background(XomperColors.successGreen)
+                            .clipShape(Capsule())
+                    }
+                }
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(String(format: "%.1f", entry.seasonHPP))
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+                    .monospacedDigit()
+                Text("season HPP")
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.textMuted)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+    }
+
+    // MARK: - Compute
+
+    private func compute() -> DraftOrderProjection {
+        guard let league = leagueStore.myLeague else { return .empty }
+        let standings = StandingsBuilder.buildStandings(
+            rosters: leagueStore.myLeagueRosters,
+            users: leagueStore.myLeagueUsers,
+            league: league
+        )
+
+        let rosterPositions = league.rosterPositions ?? []
+        let playoffTeams = league.settings?.playoffTeams ?? 6
+        let regularSeasonLastWeek = regularSeasonLastWeek
+
+        let entries: [DraftOrderProjection.Entry] = standings.map { team in
+            let hpp = HighestPossibleCalculator.seasonHPP(
+                rosterId: team.rosterId,
+                rosterPositions: rosterPositions,
+                playerPointsStore: playerPointsStore,
+                playerStore: playerStore,
+                regularSeasonLastWeek: regularSeasonLastWeek
+            )
+            return DraftOrderProjection.Entry(
+                rosterId: team.rosterId,
+                teamName: team.teamName,
+                recordLabel: "\(team.wins)-\(team.losses)\(team.ties > 0 ? "-\(team.ties)" : "")",
+                actualPFLabel: String(format: "%.1f PF", team.fpts),
+                actualPF: team.fpts,
+                seasonHPP: hpp,
+                leagueRank: team.leagueRank
+            )
+        }
+
+        // Standings is already sorted by wins-DESC then PF-DESC. Top
+        // playoff_teams qualify; rest go to non-playoff.
+        let playoffEntries = Array(entries.prefix(playoffTeams))
+        let nonPlayoff = Array(entries.dropFirst(playoffTeams))
+            .sorted(by: { $0.seasonHPP < $1.seasonHPP })  // ascending HPP
+
+        return DraftOrderProjection(
+            nonPlayoffOrder: nonPlayoff,
+            playoffOrder: playoffEntries
+        )
+    }
+
+    // MARK: - Data loading
+
+    private func ensureLoaded() async {
+        if !playerPointsStore.hasData,
+           let leagueId = leagueStore.myLeague?.leagueId {
+            await playerPointsStore.loadRegularSeason(
+                leagueId: leagueId,
+                regularSeasonLastWeek: regularSeasonLastWeek
+            )
+        }
+    }
+
+    private var regularSeasonLastWeek: Int {
+        guard let value = leagueStore.myLeague?.settings?.additionalSettings?["playoff_week_start"] else {
+            return 14
+        }
+        if let i = value.intValue { return max(i - 1, 1) }
+        if let d = value.doubleValue { return max(Int(d) - 1, 1) }
+        return 14
+    }
+}
+
+// MARK: - Projection
+
+struct DraftOrderProjection: Sendable {
+    let nonPlayoffOrder: [Entry]
+    let playoffOrder: [Entry]
+
+    static let empty = DraftOrderProjection(nonPlayoffOrder: [], playoffOrder: [])
+
+    struct Entry: Sendable, Hashable {
+        let rosterId: Int
+        let teamName: String
+        let recordLabel: String
+        let actualPFLabel: String
+        let actualPF: Double
+        let seasonHPP: Double
+        let leagueRank: Int
+    }
+}

--- a/Xomper/Features/Shell/DrawerView.swift
+++ b/Xomper/Features/Shell/DrawerView.swift
@@ -34,7 +34,7 @@ struct DrawerView: View {
         ),
         TraySection(
             title: "League",
-            entries: [.payouts, .rulebook, .scoring, .leagueSettings, .ruleProposals]
+            entries: [.payouts, .draftOrder, .rulebook, .scoring, .leagueSettings, .ruleProposals]
         ),
     ]
 

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -196,6 +196,13 @@ struct MainShell: View {
                     authStore: authStore
                 )
 
+            case .draftOrder:
+                DraftOrderView(
+                    leagueStore: leagueStore,
+                    playerStore: playerStore,
+                    playerPointsStore: playerPointsStore
+                )
+
             case .rulebook:
                 rulesPage(.rulebook)
 

--- a/Xomper/Features/Shell/TrayDestination.swift
+++ b/Xomper/Features/Shell/TrayDestination.swift
@@ -24,6 +24,7 @@ enum TrayDestination: Hashable {
     case leagueSettings
     case ruleProposals
     case payouts
+    case draftOrder
     case profile
     case settings
 
@@ -45,6 +46,7 @@ enum TrayDestination: Hashable {
         case .leagueSettings: "League Settings"
         case .ruleProposals:  "Rule Proposals"
         case .payouts:        "Payouts"
+        case .draftOrder:     "Draft Order"
         case .profile:        "Profile"
         case .settings:       "Settings"
         }
@@ -67,6 +69,7 @@ enum TrayDestination: Hashable {
         case .leagueSettings: "slider.horizontal.3"
         case .ruleProposals:  "checkmark.bubble.fill"
         case .payouts:        "dollarsign.circle.fill"
+        case .draftOrder:     "list.bullet.rectangle"
         case .profile:        "person.crop.circle.fill"
         case .settings:       "gearshape.fill"
         }


### PR DESCRIPTION
## Summary
- New "Draft Order" page under the League drawer section that projects next year's rookie draft order using the reverse-HPP rule from #57.
- Non-playoff teams pick in ascending order of season Highest Possible Points; playoff teams pick at the back of round 1 by playoff finish.
- HPP captures whether managers maximized their starts: bad lineups → high HPP / low wins → late pick, while unlucky managers with low HPP → early pick.

## Implementation
- `HighestPossibleCalculator` (new): greedy optimal-lineup, slots sorted by restrictiveness so specific positions fill before flex/super-flex.
- `PlayerPointsStore` now also captures full per-roster weekly scores (starters + bench) keyed by `{week}-{rosterId}` so HPP can re-pick the optimal lineup regardless of what the manager actually started.
- `DraftOrderView`: explainer card + two ranked sections (non-playoff reverse-HPP, then playoff teams).

Closes #57

## Test plan
- [ ] Build clean (verified locally)
- [ ] Open drawer → League → Draft Order
- [ ] Confirm explainer card renders, non-playoff teams sorted ascending by HPP, playoff teams at bottom with PLAYOFFS pill
- [ ] Pull-to-refresh recomputes after week rollover