### PR TITLE
fix: stop scrolls firing taps across all list/card screens

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		F5AD059EF52A068C469AFB6E /* URL+Sleeper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2452A5AEC270BE14CC085E1 /* URL+Sleeper.swift */; };
 		F66FCFE7466291137B314370 /* HighestPossibleLineup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 765C03E7E4268373F28754DC /* HighestPossibleLineup.swift */; };
 		F7E0A8B9AECD0291527E0D0E /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F46A0AAE61A4E963BB15B0 /* SearchView.swift */; };
+		F9A37723FE37F4C30D46D6E1 /* PressableCardButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FB63BCA4BDD437FFE6D3A8 /* PressableCardButtonStyle.swift */; };
 		FAE7847413A293EF8CE9090C /* NFLTeamColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DF8F2FE857C55AFB1C1205 /* NFLTeamColors.swift */; };
 		FCD03562C1879183A5DC02E2 /* PlayerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3F6B5022E8151683A45F4F /* PlayerStore.swift */; };
 /* End PBXBuildFile section */
@@ -165,6 +166,7 @@
 		6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayoffBracket.swift; sourceTree = "<group>"; };
 		6F2C7D74B3584D53CE601054 /* MatchupDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupDetailView.swift; sourceTree = "<group>"; };
 		6F2D6E80C100927C4C20FAD7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		71FB63BCA4BDD437FFE6D3A8 /* PressableCardButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PressableCardButtonStyle.swift; sourceTree = "<group>"; };
 		72CFD764A2BA7FF93B318A7F /* CareerStatsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareerStatsSection.swift; sourceTree = "<group>"; };
 		765C03E7E4268373F28754DC /* HighestPossibleLineup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighestPossibleLineup.swift; sourceTree = "<group>"; };
 		7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Draft.swift; sourceTree = "<group>"; };
@@ -545,6 +547,7 @@
 			isa = PBXGroup;
 			children = (
 				09DF8F2FE857C55AFB1C1205 /* NFLTeamColors.swift */,
+				71FB63BCA4BDD437FFE6D3A8 /* PressableCardButtonStyle.swift */,
 				C82B0FEAAB9BC80BA0801E98 /* XomperColors.swift */,
 				1FBB5433786555EDDBC896C7 /* XomperTheme.swift */,
 			);
@@ -747,6 +750,7 @@
 				B309CAE3F00F954918C09554 /* PlayerValuesStore.swift in Sources */,
 				F201A3A40D624F6AAA0C0CC1 /* PlayoffBracket.swift in Sources */,
 				CB47F51AA46AEBC59183C449 /* PlayoffBracketView.swift in Sources */,
+				F9A37723FE37F4C30D46D6E1 /* PressableCardButtonStyle.swift in Sources */,
 				6C89029D05AEE66FB2315616 /* Profile.swift in Sources */,
 				77A0EFCEE4340D3A7853BF08 /* ProfileView.swift in Sources */,
 				7D94ADAC136455C3056D5867 /* PushNotificationManager.swift in Sources */,

--- a/Xomper/Core/Theme/PressableCardButtonStyle.swift
+++ b/Xomper/Core/Theme/PressableCardButtonStyle.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// Press-feedback ButtonStyle for tappable cards inside ScrollView /
+/// LazyVStack. Drives a subtle scale + opacity from
+/// `configuration.isPressed`, which SwiftUI's ScrollView correctly
+/// defers until a tap is confirmed — so it never fights scrolls.
+///
+/// **Replaces the broken pattern** (`.buttonStyle(.plain)` + a
+/// `simultaneousGesture(DragGesture(minimumDistance: 0))` that drove
+/// `@State isPressed`). That combination caused taps to fire when the
+/// user meant to scroll: the zero-distance drag swallowed the scroll
+/// pan and SwiftUI couldn't disambiguate. Routing press state through
+/// `ButtonStyle` is the canonical fix.
+struct PressableCardButtonStyle: ButtonStyle {
+    var pressedScale: CGFloat = 0.98
+    var pressedOpacity: Double = 0.92
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? pressedScale : 1.0)
+            .opacity(configuration.isPressed ? pressedOpacity : 1.0)
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+            .contentShape(Rectangle())
+    }
+}
+
+extension ButtonStyle where Self == PressableCardButtonStyle {
+    static var pressableCard: PressableCardButtonStyle { PressableCardButtonStyle() }
+}

--- a/Xomper/Features/Auth/LoginView.swift
+++ b/Xomper/Features/Auth/LoginView.swift
@@ -234,8 +234,6 @@ private struct PrimaryButton: View {
     var isLoading: Bool = false
     let action: () -> Void
 
-    @State private var isPressed = false
-
     enum Style {
         case primary, secondary
     }
@@ -265,14 +263,8 @@ private struct PrimaryButton: View {
             .background(style == .primary ? XomperColors.championGold : XomperColors.surfaceLight)
             .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
         }
+        .buttonStyle(PressableCardButtonStyle(pressedScale: 0.97))
         .disabled(isLoading)
-        .scaleEffect(isPressed ? 0.97 : 1.0)
-        .animation(XomperTheme.defaultAnimation, value: isPressed)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in isPressed = true }
-                .onEnded { _ in isPressed = false }
-        )
         .accessibilityLabel(title)
         .accessibilityAddTraits(.isButton)
     }
@@ -314,8 +306,6 @@ private struct GoogleSignInButton: View {
     var isLoading: Bool = false
     let action: () -> Void
 
-    @State private var isPressed = false
-
     var body: some View {
         Button {
             let generator = UIImpactFeedbackGenerator(style: .medium)
@@ -342,14 +332,8 @@ private struct GoogleSignInButton: View {
                     .fill(Color(hex: 0x4285F4))
             )
         }
+        .buttonStyle(PressableCardButtonStyle(pressedScale: 0.97))
         .disabled(isLoading)
-        .scaleEffect(isPressed ? 0.97 : 1.0)
-        .animation(XomperTheme.defaultAnimation, value: isPressed)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in isPressed = true }
-                .onEnded { _ in isPressed = false }
-        )
         .accessibilityLabel("Continue with Google")
     }
 

--- a/Xomper/Features/DraftHistory/DraftHistoryView.swift
+++ b/Xomper/Features/DraftHistory/DraftHistoryView.swift
@@ -92,7 +92,7 @@ struct DraftHistoryView: View {
                             .background(viewMode == mode ? XomperColors.championGold : Color.clear)
                             .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.pressableCard)
                     .accessibilityLabel(mode.label)
                     .accessibilityAddTraits(viewMode == mode ? .isSelected : [])
                 }
@@ -235,7 +235,7 @@ struct DraftHistoryView: View {
             .background(XomperColors.bgCard)
             .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressableCard)
         .accessibilityLabel(
             "Round \(pick.round), pick \(pick.pickNo). \(pick.playerName), \(pick.playerPosition), \(pick.playerTeam)."
         )
@@ -365,8 +365,6 @@ private struct FilterButton: View {
     let isSelected: Bool
     let action: () -> Void
 
-    @State private var isPressed = false
-
     var body: some View {
         Button {
             let generator = UIImpactFeedbackGenerator(style: .light)
@@ -383,14 +381,7 @@ private struct FilterButton: View {
                 .background(isSelected ? XomperColors.championGold : XomperColors.surfaceLight)
                 .clipShape(Capsule())
         }
-        .buttonStyle(.plain)
-        .scaleEffect(isPressed ? 0.95 : 1.0)
-        .animation(XomperTheme.defaultAnimation, value: isPressed)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in isPressed = true }
-                .onEnded { _ in isPressed = false }
-        )
+        .buttonStyle(PressableCardButtonStyle(pressedScale: 0.95))
         .accessibilityLabel(label)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
@@ -402,8 +393,6 @@ private struct DraftPickCard: View {
     let pick: DraftHistoryRecord
     let playerStore: PlayerStore
     let onTap: () -> Void
-
-    @State private var isPressed = false
 
     private var teamColor: NFLTeamColor {
         NFLTeamColors.color(for: pick.playerTeam)
@@ -433,15 +422,8 @@ private struct DraftPickCard: View {
             )
             .xomperShadow(.sm)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressableCard)
         .disabled(!hasPlayerDetail)
-        .scaleEffect(isPressed ? 0.98 : 1.0)
-        .animation(XomperTheme.defaultAnimation, value: isPressed)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in isPressed = true }
-                .onEnded { _ in isPressed = false }
-        )
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityDescription)
         .accessibilityHint(hasPlayerDetail ? "Double tap to view player details" : "")

--- a/Xomper/Features/Home/SearchResultGroup.swift
+++ b/Xomper/Features/Home/SearchResultGroup.swift
@@ -96,7 +96,7 @@ private struct UserResultRow: View {
             }
             .xomperCard()
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressableCard)
         .accessibilityLabel("View profile for \(user.resolvedDisplayName)")
         .accessibilityHint("Double tap to open profile")
     }
@@ -154,7 +154,7 @@ private struct LeagueResultRow: View {
             }
             .xomperCard()
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressableCard)
         .accessibilityLabel("View \(league.displayName)")
         .accessibilityHint("Double tap to open league")
     }
@@ -206,7 +206,7 @@ private struct PlayerResultRow: View {
             }
             .xomperCard()
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressableCard)
         .accessibilityLabel(accessibilityLabelText)
         .accessibilityHint("Double tap to view player details")
     }

--- a/Xomper/Features/Home/SearchView.swift
+++ b/Xomper/Features/Home/SearchView.swift
@@ -15,7 +15,6 @@ struct SearchView: View {
     var navStore: NavigationStore
 
     @State private var searchStore: SearchStore
-    @State private var searchButtonPressed = false
 
     init(
         leagueStore: LeagueStore,
@@ -93,7 +92,7 @@ struct SearchView: View {
                 )
                 .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressableCard)
         .accessibilityLabel("\(mode.title) search")
         .accessibilityAddTraits(searchStore.mode == mode ? .isSelected : [])
     }
@@ -148,14 +147,7 @@ struct SearchView: View {
                     .background(XomperColors.championGold)
                     .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
             }
-            .buttonStyle(.plain)
-            .scaleEffect(searchButtonPressed ? 0.95 : 1.0)
-            .animation(XomperTheme.defaultAnimation, value: searchButtonPressed)
-            .simultaneousGesture(
-                DragGesture(minimumDistance: 0)
-                    .onChanged { _ in searchButtonPressed = true }
-                    .onEnded { _ in searchButtonPressed = false }
-            )
+            .buttonStyle(PressableCardButtonStyle(pressedScale: 0.95))
             .disabled(searchStore.query.trimmingCharacters(in: .whitespaces).isEmpty || searchStore.isSearching)
             .opacity(searchStore.query.trimmingCharacters(in: .whitespaces).isEmpty ? 0.5 : 1.0)
             .accessibilityLabel("Search")

--- a/Xomper/Features/League/MatchupsView.swift
+++ b/Xomper/Features/League/MatchupsView.swift
@@ -152,7 +152,7 @@ struct MatchupsView: View {
             .background(XomperColors.bgCard)
             .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressableCard)
         .accessibilityLabel("Week \(weekData.week), \(weekData.matchups.count) matchups")
         .accessibilityHint(expandedWeek == weekData.week ? "Collapse" : "Expand to see matchups")
     }
@@ -184,8 +184,6 @@ struct MatchupsView: View {
 private struct MatchupCardView: View {
     let matchup: MatchupHistoryRecord
     let onTap: () -> Void
-
-    @State private var isPressed = false
 
     var body: some View {
         Button {
@@ -219,14 +217,7 @@ private struct MatchupCardView: View {
             )
             .xomperShadow(.sm)
         }
-        .buttonStyle(.plain)
-        .scaleEffect(isPressed ? 0.98 : 1.0)
-        .animation(XomperTheme.defaultAnimation, value: isPressed)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in isPressed = true }
-                .onEnded { _ in isPressed = false }
-        )
+        .buttonStyle(.pressableCard)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityDescription)
         .accessibilityHint("Double tap to view matchup details")

--- a/Xomper/Features/League/PlayoffBracketView.swift
+++ b/Xomper/Features/League/PlayoffBracketView.swift
@@ -96,7 +96,7 @@ struct PlayoffBracketView: View {
                         .background(bracketType == type ? XomperColors.championGold : XomperColors.surfaceLight)
                         .clipShape(Capsule())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.pressableCard)
                 .accessibilityLabel(type.title)
                 .accessibilityAddTraits(bracketType == type ? .isSelected : [])
             }

--- a/Xomper/Features/League/RulesView.swift
+++ b/Xomper/Features/League/RulesView.swift
@@ -335,7 +335,7 @@ private extension RulesView {
                 .background(XomperColors.championGold)
                 .clipShape(Capsule())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressableCard)
         .accessibilityLabel("Propose a new rule")
     }
 
@@ -368,7 +368,7 @@ private extension RulesView {
                             )
                             .clipShape(Capsule())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.pressableCard)
                     .accessibilityLabel("\(filter.rawValue) proposals")
                     .accessibilityAddTraits(rulesStore.proposalFilter == filter ? .isSelected : [])
                 }
@@ -739,7 +739,7 @@ private struct ProposalCardView: View {
                         .foregroundStyle(XomperColors.textMuted)
                         .frame(minWidth: XomperTheme.minTouchTarget, minHeight: XomperTheme.minTouchTarget)
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.pressableCard)
                 .accessibilityLabel("Delete proposal")
             }
         }
@@ -868,7 +868,7 @@ private struct ProposalCardView: View {
                 .background(isVoted ? color : color.opacity(0.15))
                 .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressableCard)
         .accessibilityLabel(label)
     }
 
@@ -928,7 +928,7 @@ private struct RulebookChapterView: View {
                 .frame(minHeight: XomperTheme.minTouchTarget)
                 .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.pressableCard)
             .accessibilityLabel("\(title), \(isExpanded ? "expanded" : "collapsed")")
             .accessibilityHint("Double tap to \(isExpanded ? "collapse" : "expand")")
 

--- a/Xomper/Features/League/StandingsView.swift
+++ b/Xomper/Features/League/StandingsView.swift
@@ -80,7 +80,7 @@ struct StandingsView: View {
                         .background(viewMode == mode ? XomperColors.championGold : XomperColors.surfaceLight)
                         .clipShape(Capsule())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.pressableCard)
                 .accessibilityLabel("\(mode.title) view")
                 .accessibilityAddTraits(viewMode == mode ? .isSelected : [])
             }
@@ -226,8 +226,6 @@ private struct StandingsRowView: View {
     let onTap: () -> Void
     var onProfileTap: (() -> Void)?
 
-    @State private var isPressed = false
-
     var body: some View {
         Button {
             let generator = UIImpactFeedbackGenerator(style: .light)
@@ -253,14 +251,7 @@ private struct StandingsRowView: View {
             )
             .xomperShadow(.sm)
         }
-        .buttonStyle(.plain)
-        .scaleEffect(isPressed ? 0.98 : 1.0)
-        .animation(XomperTheme.defaultAnimation, value: isPressed)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in isPressed = true }
-                .onEnded { _ in isPressed = false }
-        )
+        .buttonStyle(.pressableCard)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityDescription)
         .accessibilityHint("Double tap to view team details")

--- a/Xomper/Features/MatchupHistory/MatchupHistoryBrowserView.swift
+++ b/Xomper/Features/MatchupHistory/MatchupHistoryBrowserView.swift
@@ -107,7 +107,7 @@ struct MatchupHistoryBrowserView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .xomperCard()
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.pressableCard)
 
             if isExpanded {
                 ForEach(bundle.matchups, id: \.id) { record in
@@ -164,7 +164,7 @@ struct MatchupHistoryBrowserView: View {
             .background(XomperColors.bgCard.opacity(0.5))
             .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md, style: .continuous))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressableCard)
     }
 
     /// Surface a placement tag ("CHAMPIONSHIP" / "3RD PLACE" / etc.)

--- a/Xomper/Features/Payouts/PayoutsView.swift
+++ b/Xomper/Features/Payouts/PayoutsView.swift
@@ -68,7 +68,7 @@ struct PayoutsView: View {
                     } label: {
                         projectionRow(projection)
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.pressableCard)
                     .disabled(projection.standings == nil)
                 }
             }

--- a/Xomper/Features/Profile/MyProfileView.swift
+++ b/Xomper/Features/Profile/MyProfileView.swift
@@ -10,7 +10,6 @@ struct MyProfileView: View {
 
     @State private var isSigningOut = false
     @State private var showSignOutConfirmation = false
-    @State private var signOutPressed = false
 
     var body: some View {
         ScrollView {
@@ -211,7 +210,7 @@ struct MyProfileView: View {
             }
             .xomperCard()
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressableCard)
         .accessibilityLabel("View \(league.displayName)")
         .accessibilityHint("Double tap to open league dashboard")
     }
@@ -242,14 +241,7 @@ struct MyProfileView: View {
             .background(XomperColors.errorRed.opacity(0.1))
             .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
         }
-        .buttonStyle(.plain)
-        .scaleEffect(signOutPressed ? 0.97 : 1.0)
-        .animation(XomperTheme.defaultAnimation, value: signOutPressed)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in signOutPressed = true }
-                .onEnded { _ in signOutPressed = false }
-        )
+        .buttonStyle(PressableCardButtonStyle(pressedScale: 0.97))
         .disabled(isSigningOut)
         .padding(.top, XomperTheme.Spacing.md)
         .accessibilityLabel("Sign out")

--- a/Xomper/Features/Profile/ProfileView.swift
+++ b/Xomper/Features/Profile/ProfileView.swift
@@ -145,7 +145,7 @@ struct ProfileView: View {
             }
             .xomperCard()
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressableCard)
         .accessibilityLabel("View \(league.displayName)")
         .accessibilityHint("Double tap to open league")
     }

--- a/Xomper/Features/Shared/ErrorView.swift
+++ b/Xomper/Features/Shared/ErrorView.swift
@@ -4,8 +4,6 @@ struct ErrorView: View {
     let message: String
     var retryAction: (() -> Void)?
 
-    @State private var isPressed = false
-
     var body: some View {
         VStack(spacing: XomperTheme.Spacing.lg) {
             Image(systemName: "exclamationmark.triangle.fill")
@@ -39,13 +37,7 @@ struct ErrorView: View {
                         .background(XomperColors.championGold)
                         .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
                 }
-                .scaleEffect(isPressed ? 0.95 : 1.0)
-                .animation(XomperTheme.defaultAnimation, value: isPressed)
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 0)
-                        .onChanged { _ in isPressed = true }
-                        .onEnded { _ in isPressed = false }
-                )
+                .buttonStyle(PressableCardButtonStyle(pressedScale: 0.95))
             }
         }
         .padding(XomperTheme.Spacing.xl)

--- a/Xomper/Features/Shell/HeaderBar.swift
+++ b/Xomper/Features/Shell/HeaderBar.swift
@@ -73,7 +73,7 @@ struct HeaderBar: View {
                     AvatarView(avatarID: avatarID, size: 36)
                         .frame(width: 44, height: 44)
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.pressableCard)
                 .accessibilityLabel("Open menu")
                 .accessibilityHint("Shows standings, history, roster and settings")
                 .accessibilityAddTraits(.isButton)
@@ -92,7 +92,7 @@ struct HeaderBar: View {
                         .foregroundStyle(XomperColors.championGold)
                         .frame(width: 44, height: 44)
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.pressableCard)
                 .accessibilityLabel("Search")
                 .accessibilityHint("Search for users or leagues")
             }

--- a/Xomper/Features/Shell/SeasonPickerBar.swift
+++ b/Xomper/Features/Shell/SeasonPickerBar.swift
@@ -53,7 +53,7 @@ struct SeasonPickerBar: View {
                 .background(isSelected ? XomperColors.championGold : XomperColors.surfaceLight)
                 .clipShape(Capsule())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressableCard)
         .accessibilityLabel("Season \(season)")
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }

--- a/Xomper/Features/Shell/TrayItem.swift
+++ b/Xomper/Features/Shell/TrayItem.swift
@@ -38,7 +38,7 @@ struct TrayItem: View {
             .background(rowBackground)
             .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg, style: .continuous))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressableCard)
         .accessibilityLabel(destination.title)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }

--- a/Xomper/Features/Shell/TrayProfileCard.swift
+++ b/Xomper/Features/Shell/TrayProfileCard.swift
@@ -54,7 +54,7 @@ struct TrayProfileCard: View {
                     .stroke(Color.white.opacity(0.12), lineWidth: 1)
             )
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressableCard)
         .accessibilityLabel("Open profile for \(displayName ?? email ?? "you")")
     }
 }

--- a/Xomper/Features/TaxiSquad/TaxiSquadView.swift
+++ b/Xomper/Features/TaxiSquad/TaxiSquadView.swift
@@ -130,7 +130,7 @@ struct TaxiSquadView: View {
                     .background(XomperColors.surfaceLight.opacity(0.4))
                     .clipShape(Capsule())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.pressableCard)
                 .accessibilityLabel(sortDescending ? "Sort descending" : "Sort ascending")
             }
         }
@@ -314,8 +314,6 @@ private struct TaxiGroupModeButton: View {
     let isSelected: Bool
     let action: () -> Void
 
-    @State private var isPressed = false
-
     var body: some View {
         Button {
             let generator = UIImpactFeedbackGenerator(style: .light)
@@ -332,14 +330,7 @@ private struct TaxiGroupModeButton: View {
                 .background(isSelected ? XomperColors.championGold : XomperColors.surfaceLight)
                 .clipShape(Capsule())
         }
-        .buttonStyle(.plain)
-        .scaleEffect(isPressed ? 0.95 : 1.0)
-        .animation(XomperTheme.defaultAnimation, value: isPressed)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in isPressed = true }
-                .onEnded { _ in isPressed = false }
-        )
+        .buttonStyle(PressableCardButtonStyle(pressedScale: 0.95))
         .accessibilityLabel("\(mode.label) grouping")
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
@@ -352,8 +343,6 @@ private struct TaxiPlayerCard: View {
     let isStolen: Bool
     let isOwnPlayer: Bool
     let onTap: () -> Void
-
-    @State private var isPressed = false
 
     private var teamColor: NFLTeamColor {
         NFLTeamColors.color(for: player.player.displayTeam)
@@ -381,14 +370,7 @@ private struct TaxiPlayerCard: View {
             )
             .xomperShadow(.sm)
         }
-        .buttonStyle(.plain)
-        .scaleEffect(isPressed ? 0.98 : 1.0)
-        .animation(XomperTheme.defaultAnimation, value: isPressed)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in isPressed = true }
-                .onEnded { _ in isPressed = false }
-        )
+        .buttonStyle(.pressableCard)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityDescription)
         .accessibilityHint("Double tap to view details")
@@ -546,7 +528,7 @@ private struct FilterChip: View {
                 .background(isSelected ? XomperColors.championGold : XomperColors.surfaceLight.opacity(0.4))
                 .clipShape(Capsule())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressableCard)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 }

--- a/Xomper/Features/TaxiSquad/TaxiStealConfirmView.swift
+++ b/Xomper/Features/TaxiSquad/TaxiStealConfirmView.swift
@@ -342,8 +342,6 @@ private struct StealActionButton: View {
     var isDisabled: Bool = false
     let action: () -> Void
 
-    @State private var isPressed = false
-
     private var backgroundColor: Color {
         switch style {
         case .primary: XomperColors.championGold
@@ -374,16 +372,9 @@ private struct StealActionButton: View {
                 .background(backgroundColor)
                 .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(PressableCardButtonStyle(pressedScale: 0.96))
         .disabled(isDisabled)
         .opacity(isDisabled ? 0.5 : 1.0)
-        .scaleEffect(isPressed ? 0.96 : 1.0)
-        .animation(XomperTheme.defaultAnimation, value: isPressed)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in isPressed = true }
-                .onEnded { _ in isPressed = false }
-        )
         .accessibilityLabel(label)
     }
 }

--- a/Xomper/Features/Team/TeamView.swift
+++ b/Xomper/Features/Team/TeamView.swift
@@ -388,8 +388,6 @@ struct PlayerRow: View {
     var slotLabel: String?
     let onTap: () -> Void
 
-    @State private var isPressed = false
-
     private var teamColor: NFLTeamColor {
         NFLTeamColors.color(for: player.displayTeam)
     }
@@ -453,14 +451,7 @@ struct PlayerRow: View {
             )
             .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
         }
-        .buttonStyle(.plain)
-        .scaleEffect(isPressed ? 0.97 : 1.0)
-        .animation(XomperTheme.defaultAnimation, value: isPressed)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in isPressed = true }
-                .onEnded { _ in isPressed = false }
-        )
+        .buttonStyle(PressableCardButtonStyle(pressedScale: 0.97))
         .accessibilityLabel(playerAccessibilityLabel)
         .accessibilityHint("Double tap to view player details")
     }

--- a/Xomper/Features/TeamAnalyzer/TeamAnalyzerView.swift
+++ b/Xomper/Features/TeamAnalyzer/TeamAnalyzerView.swift
@@ -248,7 +248,7 @@ struct TeamAnalyzerView: View {
                 .background(isSelected ? Color.cyan : XomperColors.surfaceLight.opacity(0.4))
                 .clipShape(Capsule())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressableCard)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 }


### PR DESCRIPTION
## Summary
- Root cause of the recurring \"can't scroll, it just clicks into items\" bug: every tappable row used the pattern `Button { } label: { } + .buttonStyle(.plain) + simultaneousGesture(DragGesture(minimumDistance: 0))` driving an `@State isPressed` for press scale/opacity. The zero-distance drag swallowed the parent ScrollView's pan, so taps fired instead of scrolls.
- Fix: introduce `PressableCardButtonStyle` (a proper `ButtonStyle` that uses `configuration.isPressed`). SwiftUI's ScrollView correctly defers ButtonStyle press states until tap is confirmed — it never fights the scroll. Replaced every `.buttonStyle(.plain)` in `Features/` with `.buttonStyle(.pressableCard)` and removed the now-redundant `@State + DragGesture(0)` chains.
- Drawer edge-swipe is unchanged — it was already correctly confined to a 20pt leading strip + `path.count == 0` guard, so it isn't the culprit.

## Files touched
- New: `Xomper/Core/Theme/PressableCardButtonStyle.swift`
- Standings, Matchups, DraftHistory, Payouts, Team, TaxiSquad, MatchupHistory, Search, Login, MyProfile, ErrorView, Playoffs, RulesView, TeamAnalyzer, Profile, Shell chrome (HeaderBar, TrayItem, TrayProfileCard, SeasonPickerBar)

## Test plan
- [ ] Standings: scroll the team list — must not fire any taps until released over a row
- [ ] Matchups: scroll the week list, expand a week, scroll the matchup cards
- [ ] Draft History: scroll vertically in list mode AND horizontally in board mode
- [ ] Payouts: scroll the categories list — only the settled categories tap into the drill-down
- [ ] My Profile: scroll the league list — taps only fire on release
- [ ] Tapping a row still works and still has the press scale/opacity feedback