### PR TITLE
feat: trade analyzer v1 — builder + live verdict + balance suggester

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		3E5A98150356BEB75FD87145 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = 72178EB48829A7D249085476 /* Supabase */; };
 		40C507B6FB2EF2A7E647AA3C /* TeamStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36A01820FD0F6643BBF8511D /* TeamStore.swift */; };
 		427F23653F78A52108C55692 /* XomperLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3B178733D5AF9EB7DA7189 /* XomperLoader.swift */; };
+		42E7DDAD3454512247E1AFA6 /* ProposedTrade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4690614F644FE74115D0DAB6 /* ProposedTrade.swift */; };
 		4A321187068EEBA8C4E75EFE /* PayoutProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E3BE36BCEA1A7722157C37 /* PayoutProjection.swift */; };
 		4B629DB100C96EB68A6A9A41 /* SearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323F422F2D0E1C2BA5D46C0A /* SearchResults.swift */; };
 		4DB9374CF45A69E97C02FC94 /* PlayerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC44D14381C74E97D8AF868F /* PlayerDetailView.swift */; };
@@ -149,6 +150,7 @@
 		44F83A5F997AF6E13C98660E /* WorldCupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupView.swift; sourceTree = "<group>"; };
 		45B52D5FD69B62417928B713 /* MatchupHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupHistory.swift; sourceTree = "<group>"; };
 		460030AF84E8D0E83D8F5896 /* Xomper.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Xomper.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		4690614F644FE74115D0DAB6 /* ProposedTrade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProposedTrade.swift; sourceTree = "<group>"; };
 		501B8FD2B915B3BD6568F42C /* HexagonChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HexagonChartView.swift; sourceTree = "<group>"; };
 		536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthStore.swift; sourceTree = "<group>"; };
 		558164667DF7D89C4DF2F32E /* MyProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyProfileView.swift; sourceTree = "<group>"; };
@@ -449,6 +451,7 @@
 				BE87151F7F5AAB8F12F98B91 /* PlayerValue.swift */,
 				6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */,
 				42C8A3FA617E9FEB48852C45 /* Profile.swift */,
+				4690614F644FE74115D0DAB6 /* ProposedTrade.swift */,
 				AE543CB2E49335ADD02E8000 /* Roster.swift */,
 				9B7C85CB880ABD7D373E49A6 /* RuleProposal.swift */,
 				B29D510D87CD290AE7F76FBF /* StandingsTeam.swift */,
@@ -753,6 +756,7 @@
 				F9A37723FE37F4C30D46D6E1 /* PressableCardButtonStyle.swift in Sources */,
 				6C89029D05AEE66FB2315616 /* Profile.swift in Sources */,
 				77A0EFCEE4340D3A7853BF08 /* ProfileView.swift in Sources */,
+				42E7DDAD3454512247E1AFA6 /* ProposedTrade.swift in Sources */,
 				7D94ADAC136455C3056D5867 /* PushNotificationManager.swift in Sources */,
 				76260F26A40213A62E5F22FB /* RecordBadge.swift in Sources */,
 				54863F3F6ECDD3BE00083582 /* Roster.swift in Sources */,

--- a/Xomper/Core/Models/ProposedTrade.swift
+++ b/Xomper/Core/Models/ProposedTrade.swift
@@ -1,0 +1,198 @@
+import Foundation
+
+/// A proposed trade between two teams in the home league. Each side
+/// holds a roster of player IDs (extending later to draft picks per
+/// the open question in #75).
+///
+/// Pure value type — held by the Trade tab's `@State`. Evaluator runs
+/// in `TradeEvaluator.evaluate(_:against:)` and returns a fresh
+/// `TradeEvaluation` on every change.
+struct ProposedTrade: Sendable, Hashable {
+    var sideA: TradeSide
+    var sideB: TradeSide
+
+    static let empty = ProposedTrade(
+        sideA: TradeSide(rosterId: 0, teamName: "", playerIds: []),
+        sideB: TradeSide(rosterId: 0, teamName: "", playerIds: [])
+    )
+
+    var isEmpty: Bool {
+        sideA.playerIds.isEmpty && sideB.playerIds.isEmpty
+    }
+}
+
+struct TradeSide: Sendable, Hashable {
+    let rosterId: Int
+    let teamName: String
+    var playerIds: [String]
+}
+
+// MARK: - Evaluation
+
+/// Result of running `TradeEvaluator` over a `ProposedTrade`. Drives
+/// the live evaluation strip + verdict pill in the trade builder.
+struct TradeEvaluation: Sendable, Hashable {
+    let sideAValue: Int
+    let sideBValue: Int
+    let delta: Int
+    let percentGap: Double
+    let verdict: Verdict
+
+    /// Threshold below which a trade is considered "fair." Picked at
+    /// 5% per the issue spec — tight enough that close trades don't
+    /// auto-pass but loose enough to allow the typical
+    /// star-for-depth packages.
+    static let fairThreshold: Double = 0.05
+
+    enum Verdict: Sendable, Hashable {
+        case empty
+        case fair
+        case sideAWins(byPercent: Double)
+        case sideBWins(byPercent: Double)
+
+        var label: String {
+            switch self {
+            case .empty:
+                return "Add players to evaluate"
+            case .fair:
+                return "Fair (within 5%)"
+            case .sideAWins(let pct):
+                return String(format: "Side A wins by %.0f%%", pct * 100)
+            case .sideBWins(let pct):
+                return String(format: "Side B wins by %.0f%%", pct * 100)
+            }
+        }
+
+        var isFair: Bool {
+            if case .fair = self { return true }
+            return false
+        }
+    }
+}
+
+@MainActor
+enum TradeEvaluator {
+
+    /// Run the full evaluation against a `PlayerValuesStore` snapshot.
+    /// Pure function — no side effects, safe to call on every UI
+    /// re-render.
+    static func evaluate(
+        _ trade: ProposedTrade,
+        valuesStore: PlayerValuesStore
+    ) -> TradeEvaluation {
+        let aValue = trade.sideA.playerIds.reduce(0) { $0 + valuesStore.value(for: $1) }
+        let bValue = trade.sideB.playerIds.reduce(0) { $0 + valuesStore.value(for: $1) }
+        let delta = aValue - bValue
+        let larger = max(aValue, bValue)
+        let gap = larger > 0 ? Double(abs(delta)) / Double(larger) : 0
+
+        let verdict: TradeEvaluation.Verdict
+        if trade.isEmpty {
+            verdict = .empty
+        } else if gap <= TradeEvaluation.fairThreshold {
+            verdict = .fair
+        } else if aValue > bValue {
+            verdict = .sideAWins(byPercent: gap)
+        } else {
+            verdict = .sideBWins(byPercent: gap)
+        }
+
+        return TradeEvaluation(
+            sideAValue: aValue,
+            sideBValue: bValue,
+            delta: delta,
+            percentGap: gap,
+            verdict: verdict
+        )
+    }
+
+    /// Suggest add-ons from the *lighter* side that would close the
+    /// gap. Returns up to `limit` players ranked by how close they
+    /// bring the trade to fair, but never overshoots beyond the fair
+    /// threshold (overshoot would just flip the imbalance).
+    ///
+    /// Excludes players already in either side of the trade and
+    /// players the lighter side has already promised away.
+    static func suggestBalance(
+        for trade: ProposedTrade,
+        evaluation: TradeEvaluation,
+        rosters: [Roster],
+        valuesStore: PlayerValuesStore,
+        playerStore: PlayerStore,
+        limit: Int = 5
+    ) -> [SuggestedAddOn] {
+        guard !evaluation.verdict.isFair, !trade.isEmpty else { return [] }
+
+        let lighterSide: TradeSide
+        let lighterValue: Int
+        let heavierValue: Int
+        switch evaluation.verdict {
+        case .sideAWins:
+            lighterSide = trade.sideB
+            lighterValue = evaluation.sideBValue
+            heavierValue = evaluation.sideAValue
+        case .sideBWins:
+            lighterSide = trade.sideA
+            lighterValue = evaluation.sideAValue
+            heavierValue = evaluation.sideBValue
+        default:
+            return []
+        }
+
+        let neededValue = heavierValue - lighterValue
+        // Acceptable range — any single add-on should leave the trade
+        // within fair_threshold on either side. So the candidate's
+        // value must be ≥ minimum that keeps the gap closing without
+        // overshooting fair on the other side.
+        let upperBound = neededValue + Int(Double(heavierValue) * TradeEvaluation.fairThreshold)
+        let lowerBound = neededValue - Int(Double(heavierValue) * TradeEvaluation.fairThreshold)
+
+        guard let roster = rosters.first(where: { $0.rosterId == lighterSide.rosterId }) else {
+            return []
+        }
+
+        let alreadyInTrade = Set(trade.sideA.playerIds + trade.sideB.playerIds)
+
+        let candidates: [SuggestedAddOn] = (roster.players ?? []).compactMap { pid in
+            guard !alreadyInTrade.contains(pid) else { return nil }
+            let value = valuesStore.value(for: pid)
+            guard value > 0 else { return nil }
+            let player = playerStore.player(for: pid)
+            return SuggestedAddOn(
+                playerId: pid,
+                playerName: player?.fullDisplayName ?? "Player #\(pid)",
+                position: player?.displayPosition ?? "?",
+                value: value,
+                gapClosed: abs(value - neededValue)
+            )
+        }
+
+        // Prefer add-ons within the band first; if nothing fits the
+        // band, fall back to closest-to-needed regardless.
+        let inBand = candidates
+            .filter { $0.value >= lowerBound && $0.value <= upperBound }
+            .sorted(by: { $0.gapClosed < $1.gapClosed })
+
+        if !inBand.isEmpty {
+            return Array(inBand.prefix(limit))
+        }
+
+        return Array(
+            candidates
+                .sorted(by: { $0.gapClosed < $1.gapClosed })
+                .prefix(limit)
+        )
+    }
+}
+
+struct SuggestedAddOn: Sendable, Hashable, Identifiable {
+    let playerId: String
+    let playerName: String
+    let position: String
+    let value: Int
+    /// |candidate.value − neededValue|. Lower = closer to a perfectly
+    /// balanced trade after this add-on is included.
+    let gapClosed: Int
+
+    var id: String { playerId }
+}

--- a/Xomper/Features/TeamAnalyzer/TeamAnalyzerView.swift
+++ b/Xomper/Features/TeamAnalyzer/TeamAnalyzerView.swift
@@ -26,6 +26,14 @@ struct TeamAnalyzerView: View {
     @State private var activeTab: AnalyzerTab = .compare
     @State private var comparisonRosterId: Int?
 
+    // Trade-builder state. Lives at the parent so the proposal
+    // survives tab switches; the user can hop to Compare / League
+    // mid-build and come back to the same trade.
+    @State private var tradePartnerRosterId: Int?
+    @State private var tradeSideAPlayerIds: [String] = []
+    @State private var tradeSideBPlayerIds: [String] = []
+    @State private var showSidePicker: TradeSidePickerContext?
+
     var body: some View {
         Group {
             if !valuesStore.hasValues && valuesStore.isLoading {
@@ -87,6 +95,11 @@ struct TeamAnalyzerView: View {
                     axisMaxes: axisMaxes,
                     leagueAverages: leagueAverages,
                     myUserId: authStore.sleeperUserId
+                )
+            case .trade:
+                tradeTab(
+                    my: myAnalysis,
+                    analyses: analyses
                 )
             }
         }
@@ -546,16 +559,539 @@ struct TeamAnalyzerView: View {
     }
 }
 
+// MARK: - Trade tab
+
+extension TeamAnalyzerView {
+
+    @ViewBuilder
+    fileprivate func tradeTab(
+        my: TeamAnalysis?,
+        analyses: [TeamAnalysis]
+    ) -> some View {
+        if let my {
+            tradeBuilder(my: my, analyses: analyses)
+                .sheet(item: $showSidePicker) { context in
+                    NavigationStack {
+                        tradePlayerPicker(
+                            context: context,
+                            my: my,
+                            analyses: analyses
+                        )
+                    }
+                    .presentationDetents([.large])
+                }
+        } else {
+            EmptyStateView(
+                icon: "person.crop.square",
+                title: "Team Not Found",
+                message: "Could not resolve your team in this league."
+            )
+        }
+    }
+
+    private func tradeBuilder(
+        my: TeamAnalysis,
+        analyses: [TeamAnalysis]
+    ) -> some View {
+        let partner = analyses.first { $0.rosterId == tradePartnerRosterId }
+        let trade = currentTrade(my: my, partner: partner)
+        let evaluation = TradeEvaluator.evaluate(trade, valuesStore: valuesStore)
+        let suggestions = TradeEvaluator.suggestBalance(
+            for: trade,
+            evaluation: evaluation,
+            rosters: leagueStore.myLeagueRosters,
+            valuesStore: valuesStore,
+            playerStore: playerStore
+        )
+
+        return ScrollView {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
+                tradeExplainer
+
+                tradePartnerPicker(my: my, analyses: analyses)
+
+                if partner != nil {
+                    tradeEvaluationStrip(evaluation: evaluation)
+
+                    tradeSideCard(
+                        sideLabel: "You give",
+                        teamName: my.teamName,
+                        playerIds: tradeSideAPlayerIds,
+                        sideValue: evaluation.sideAValue,
+                        addAction: {
+                            showSidePicker = TradeSidePickerContext(
+                                side: .a,
+                                rosterId: my.rosterId,
+                                teamName: my.teamName
+                            )
+                        },
+                        removeAction: { pid in
+                            tradeSideAPlayerIds.removeAll { $0 == pid }
+                        }
+                    )
+
+                    if let partner {
+                        tradeSideCard(
+                            sideLabel: "You receive",
+                            teamName: partner.teamName,
+                            playerIds: tradeSideBPlayerIds,
+                            sideValue: evaluation.sideBValue,
+                            addAction: {
+                                showSidePicker = TradeSidePickerContext(
+                                    side: .b,
+                                    rosterId: partner.rosterId,
+                                    teamName: partner.teamName
+                                )
+                            },
+                            removeAction: { pid in
+                                tradeSideBPlayerIds.removeAll { $0 == pid }
+                            }
+                        )
+                    }
+
+                    if !suggestions.isEmpty {
+                        balanceSuggestionsCard(
+                            suggestions: suggestions,
+                            evaluation: evaluation
+                        )
+                    }
+
+                    if !trade.isEmpty {
+                        Button(role: .destructive) {
+                            tradeSideAPlayerIds = []
+                            tradeSideBPlayerIds = []
+                        } label: {
+                            Text("Clear trade")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(XomperColors.errorRed)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, XomperTheme.Spacing.sm)
+                        }
+                        .buttonStyle(.pressableCard)
+                        .padding(.horizontal, XomperTheme.Spacing.md)
+                    }
+                }
+            }
+            .padding(.bottom, XomperTheme.Spacing.xl)
+        }
+    }
+
+    private func currentTrade(my: TeamAnalysis, partner: TeamAnalysis?) -> ProposedTrade {
+        ProposedTrade(
+            sideA: TradeSide(
+                rosterId: my.rosterId,
+                teamName: my.teamName,
+                playerIds: tradeSideAPlayerIds
+            ),
+            sideB: TradeSide(
+                rosterId: partner?.rosterId ?? 0,
+                teamName: partner?.teamName ?? "",
+                playerIds: tradeSideBPlayerIds
+            )
+        )
+    }
+
+    private var tradeExplainer: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                Image(systemName: "arrow.left.arrow.right.circle.fill")
+                    .foregroundStyle(XomperColors.championGold)
+                Text("Trade analyzer")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+            }
+            Text("Pick a partner, drop in players from each side. Live FantasyCalc value totals + verdict pill update on every change. If the trade is uneven, balance suggestions surface players from the lighter side that close the gap.")
+                .font(.caption)
+                .foregroundStyle(XomperColors.textSecondary)
+            Text("Draft pick values + cross-team \"recommended trades\" coming next — see #75.")
+                .font(.caption2)
+                .foregroundStyle(XomperColors.textMuted)
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    private func tradePartnerPicker(my: TeamAnalysis, analyses: [TeamAnalysis]) -> some View {
+        let candidates = analyses
+            .filter { $0.rosterId != my.rosterId }
+            .sorted { $0.totalValue > $1.totalValue }
+        let selectedName = candidates.first { $0.rosterId == tradePartnerRosterId }?.teamName
+
+        return HStack(spacing: XomperTheme.Spacing.sm) {
+            Text("Trade partner")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(XomperColors.textSecondary)
+
+            Menu {
+                Button("None") {
+                    tradePartnerRosterId = nil
+                    tradeSideBPlayerIds = []
+                }
+                Divider()
+                ForEach(candidates, id: \.rosterId) { team in
+                    Button {
+                        if tradePartnerRosterId != team.rosterId {
+                            tradeSideBPlayerIds = []
+                        }
+                        tradePartnerRosterId = team.rosterId
+                    } label: {
+                        HStack {
+                            Text(team.teamName)
+                            Spacer()
+                            Text("\(team.totalValue)")
+                                .monospacedDigit()
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: XomperTheme.Spacing.xs) {
+                    Text(selectedName ?? "Pick partner")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(selectedName == nil ? XomperColors.textSecondary : XomperColors.bgDark)
+                        .lineLimit(1)
+                    Image(systemName: "chevron.down")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(selectedName == nil ? XomperColors.textSecondary : XomperColors.bgDark)
+                }
+                .padding(.horizontal, XomperTheme.Spacing.md)
+                .padding(.vertical, XomperTheme.Spacing.xs)
+                .frame(minHeight: 36)
+                .background(selectedName == nil ? XomperColors.surfaceLight.opacity(0.4) : Color.cyan)
+                .clipShape(Capsule())
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    private func tradeEvaluationStrip(evaluation: TradeEvaluation) -> some View {
+        let pillColor: Color = {
+            switch evaluation.verdict {
+            case .empty:    return XomperColors.surfaceLight.opacity(0.4)
+            case .fair:     return XomperColors.successGreen
+            case .sideAWins, .sideBWins: return XomperColors.errorRed.opacity(0.85)
+            }
+        }()
+
+        return VStack(spacing: XomperTheme.Spacing.sm) {
+            HStack {
+                tradeValueColumn(label: "You give", value: evaluation.sideAValue)
+                Spacer()
+                Image(systemName: "arrow.left.arrow.right")
+                    .foregroundStyle(XomperColors.textMuted)
+                Spacer()
+                tradeValueColumn(label: "You receive", value: evaluation.sideBValue)
+            }
+
+            Text(evaluation.verdict.label)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(evaluation.verdict.isFair ? XomperColors.bgDark : .white)
+                .textCase(.uppercase)
+                .padding(.horizontal, XomperTheme.Spacing.md)
+                .padding(.vertical, XomperTheme.Spacing.xs)
+                .background(pillColor)
+                .clipShape(Capsule())
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    private func tradeValueColumn(label: String, value: Int) -> some View {
+        VStack(spacing: 2) {
+            Text(label)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(XomperColors.textMuted)
+                .textCase(.uppercase)
+                .tracking(0.5)
+            Text("\(value)")
+                .font(.title3.weight(.bold))
+                .foregroundStyle(XomperColors.championGold)
+                .monospacedDigit()
+        }
+    }
+
+    private func tradeSideCard(
+        sideLabel: String,
+        teamName: String,
+        playerIds: [String],
+        sideValue: Int,
+        addAction: @escaping () -> Void,
+        removeAction: @escaping (String) -> Void
+    ) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(sideLabel)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(XomperColors.textMuted)
+                        .textCase(.uppercase)
+                        .tracking(0.5)
+                    Text(teamName)
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(XomperColors.textPrimary)
+                        .lineLimit(1)
+                }
+                Spacer()
+                Text("\(sideValue)")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+                    .monospacedDigit()
+            }
+
+            if playerIds.isEmpty {
+                Text("No players added yet.")
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textMuted)
+                    .padding(.vertical, XomperTheme.Spacing.xs)
+            } else {
+                ForEach(playerIds, id: \.self) { pid in
+                    tradePlayerRow(pid: pid, removeAction: { removeAction(pid) })
+                }
+            }
+
+            Button(action: addAction) {
+                HStack(spacing: XomperTheme.Spacing.xs) {
+                    Image(systemName: "plus.circle.fill")
+                    Text("Add player")
+                }
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(XomperColors.bgDark)
+                .padding(.horizontal, XomperTheme.Spacing.md)
+                .padding(.vertical, XomperTheme.Spacing.xs)
+                .frame(minHeight: 36)
+                .background(XomperColors.championGold)
+                .clipShape(Capsule())
+            }
+            .buttonStyle(.pressableCard)
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    private func tradePlayerRow(pid: String, removeAction: @escaping () -> Void) -> some View {
+        let player = playerStore.player(for: pid)
+        let value = valuesStore.value(for: pid)
+        return HStack(spacing: XomperTheme.Spacing.sm) {
+            Text(player?.fullDisplayName ?? "Player #\(pid)")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(XomperColors.textPrimary)
+                .lineLimit(1)
+            Text(player?.displayPosition ?? "")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(XomperColors.textSecondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(XomperColors.surfaceLight.opacity(0.4))
+                .clipShape(Capsule())
+            Spacer()
+            Text("\(value)")
+                .font(.subheadline.weight(.bold))
+                .foregroundStyle(XomperColors.championGold)
+                .monospacedDigit()
+            Button(action: removeAction) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(XomperColors.textMuted)
+            }
+            .buttonStyle(.pressableCard)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func balanceSuggestionsCard(
+        suggestions: [SuggestedAddOn],
+        evaluation: TradeEvaluation
+    ) -> some View {
+        let lighterLabel: String = {
+            switch evaluation.verdict {
+            case .sideAWins: return "You receive"
+            case .sideBWins: return "You give"
+            default: return ""
+            }
+        }()
+
+        return VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Balance suggestions")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+                Text("Add one of these to \(lighterLabel.lowercased()) to bring the trade within 5%.")
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.textMuted)
+            }
+
+            ForEach(suggestions) { suggestion in
+                Button {
+                    switch evaluation.verdict {
+                    case .sideAWins:
+                        if !tradeSideBPlayerIds.contains(suggestion.playerId) {
+                            tradeSideBPlayerIds.append(suggestion.playerId)
+                        }
+                    case .sideBWins:
+                        if !tradeSideAPlayerIds.contains(suggestion.playerId) {
+                            tradeSideAPlayerIds.append(suggestion.playerId)
+                        }
+                    default:
+                        break
+                    }
+                } label: {
+                    HStack(spacing: XomperTheme.Spacing.sm) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(suggestion.playerName)
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(XomperColors.textPrimary)
+                                .lineLimit(1)
+                            Text(suggestion.position)
+                                .font(.caption2.weight(.bold))
+                                .foregroundStyle(XomperColors.textSecondary)
+                        }
+                        Spacer()
+                        Text("\(suggestion.value)")
+                            .font(.subheadline.weight(.bold))
+                            .foregroundStyle(XomperColors.championGold)
+                            .monospacedDigit()
+                        Image(systemName: "plus.circle.fill")
+                            .foregroundStyle(XomperColors.championGold)
+                    }
+                    .padding(.vertical, 4)
+                }
+                .buttonStyle(.pressableCard)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.4), lineWidth: 1)
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    // MARK: - Player picker sheet
+
+    @ViewBuilder
+    fileprivate func tradePlayerPicker(
+        context: TradeSidePickerContext,
+        my: TeamAnalysis,
+        analyses: [TeamAnalysis]
+    ) -> some View {
+        let alreadyPicked: Set<String> = {
+            switch context.side {
+            case .a: return Set(tradeSideAPlayerIds)
+            case .b: return Set(tradeSideBPlayerIds)
+            }
+        }()
+        let roster = leagueStore.myLeagueRosters.first { $0.rosterId == context.rosterId }
+        let players: [TradePickerEntry] = (roster?.players ?? [])
+            .compactMap { pid in
+                guard !alreadyPicked.contains(pid) else { return nil }
+                let value = valuesStore.value(for: pid)
+                guard value > 0 else { return nil }
+                let player = playerStore.player(for: pid)
+                return TradePickerEntry(
+                    playerId: pid,
+                    name: player?.fullDisplayName ?? "Player #\(pid)",
+                    position: player?.displayPosition ?? "?",
+                    value: value
+                )
+            }
+            .sorted(by: { $0.value > $1.value })
+
+        ScrollView {
+            VStack(spacing: XomperTheme.Spacing.xs) {
+                ForEach(players) { entry in
+                    Button {
+                        switch context.side {
+                        case .a:
+                            tradeSideAPlayerIds.append(entry.playerId)
+                        case .b:
+                            tradeSideBPlayerIds.append(entry.playerId)
+                        }
+                        showSidePicker = nil
+                    } label: {
+                        HStack(spacing: XomperTheme.Spacing.sm) {
+                            Text(entry.name)
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(XomperColors.textPrimary)
+                                .lineLimit(1)
+                            Text(entry.position)
+                                .font(.caption2.weight(.bold))
+                                .foregroundStyle(XomperColors.textSecondary)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(XomperColors.surfaceLight.opacity(0.4))
+                                .clipShape(Capsule())
+                            Spacer()
+                            Text("\(entry.value)")
+                                .font(.subheadline.weight(.bold))
+                                .foregroundStyle(XomperColors.championGold)
+                                .monospacedDigit()
+                        }
+                        .padding(XomperTheme.Spacing.md)
+                        .background(XomperColors.bgCard)
+                        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+                    }
+                    .buttonStyle(.pressableCard)
+                }
+            }
+            .padding(XomperTheme.Spacing.md)
+        }
+        .background(XomperColors.bgDark)
+        .navigationTitle("Add from \(context.teamName)")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { showSidePicker = nil }
+                    .foregroundStyle(XomperColors.championGold)
+            }
+        }
+    }
+}
+
+// MARK: - Trade picker context
+
+struct TradeSidePickerContext: Identifiable, Hashable {
+    enum Side: Hashable { case a, b }
+    let side: Side
+    let rosterId: Int
+    let teamName: String
+    var id: Int { side == .a ? -rosterId : rosterId }
+}
+
+private struct TradePickerEntry: Identifiable, Hashable {
+    let playerId: String
+    let name: String
+    let position: String
+    let value: Int
+    var id: String { playerId }
+}
+
 // MARK: - Tabs
 
 private enum AnalyzerTab: CaseIterable, Sendable {
     case compare
     case league
+    case trade
 
     var title: String {
         switch self {
         case .compare: "Compare"
         case .league:  "League"
+        case .trade:   "Trade"
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds a third tab to Team Analyzer (Compare / League / **Trade**) that implements the v1 trade-analyzer flow from #75. Players-only; pick values + cross-team recommended trades are deferred to follow-up per the open questions in #75.

**What's in:**
- \`ProposedTrade\` / \`TradeSide\` / \`TradeEvaluation\` value types
- \`TradeEvaluator.evaluate(_:)\` — pure function, runs on every render. ≤5% gap → \"Fair\"; otherwise \"Side X wins by N%\"
- \`TradeEvaluator.suggestBalance(...)\` — walks the lighter side's roster, ranks candidates by how close they bring the trade to fair, prefers in-band picks
- Trade tab UI: partner picker (Menu), give/receive cards, live evaluation strip, color-coded verdict pill, balance suggestions card (tap to insert), player picker sheet, clear-trade button

**Deferred to follow-up (still tracked in #75):**
- FantasyCalc draft pick values for current + future years
- Recommended-trades section (fair-value trades that fix weak spots)
- Multi-team trades, FAAB, conditional picks

## Test plan
- [ ] Team Analyzer → Trade tab → explainer card mentions deferred items
- [ ] Pick a trade partner from the dropdown → \"You give\" + \"You receive\" cards appear
- [ ] Tap \"Add player\" on each side → sheet shows that team's roster sorted by value desc
- [ ] Add players to both sides → verdict pill updates live (Fair / Side X wins by N%)
- [ ] Uneven trade → balance suggestions card lists 1-5 add-ons from the lighter side; tapping one inserts into that side and re-evaluates
- [ ] Clear trade button resets both sides; verdict goes back to empty state
- [ ] Switch to Compare or League and back → trade state survives

🤖 Closes part of #75