### PR TITLE
fix: label championship + placement games across all seasons

### DIFF
--- a/Xomper/Core/Models/MatchupHistory.swift
+++ b/Xomper/Core/Models/MatchupHistory.swift
@@ -20,6 +20,12 @@ struct MatchupHistoryRecord: Codable, Identifiable, Sendable {
     let isChampionship: Bool
     let teamADivision: Int
     let teamBDivision: Int
+    /// Final placement this matchup decided, taken from Sleeper's
+    /// playoff bracket (`match.placement`). 1 = championship, 3 = 3rd
+    /// place, 5/7/9/11 = consolation seeding rounds. `nil` for
+    /// regular-season games and for early-round playoff games whose
+    /// match doesn't carry a placement.
+    let playoffPlacement: Int?
 
     var id: String { "\(leagueId)-\(season)-\(week)-\(matchupId)" }
 
@@ -43,5 +49,74 @@ struct MatchupHistoryRecord: Codable, Identifiable, Sendable {
         case isChampionship = "is_championship"
         case teamADivision = "team_a_division"
         case teamBDivision = "team_b_division"
+        case playoffPlacement = "playoff_placement"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        leagueId = try c.decode(String.self, forKey: .leagueId)
+        season = try c.decode(String.self, forKey: .season)
+        week = try c.decode(Int.self, forKey: .week)
+        matchupId = try c.decode(Int.self, forKey: .matchupId)
+        teamARosterId = try c.decode(Int.self, forKey: .teamARosterId)
+        teamAUserId = try c.decode(String.self, forKey: .teamAUserId)
+        teamAUsername = try c.decode(String.self, forKey: .teamAUsername)
+        teamATeamName = try c.decode(String.self, forKey: .teamATeamName)
+        teamAPoints = try c.decode(Double.self, forKey: .teamAPoints)
+        teamBRosterId = try c.decode(Int.self, forKey: .teamBRosterId)
+        teamBUserId = try c.decode(String.self, forKey: .teamBUserId)
+        teamBUsername = try c.decode(String.self, forKey: .teamBUsername)
+        teamBTeamName = try c.decode(String.self, forKey: .teamBTeamName)
+        teamBPoints = try c.decode(Double.self, forKey: .teamBPoints)
+        winnerRosterId = try c.decodeIfPresent(Int.self, forKey: .winnerRosterId)
+        isPlayoff = try c.decode(Bool.self, forKey: .isPlayoff)
+        isChampionship = try c.decode(Bool.self, forKey: .isChampionship)
+        teamADivision = try c.decode(Int.self, forKey: .teamADivision)
+        teamBDivision = try c.decode(Int.self, forKey: .teamBDivision)
+        playoffPlacement = try c.decodeIfPresent(Int.self, forKey: .playoffPlacement)
+    }
+
+    init(
+        leagueId: String,
+        season: String,
+        week: Int,
+        matchupId: Int,
+        teamARosterId: Int,
+        teamAUserId: String,
+        teamAUsername: String,
+        teamATeamName: String,
+        teamAPoints: Double,
+        teamBRosterId: Int,
+        teamBUserId: String,
+        teamBUsername: String,
+        teamBTeamName: String,
+        teamBPoints: Double,
+        winnerRosterId: Int?,
+        isPlayoff: Bool,
+        isChampionship: Bool,
+        teamADivision: Int,
+        teamBDivision: Int,
+        playoffPlacement: Int? = nil
+    ) {
+        self.leagueId = leagueId
+        self.season = season
+        self.week = week
+        self.matchupId = matchupId
+        self.teamARosterId = teamARosterId
+        self.teamAUserId = teamAUserId
+        self.teamAUsername = teamAUsername
+        self.teamATeamName = teamATeamName
+        self.teamAPoints = teamAPoints
+        self.teamBRosterId = teamBRosterId
+        self.teamBUserId = teamBUserId
+        self.teamBUsername = teamBUsername
+        self.teamBTeamName = teamBTeamName
+        self.teamBPoints = teamBPoints
+        self.winnerRosterId = winnerRosterId
+        self.isPlayoff = isPlayoff
+        self.isChampionship = isChampionship
+        self.teamADivision = teamADivision
+        self.teamBDivision = teamBDivision
+        self.playoffPlacement = playoffPlacement
     }
 }

--- a/Xomper/Core/Stores/HistoryStore.swift
+++ b/Xomper/Core/Stores/HistoryStore.swift
@@ -511,9 +511,19 @@ final class HistoryStore {
         // Load users + rosters in parallel
         async let usersTask = apiClient.fetchLeagueUsers(league.leagueId)
         async let rostersTask = apiClient.fetchLeagueRosters(league.leagueId)
+        // Brackets — best-effort. Pre-playoff seasons return empty arrays;
+        // missing brackets just mean no placement labels for that season.
+        async let winnersTask: [PlayoffBracketMatch] = {
+            (try? await apiClient.fetchWinnersBracket(league.leagueId)) ?? []
+        }()
+        async let losersTask: [PlayoffBracketMatch] = {
+            (try? await apiClient.fetchLosersBracket(league.leagueId)) ?? []
+        }()
 
         let users = try await usersTask
         let rosters = try await rostersTask
+        let winners = await winnersTask
+        let losers = await losersTask
 
         let totalWeeks = 17
 
@@ -540,13 +550,57 @@ final class HistoryStore {
             return results.sorted { $0.0 < $1.0 }
         }
 
+        let placementMap = Self.buildPlacementMap(
+            winners: winners,
+            losers: losers,
+            playoffWeekStart: Self.playoffWeekStart(for: league)
+        )
+
         return convertMatchupResults(
             leagueId: league.leagueId,
             season: league.season,
             weekResults: weekResults,
             users: users,
-            rosters: rosters
+            rosters: rosters,
+            placementMap: placementMap
         )
+    }
+
+    /// `(week, sorted roster pair)` → placement, derived from a
+    /// league's bracket. Sorted to make the lookup direction-agnostic.
+    /// Only matches with a non-nil `placement` and both roster IDs
+    /// resolved are included — early-round games stay unlabeled.
+    private nonisolated static func buildPlacementMap(
+        winners: [PlayoffBracketMatch],
+        losers: [PlayoffBracketMatch],
+        playoffWeekStart: Int?
+    ) -> [String: Int] {
+        guard let start = playoffWeekStart else { return [:] }
+        var map: [String: Int] = [:]
+        for match in winners + losers {
+            guard let placement = match.placement,
+                  let r1 = match.team1RosterId,
+                  let r2 = match.team2RosterId else { continue }
+            // Round 1 → playoff_week_start, round 2 → +1, etc.
+            // (`playoff_round_type=1` two-week rounds aren't modeled —
+            // placement still resolves on the second/final week.)
+            let week = start + match.round - 1
+            let key = bracketKeyStatic(week: week, rosters: [r1, r2])
+            map[key] = placement
+        }
+        return map
+    }
+
+    private nonisolated static func bracketKeyStatic(week: Int, rosters: [Int]) -> String {
+        let sorted = rosters.sorted()
+        return "\(week)-\(sorted.map(String.init).joined(separator: "-"))"
+    }
+
+    private nonisolated static func playoffWeekStart(for league: League) -> Int? {
+        guard let value = league.settings?.additionalSettings?["playoff_week_start"] else { return nil }
+        if let i = value.intValue { return i }
+        if let d = value.doubleValue { return Int(d) }
+        return nil
     }
 
     // MARK: - Private: Pair Matchups
@@ -579,7 +633,8 @@ final class HistoryStore {
         season: String,
         weekResults: [(week: Int, pairs: [MatchupPair])],
         users: [SleeperUser],
-        rosters: [Roster]
+        rosters: [Roster],
+        placementMap: [String: Int] = [:]
     ) -> [MatchupHistoryRecord] {
         var records: [MatchupHistoryRecord] = []
 
@@ -602,6 +657,12 @@ final class HistoryStore {
                     winnerId = nil
                 }
 
+                let placementKey = Self.bracketKeyStatic(
+                    week: week,
+                    rosters: [pair.teamA.rosterId, pair.teamB.rosterId]
+                )
+                let placement = placementMap[placementKey]
+
                 let record = MatchupHistoryRecord(
                     leagueId: leagueId,
                     season: season,
@@ -619,9 +680,14 @@ final class HistoryStore {
                     teamBPoints: pointsB,
                     winnerRosterId: winnerId,
                     isPlayoff: week > 14,
-                    isChampionship: week == 16 || week == 17,
+                    // Authoritative championship flag: only the bracket
+                    // game with placement == 1 is the title game. Falls
+                    // back to the loose week-16/17 flag when the bracket
+                    // wasn't loaded (legacy/empty-bracket leagues).
+                    isChampionship: placement == 1 || (placementMap.isEmpty && (week == 16 || week == 17)),
                     teamADivision: rosterA?.division ?? 0,
-                    teamBDivision: rosterB?.division ?? 0
+                    teamBDivision: rosterB?.division ?? 0,
+                    playoffPlacement: placement
                 )
 
                 records.append(record)

--- a/Xomper/Features/MatchupHistory/MatchupHistoryBrowserView.swift
+++ b/Xomper/Features/MatchupHistory/MatchupHistoryBrowserView.swift
@@ -39,7 +39,6 @@ struct MatchupHistoryBrowserView: View {
         .background(XomperColors.bgDark.ignoresSafeArea())
         .task(id: leagueStore.myLeague?.leagueId) {
             await ensureLoaded()
-            await ensureBracketLoaded()
         }
         .refreshable {
             await reload()
@@ -168,16 +167,13 @@ struct MatchupHistoryBrowserView: View {
     }
 
     /// Surface a placement tag ("CHAMPIONSHIP" / "3RD PLACE" / etc.)
-    /// on matchup rows. Cross-references the playoff bracket for an
-    /// authoritative answer — `MatchupHistoryRecord.isChampionship`
-    /// is set for ALL week-16/17 records by HistoryStore (loose flag),
-    /// which made every playoff matchup in the same week show
-    /// "CHAMPIONSHIP" before. Only matches whose roster pair appears
-    /// in the bracket at a placement-bearing slot get tagged here;
-    /// other playoff games show "PLAYOFFS · WEEK N".
+    /// on matchup rows. Reads the placement stamped onto each record
+    /// at ingest by HistoryStore (which loads each league's bracket
+    /// per-season — so labels work for past seasons too, not just the
+    /// currently-anchored league). Other playoff games show
+    /// "PLAYOFFS · WEEK N".
     private func placementLabel(for record: MatchupHistoryRecord) -> String? {
-        let key = bracketKey(week: record.week, rosters: [record.teamARosterId, record.teamBRosterId])
-        if let placement = placementByKey[key] {
+        if let placement = record.playoffPlacement {
             return placementCopy(for: placement)
         }
         if record.isPlayoff {
@@ -197,45 +193,6 @@ struct MatchupHistoryBrowserView: View {
         case 11: return "11TH PLACE"
         default: return "\(placement) PLACE"
         }
-    }
-
-    /// (week, sorted roster pair) → placement, derived from the
-    /// playoff brackets. Sorted to make the lookup direction-agnostic.
-    private var placementByKey: [String: Int] {
-        var map: [String: Int] = [:]
-        let allMatches = (leagueStore.winnersBracket ?? []) + (leagueStore.losersBracket ?? [])
-        guard let weekStart = playoffWeekStart else { return map }
-        for match in allMatches {
-            guard let placement = match.placement,
-                  let r1 = match.team1RosterId,
-                  let r2 = match.team2RosterId else { continue }
-            // Round → NFL week mapping mirrors PlayoffBracketView's
-            // resolution. `playoff_round_type=1` two-week rounds aren't
-            // modeled; the placement still applies on the second week.
-            let week = weekStart + match.round - 1
-            map[bracketKey(week: week, rosters: [r1, r2])] = placement
-        }
-        return map
-    }
-
-    private var playoffWeekStart: Int? {
-        guard let value = leagueStore.myLeague?.settings?.additionalSettings?["playoff_week_start"] else {
-            return nil
-        }
-        if let i = value.intValue { return i }
-        if let d = value.doubleValue { return Int(d) }
-        return nil
-    }
-
-    private func bracketKey(week: Int, rosters: [Int]) -> String {
-        let sorted = rosters.sorted()
-        return "\(week)-\(sorted.map(String.init).joined(separator: "-"))"
-    }
-
-    private func ensureBracketLoaded() async {
-        guard leagueStore.winnersBracket == nil || leagueStore.losersBracket == nil,
-              let leagueId = leagueStore.myLeague?.leagueId else { return }
-        await leagueStore.fetchBrackets(leagueId: leagueId)
     }
 
     private func teamColumn(name: String, points: Double, isWinner: Bool, showOutcome: Bool) -> some View {


### PR DESCRIPTION
## Summary
- Previous fix removed all playoff labels from matchup history (overcorrection from the \"every week 17 said CHAMPIONSHIP\" bug).
- Root cause: placement lookup cross-referenced \`leagueStore.winnersBracket\` which only holds the *current* league's bracket — past seasons couldn't resolve, and the current season depended on a separate bracket fetch landing in time.
- Move placement resolution into the history ingest: \`HistoryStore.fetchSeasonMatchups\` now also fetches each league's winners + losers brackets in parallel and stamps a \`playoffPlacement: Int?\` onto every \`MatchupHistoryRecord\`.
- View reads \`record.playoffPlacement\` directly — no per-view bracket fetch needed, works for current AND past seasons.
- \`isChampionship\` is now strict (placement == 1) when the bracket loaded, with fallback to the legacy week-16/17 rule when brackets are missing. Trophy case selection still works.

## Test plan
- [ ] Matchup History → 2025 → final week shows CHAMPIONSHIP on the title game, 3RD PLACE on the consolation final, 5TH/7TH/etc. on losers' bracket games
- [ ] Matchup History → 2024 → same labels resolve for that season
- [ ] Trophy case on profile still shows correct championship wins (no duplicates from week 16 + 17)
- [ ] Regular-season weeks have no placement label
- [ ] First-round playoff games (no placement) show \"PLAYOFFS · WEEK N\"