### PR TITLE
fix: remove duplicate Team Analyzer title

### DIFF
--- a/Xomper/Features/TeamAnalyzer/TeamAnalyzerView.swift
+++ b/Xomper/Features/TeamAnalyzer/TeamAnalyzerView.swift
@@ -96,18 +96,14 @@ struct TeamAnalyzerView: View {
     // MARK: - Header
 
     private func headerCard(my: TeamAnalysis, opp: TeamAnalysis?) -> some View {
-        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
-            Text("Team Analyzer")
-                .font(.title2.weight(.bold))
-                .foregroundStyle(XomperColors.textPrimary)
-
-            Text(opp == nil
-                ? "Your roster, valued by position group."
-                : "Comparing your team vs \(opp!.teamName)."
-            )
-            .font(.subheadline)
-            .foregroundStyle(XomperColors.textSecondary)
-        }
+        // Page title is rendered by `MainShell.navigationTitle` —
+        // don't repeat it here. Just surface the comparison subtitle.
+        Text(opp == nil
+            ? "Your roster, valued by position group."
+            : "Comparing your team vs \(opp!.teamName)."
+        )
+        .font(.subheadline)
+        .foregroundStyle(XomperColors.textSecondary)
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, XomperTheme.Spacing.md)
     }


### PR DESCRIPTION
## Summary
The page rendered \"Team Analyzer\" twice — once from \`MainShell\`'s navigation title, and again as a \`.title2\` Text inside the view's header card. Drops the in-view title; the comparison subtitle stays.

## Test plan
- [ ] Open Team Analyzer → only one \"Team Analyzer\" title visible (the large nav header)
- [ ] Subtitle still reads \"Comparing your team vs ...\" or \"Your roster, valued by position group.\"