### PR TITLE
feat: season switcher on Payouts + historical projections

### DIFF
--- a/Xomper/Core/Models/PayoutProjection.swift
+++ b/Xomper/Core/Models/PayoutProjection.swift
@@ -47,10 +47,9 @@ struct PayoutProjection: Sendable, Identifiable {
 @MainActor
 enum PayoutCalculator {
 
-    /// Builds projections for every configured category. Pure
-    /// derivation from the existing stores — no network. Categories
-    /// the data doesn't support (position MVPs without per-player
-    /// scoring) come back with `unavailableReason` set.
+    /// Current-season projections. Uses the live league snapshot
+    /// (standings, roster, bracket, per-player starter points) so
+    /// every category can be resolved.
     static func project(
         payouts: LeaguePayouts,
         standings: [StandingsTeam],
@@ -85,6 +84,115 @@ enum PayoutCalculator {
                 )
             }
         }
+    }
+
+    /// Historical-season projections. Live snapshots aren't available
+    /// for past leagues (rosters/playerPoints/bracket are anchored to
+    /// the current league only), so this branch derives everything it
+    /// can from the persisted matchup history (W-L-PF, weekly highs,
+    /// championship/runner-up/3rd from `record.playoffPlacement`
+    /// stamped at ingest by HistoryStore). Position MVPs and any
+    /// category that needs per-player starter aggregation degrade
+    /// with `unavailableReason` so the structure of the past season's
+    /// pot is still visible.
+    static func projectHistorical(
+        season: String,
+        payouts: LeaguePayouts,
+        matchupHistory: [MatchupHistoryRecord],
+        userId: String?
+    ) -> [PayoutProjection] {
+        let seasonRecords = matchupHistory.filter { $0.season == season }
+        let standings = StandingsBuilder.buildStandingsFromHistory(records: seasonRecords)
+
+        return payouts.categories.map { category in
+            switch category.kind {
+            case .champion:
+                return historicalPlacement(category: category, placement: 1, records: seasonRecords, userId: userId)
+            case .runnerUp:
+                return historicalPlacement(category: category, placement: 2, records: seasonRecords, userId: userId)
+            case .thirdPlace:
+                return historicalPlacement(category: category, placement: 3, records: seasonRecords, userId: userId)
+            case .seasonHighPF:
+                return seasonHighPF(category: category, standings: standings, userId: userId)
+            case .weeklyHighScore:
+                return weeklyHigh(category: category, matchupHistory: seasonRecords, standings: standings, userId: userId)
+            case .positionMVP:
+                return PayoutProjection(
+                    category: category,
+                    leader: nil,
+                    userPlacement: .notApplicable,
+                    projectedAmount: 0,
+                    standings: nil,
+                    unavailableReason: "Per-player history not retained for past seasons."
+                )
+            }
+        }
+    }
+
+    // MARK: - Historical placement (champion / runner-up / 3rd)
+
+    /// Resolve the team that earned a given playoff `placement` for a
+    /// past season directly from the stamped `playoffPlacement` field
+    /// on matchup history records — no live bracket needed.
+    /// Placement 1 = winning team of the championship game, 2 = the
+    /// loser, 3 = winning team of the 3rd-place game.
+    private static func historicalPlacement(
+        category: LeaguePayoutCategory,
+        placement: Int,
+        records: [MatchupHistoryRecord],
+        userId: String?
+    ) -> PayoutProjection {
+        // For placements 1 and 3, the bracket places the *winner* of
+        // that placement match. For placement 2 (runner-up), it's the
+        // loser of the championship (placement-1) match.
+        let lookupPlacement = (placement == 2) ? 1 : placement
+        guard let match = records.first(where: { $0.playoffPlacement == lookupPlacement }) else {
+            return PayoutProjection(
+                category: category,
+                leader: nil,
+                userPlacement: .notApplicable,
+                projectedAmount: 0,
+                standings: nil,
+                unavailableReason: "No \(category.label) game recorded this season."
+            )
+        }
+
+        let targetRosterId: Int? = {
+            switch placement {
+            case 1, 3:
+                return match.winnerRosterId
+            case 2:
+                guard let winner = match.winnerRosterId else { return nil }
+                return winner == match.teamARosterId ? match.teamBRosterId : match.teamARosterId
+            default:
+                return nil
+            }
+        }()
+
+        guard let rid = targetRosterId else {
+            return PayoutProjection(
+                category: category,
+                leader: nil,
+                userPlacement: .notApplicable,
+                projectedAmount: 0,
+                standings: nil,
+                unavailableReason: "Result tied or missing."
+            )
+        }
+
+        let isTeamA = rid == match.teamARosterId
+        let winnerUserId = isTeamA ? match.teamAUserId : match.teamBUserId
+        let winnerTeamName = isTeamA ? match.teamATeamName : match.teamBTeamName
+        let isMine = winnerUserId == userId
+
+        return PayoutProjection(
+            category: category,
+            leader: .init(userId: winnerUserId, teamName: winnerTeamName, displayValue: ""),
+            userPlacement: isMine ? .won(amount: category.amount) : .behind(by: ""),
+            projectedAmount: isMine ? category.amount : 0,
+            standings: nil,
+            unavailableReason: nil
+        )
     }
 
     // MARK: - Position MVP

--- a/Xomper/Core/Stores/StandingsStore.swift
+++ b/Xomper/Core/Stores/StandingsStore.swift
@@ -61,6 +61,118 @@ enum StandingsBuilder {
         return teams
     }
 
+    // MARK: - Build From Matchup History
+
+    /// Reconstruct a season's standings from `MatchupHistoryRecord`s
+    /// alone — no live roster data needed. Used by Payouts when the
+    /// user picks a past season's chip; that league's roster snapshot
+    /// is no longer in `LeagueStore.myLeagueRosters` (those track the
+    /// currently-anchored league only).
+    ///
+    /// Wins / losses / ties / PF aggregate over **regular-season**
+    /// records only (`isPlayoff == false`). Tiebreak: wins desc, then
+    /// PF desc — same as the live builder.
+    static func buildStandingsFromHistory(
+        records: [MatchupHistoryRecord]
+    ) -> [StandingsTeam] {
+        // First pass — aggregate per-roster regular-season stats and
+        // capture the most recent display fields we see for that team.
+        struct Aggregate {
+            var rosterId: Int
+            var userId: String
+            var username: String
+            var teamName: String
+            var wins: Int = 0
+            var losses: Int = 0
+            var ties: Int = 0
+            var fpts: Double = 0
+            var fptsAgainst: Double = 0
+        }
+        var byRoster: [Int: Aggregate] = [:]
+
+        func upsert(rosterId: Int, userId: String, username: String, teamName: String) {
+            if byRoster[rosterId] == nil {
+                byRoster[rosterId] = Aggregate(
+                    rosterId: rosterId,
+                    userId: userId,
+                    username: username,
+                    teamName: teamName.isEmpty ? "\(username)'s Team" : teamName
+                )
+            }
+        }
+
+        for record in records {
+            upsert(
+                rosterId: record.teamARosterId,
+                userId: record.teamAUserId,
+                username: record.teamAUsername,
+                teamName: record.teamATeamName
+            )
+            upsert(
+                rosterId: record.teamBRosterId,
+                userId: record.teamBUserId,
+                username: record.teamBUsername,
+                teamName: record.teamBTeamName
+            )
+
+            // Only regular-season weeks count toward standings.
+            guard !record.isPlayoff else { continue }
+            // Skip empty/preseason placeholder weeks.
+            guard record.teamAPoints > 0 || record.teamBPoints > 0 else { continue }
+
+            byRoster[record.teamARosterId]?.fpts += record.teamAPoints
+            byRoster[record.teamARosterId]?.fptsAgainst += record.teamBPoints
+            byRoster[record.teamBRosterId]?.fpts += record.teamBPoints
+            byRoster[record.teamBRosterId]?.fptsAgainst += record.teamAPoints
+
+            if let winner = record.winnerRosterId {
+                if winner == record.teamARosterId {
+                    byRoster[record.teamARosterId]?.wins += 1
+                    byRoster[record.teamBRosterId]?.losses += 1
+                } else if winner == record.teamBRosterId {
+                    byRoster[record.teamBRosterId]?.wins += 1
+                    byRoster[record.teamARosterId]?.losses += 1
+                }
+            } else {
+                byRoster[record.teamARosterId]?.ties += 1
+                byRoster[record.teamBRosterId]?.ties += 1
+            }
+        }
+
+        var teams: [StandingsTeam] = byRoster.values.map { agg in
+            StandingsTeam(
+                rosterId: agg.rosterId,
+                userId: agg.userId,
+                username: agg.username,
+                displayName: agg.username,
+                teamName: agg.teamName,
+                avatarId: nil,
+                division: 0,
+                divisionName: "",
+                divisionAvatar: nil,
+                wins: agg.wins,
+                losses: agg.losses,
+                ties: agg.ties,
+                fpts: agg.fpts,
+                fptsAgainst: agg.fptsAgainst,
+                streak: .none,
+                leagueRank: 0,
+                divisionRank: 0
+            )
+        }
+
+        teams.sort { a, b in
+            if a.wins != b.wins { return a.wins > b.wins }
+            return a.fpts > b.fpts
+        }
+
+        for i in teams.indices {
+            teams[i].leagueRank = i + 1
+        }
+
+        return teams
+    }
+
     // MARK: - Build Division Standings
 
     /// Groups teams by division and assigns per-division ranks.

--- a/Xomper/Features/Payouts/PayoutsView.swift
+++ b/Xomper/Features/Payouts/PayoutsView.swift
@@ -1,20 +1,35 @@
 import SwiftUI
 
-/// Projects the signed-in user's current payout total based on the
-/// hardcoded `LeaguePayouts.charlotteDynastyDefault` structure +
-/// derived stats (champion bracket, season-high PF, weekly-high tally).
-/// Categories that need data we don't yet aggregate (position MVPs)
-/// render as "Coming soon" rows so the structure is visible.
+/// Projects payouts for the season the user has selected via the
+/// shared `SeasonStore` chip. Defaults to the current NFL season.
+/// For the current season, every category resolves from live data
+/// (live standings, bracket, per-player starter points). For past
+/// seasons, falls back to history-derived projections — championship
+/// / runner-up / 3rd from `MatchupHistoryRecord.playoffPlacement`,
+/// weekly high + season high PF from filtered matchup history.
+/// Position MVPs degrade with an explanation since per-player history
+/// isn't kept across seasons.
 struct PayoutsView: View {
     var leagueStore: LeagueStore
     var historyStore: HistoryStore
     var playerStore: PlayerStore
     var playerPointsStore: PlayerPointsStore
     var authStore: AuthStore
+    var nflStateStore: NflStateStore
+
+    @Environment(\.selectedSeason) private var seasonStore: SeasonStore?
 
     private let payouts: LeaguePayouts = .charlotteDynastyDefault
 
     @State private var selectedDrillDown: PayoutProjection?
+
+    private var selectedSeason: String {
+        seasonStore?.selectedSeason ?? nflStateStore.currentSeason
+    }
+
+    private var isCurrentSeason: Bool {
+        selectedSeason == nflStateStore.currentSeason
+    }
 
     var body: some View {
         Group {
@@ -42,17 +57,27 @@ struct PayoutsView: View {
     // MARK: - Content
 
     private var content: some View {
-        let standings = computedStandings
-        let projections = PayoutCalculator.project(
-            payouts: payouts,
-            standings: standings,
-            matchupHistory: historyStore.matchupHistory,
-            winnersBracket: leagueStore.winnersBracket,
-            rosters: leagueStore.myLeagueRosters,
-            playerStore: playerStore,
-            playerPointsStore: playerPointsStore,
-            userId: authStore.sleeperUserId
-        )
+        let projections: [PayoutProjection] = {
+            if isCurrentSeason {
+                return PayoutCalculator.project(
+                    payouts: payouts,
+                    standings: computedStandings,
+                    matchupHistory: historyStore.matchupHistory,
+                    winnersBracket: leagueStore.winnersBracket,
+                    rosters: leagueStore.myLeagueRosters,
+                    playerStore: playerStore,
+                    playerPointsStore: playerPointsStore,
+                    userId: authStore.sleeperUserId
+                )
+            } else {
+                return PayoutCalculator.projectHistorical(
+                    season: selectedSeason,
+                    payouts: payouts,
+                    matchupHistory: historyStore.matchupHistory,
+                    userId: authStore.sleeperUserId
+                )
+            }
+        }()
         let projected = projections.map(\.projectedAmount).reduce(0, +)
         let upside = payouts.totalUpside
 
@@ -81,7 +106,7 @@ struct PayoutsView: View {
 
     private func summaryCard(projected: Double, upside: Double) -> some View {
         VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
-            Text("Projected payout")
+            Text(isCurrentSeason ? "Projected payout · \(selectedSeason)" : "\(selectedSeason) earnings")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(XomperColors.textMuted)
                 .textCase(.uppercase)
@@ -96,7 +121,11 @@ struct PayoutsView: View {
                 .font(.caption)
                 .foregroundStyle(XomperColors.textSecondary)
 
-            Text("Based on current league data + the hardcoded payout structure. Tap any settled category for the full breakdown.")
+            Text(
+                isCurrentSeason
+                    ? "Based on current league data + the hardcoded payout structure. Tap any settled category for the full breakdown."
+                    : "Settled payouts for the \(selectedSeason) season. Position MVPs aren't retained for past seasons."
+            )
                 .font(.caption2)
                 .foregroundStyle(XomperColors.textMuted)
                 .padding(.top, XomperTheme.Spacing.xs)

--- a/Xomper/Features/Shell/HeaderBar.swift
+++ b/Xomper/Features/Shell/HeaderBar.swift
@@ -28,6 +28,7 @@ struct HeaderBar: View {
         .matchups,
         .draftHistory,
         .matchupHistory,
+        .payouts,
     ]
 
     var body: some View {

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -195,7 +195,8 @@ struct MainShell: View {
                     historyStore: historyStore,
                     playerStore: playerStore,
                     playerPointsStore: playerPointsStore,
-                    authStore: authStore
+                    authStore: authStore,
+                    nflStateStore: nflStateStore
                 )
 
             case .draftOrder:


### PR DESCRIPTION
## Summary
- Adds a season picker to the Payouts page (defaults to current NFL season). Reuses the existing \`SeasonStore\`.
- New \`PayoutCalculator.projectHistorical(season:...)\` derives champion / runner-up / 3rd from \`MatchupHistoryRecord.playoffPlacement\` (stamped at ingest in #69), plus Weekly High and Season High PF from filtered records.
- Position MVPs degrade with an explanation since per-player history isn't retained across seasons.
- Lets the user verify last year's earnings — pick 2024, see which categories paid out.

## Test plan
- [ ] Open Payouts → defaults to 2026 chip
- [ ] Tap 2024 chip → header shows \"2024 earnings\" and projected dollar total updates
- [ ] Champion / runner-up / 3rd place rows show the actual 2024 winners (matches Sleeper bracket)
- [ ] Weekly High shows weeks-won tally for the user across the 2024 regular season
- [ ] Position MVP rows show \"Per-player history not retained for past seasons.\"
- [ ] Switch back to 2026 → live calculator returns and all categories resolve normally