### PR TITLE
feat: admin portal — activity feed + test sender

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		133F58C70F4FA02676079E9A /* RulesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FDC8A9B02A2BFD83398D04F /* RulesStore.swift */; };
 		143F0C4F56D88430BDC07B2A /* SeasonPickerBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD5AF5657020E1DBB5CB8886 /* SeasonPickerBar.swift */; };
 		16F47DD114B2470F88D007A5 /* MatchupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8521885A7FF4C6910DFBF549 /* MatchupsView.swift */; };
+		1720E856ACCE0189331605F2 /* AdminStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7839DD9CF0968986F91A58DB /* AdminStore.swift */; };
 		194BED1749B3F623C8D732DE /* XomperColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82B0FEAAB9BC80BA0801E98 /* XomperColors.swift */; };
 		1A9D12F3D247BD472801D26D /* XomperApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8BD31456E25771C8D7D39C9 /* XomperApp.swift */; };
 		1C4049A62CC4A443AC38E464 /* Draft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */; };
@@ -104,6 +105,7 @@
 		D78D5302B3D17DE9BE7D557C /* AuthGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5E661424C55F695BF96281 /* AuthGateView.swift */; };
 		D7A95C32621E03E2AAB37327 /* TaxiStealConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66A2C896FE4C62CF9719D7A /* TaxiStealConfirmView.swift */; };
 		E1D933F9B0C3E87F9C1C907A /* XomperAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89FC018282A1F1D8B2FD1B60 /* XomperAPIClient.swift */; };
+		E2E0551B857C17254E9B789B /* AdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E257076F7FE641947D1DC978 /* AdminView.swift */; };
 		E2EC532916CAA2FBB779DB35 /* UserStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62948D0A455E7CE99B15CB75 /* UserStore.swift */; };
 		EDDACB3FFB20E468D9D9D67D /* HeaderBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E7D0FD804723AC6A3E4298 /* HeaderBar.swift */; };
 		F201A3A40D624F6AAA0C0CC1 /* PlayoffBracket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */; };
@@ -171,6 +173,7 @@
 		71FB63BCA4BDD437FFE6D3A8 /* PressableCardButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PressableCardButtonStyle.swift; sourceTree = "<group>"; };
 		72CFD764A2BA7FF93B318A7F /* CareerStatsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareerStatsSection.swift; sourceTree = "<group>"; };
 		765C03E7E4268373F28754DC /* HighestPossibleLineup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighestPossibleLineup.swift; sourceTree = "<group>"; };
+		7839DD9CF0968986F91A58DB /* AdminStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStore.swift; sourceTree = "<group>"; };
 		7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Draft.swift; sourceTree = "<group>"; };
 		8098F78566BB324ACC70FB94 /* TeamAnalyzerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamAnalyzerView.swift; sourceTree = "<group>"; };
 		840D50097382434B0D123ACB /* NavigationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStore.swift; sourceTree = "<group>"; };
@@ -217,6 +220,7 @@
 		E0C5F37100E6EBB467EBFE1C /* SearchStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchStore.swift; sourceTree = "<group>"; };
 		E1A497DF9DD9066BD24A1E19 /* TraySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraySection.swift; sourceTree = "<group>"; };
 		E1E5A60EE78F668F02CF63C0 /* NflState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NflState.swift; sourceTree = "<group>"; };
+		E257076F7FE641947D1DC978 /* AdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminView.swift; sourceTree = "<group>"; };
 		E6A47FD1CF3BE7AE0B940DEC /* StandingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsView.swift; sourceTree = "<group>"; };
 		E70E04168BDBA7D3372BB605 /* TrayDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayDestination.swift; sourceTree = "<group>"; };
 		E767CD5492176E84C2092B0F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -295,6 +299,7 @@
 		27CD6E130AD93E0D7EAA4B67 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				DC10CB585B73997726A6710A /* Admin */,
 				390D24DCB17100460C0E682A /* Auth */,
 				EB7304EC920FBEC53F6E4CEB /* DraftHistory */,
 				680358FA986CFA519A36A85D /* DraftOrder */,
@@ -515,9 +520,18 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		DC10CB585B73997726A6710A /* Admin */ = {
+			isa = PBXGroup;
+			children = (
+				E257076F7FE641947D1DC978 /* AdminView.swift */,
+			);
+			path = Admin;
+			sourceTree = "<group>";
+		};
 		E1A7A2D932D868B1C49CE814 /* Stores */ = {
 			isa = PBXGroup;
 			children = (
+				7839DD9CF0968986F91A58DB /* AdminStore.swift */,
 				536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */,
 				3728C5F6BEF61FE509A3EA32 /* ClinchCalculator.swift */,
 				F013CD37874EFB0FA1CB4261 /* HistoryStore.swift */,
@@ -698,6 +712,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1720E856ACCE0189331605F2 /* AdminStore.swift in Sources */,
+				E2E0551B857C17254E9B789B /* AdminView.swift in Sources */,
 				9D9E8D2C4A8A0C623AC1EF0D /* AppDelegate.swift in Sources */,
 				8C67D3AAFE5A0A124BDE5F1A /* AppRouter.swift in Sources */,
 				D78D5302B3D17DE9BE7D557C /* AuthGateView.swift in Sources */,

--- a/Xomper/Core/Models/Profile.swift
+++ b/Xomper/Core/Models/Profile.swift
@@ -26,17 +26,33 @@ struct WhitelistedUser: Codable, Sendable {
     let id: String
     let email: String
     let sleeperUsername: String?
+    let sleeperUserId: String?
     let displayName: String?
     let role: String?
     let isActive: Bool
+    let isAdmin: Bool
 
     enum CodingKeys: String, CodingKey {
         case id
         case email
         case sleeperUsername = "sleeper_username"
+        case sleeperUserId = "sleeper_user_id"
         case displayName = "display_name"
         case role
         case isActive = "is_active"
+        case isAdmin = "is_admin"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        email = try c.decode(String.self, forKey: .email)
+        sleeperUsername = try c.decodeIfPresent(String.self, forKey: .sleeperUsername)
+        sleeperUserId = try c.decodeIfPresent(String.self, forKey: .sleeperUserId)
+        displayName = try c.decodeIfPresent(String.self, forKey: .displayName)
+        role = try c.decodeIfPresent(String.self, forKey: .role)
+        isActive = (try? c.decodeIfPresent(Bool.self, forKey: .isActive)) ?? false
+        isAdmin = (try? c.decodeIfPresent(Bool.self, forKey: .isAdmin)) ?? false
     }
 }
 

--- a/Xomper/Core/Networking/XomperAPIClient.swift
+++ b/Xomper/Core/Networking/XomperAPIClient.swift
@@ -9,6 +9,10 @@ protocol XomperAPIClientProtocol: Sendable {
     func sendTaxiStealEmail(stealer: TaxiStealerPayload, player: TaxiPlayerPayload, owner: TaxiOwnerPayload, recipients: [String], userIds: [String], leagueName: String) async throws
     func registerDevice(userId: String, deviceToken: String) async throws
     func unregisterDevice(userId: String, deviceToken: String) async throws
+
+    // Admin portal
+    func adminListNotifications(sleeperUserId: String, daysBack: Int, kind: String?, status: String?, limit: Int) async throws -> AdminNotificationsResponse
+    func adminTestSend(sleeperUserId: String, email: String?, kind: String, channels: [String]) async throws -> AdminTestSendResponse
 }
 
 // MARK: - Request Payloads
@@ -74,6 +78,83 @@ struct XomperAPIResponse: Decodable, Sendable {
     enum CodingKeys: String, CodingKey {
         case success = "Success"
         case message = "Message"
+    }
+}
+
+// MARK: - Admin Portal
+
+/// Single row from `/admin/notifications`. Mirrors the
+/// xomper-notification-log DynamoDB schema. Channel-specific fields
+/// (`recipient` / `subject` for email, `userId` / `title` / `body`
+/// for push) are decoded leniently — server returns whatever was
+/// captured at send time.
+struct AdminNotificationLogEntry: Decodable, Identifiable, Sendable, Hashable {
+    let id: String
+    let day: String
+    let epochMs: Int
+    let kind: String
+    let status: String
+    let userId: String?
+    let title: String?
+    let body: String?
+    let category: String?
+    let recipient: String?
+    let subject: String?
+    let bodySnippet: String?
+    let handler: String?
+    let error: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, day, kind, status, title, body, category, recipient, subject, handler, error
+        case epochMs = "epoch_ms"
+        case userId = "user_id"
+        case bodySnippet = "body_snippet"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = (try? c.decode(String.self, forKey: .id)) ?? UUID().uuidString
+        day = (try? c.decode(String.self, forKey: .day)) ?? ""
+        epochMs = (try? c.decode(Int.self, forKey: .epochMs)) ?? 0
+        kind = (try? c.decode(String.self, forKey: .kind)) ?? ""
+        status = (try? c.decode(String.self, forKey: .status)) ?? ""
+        userId = try? c.decodeIfPresent(String.self, forKey: .userId)
+        title = try? c.decodeIfPresent(String.self, forKey: .title)
+        body = try? c.decodeIfPresent(String.self, forKey: .body)
+        category = try? c.decodeIfPresent(String.self, forKey: .category)
+        recipient = try? c.decodeIfPresent(String.self, forKey: .recipient)
+        subject = try? c.decodeIfPresent(String.self, forKey: .subject)
+        bodySnippet = try? c.decodeIfPresent(String.self, forKey: .bodySnippet)
+        handler = try? c.decodeIfPresent(String.self, forKey: .handler)
+        error = try? c.decodeIfPresent(String.self, forKey: .error)
+    }
+
+    var date: Date {
+        Date(timeIntervalSince1970: Double(epochMs) / 1000.0)
+    }
+
+    var isSuccess: Bool {
+        status == "success"
+    }
+
+    var isPush: Bool { kind == "push" }
+    var isEmail: Bool { kind == "email" }
+}
+
+struct AdminNotificationsResponse: Decodable, Sendable {
+    let rows: [AdminNotificationLogEntry]
+    let count: Int
+}
+
+struct AdminTestSendResponse: Decodable, Sendable {
+    let kind: String
+    let pushSent: Int
+    let emailSent: Int
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case pushSent = "push_sent"
+        case emailSent = "email_sent"
     }
 }
 
@@ -229,7 +310,116 @@ final class XomperAPIClient: XomperAPIClientProtocol {
         try await post("/device/unregister", body: body)
     }
 
+    // MARK: - Admin Portal
+
+    func adminListNotifications(
+        sleeperUserId: String,
+        daysBack: Int = 7,
+        kind: String? = nil,
+        status: String? = nil,
+        limit: Int = 100
+    ) async throws -> AdminNotificationsResponse {
+        var items: [URLQueryItem] = [
+            URLQueryItem(name: "sleeper_user_id", value: sleeperUserId),
+            URLQueryItem(name: "days_back", value: String(daysBack)),
+            URLQueryItem(name: "limit", value: String(limit)),
+        ]
+        if let kind, !kind.isEmpty {
+            items.append(URLQueryItem(name: "kind", value: kind))
+        }
+        if let status, !status.isEmpty {
+            items.append(URLQueryItem(name: "status", value: status))
+        }
+        return try await get("/admin/notifications", queryItems: items)
+    }
+
+    func adminTestSend(
+        sleeperUserId: String,
+        email: String?,
+        kind: String,
+        channels: [String] = ["push", "email"]
+    ) async throws -> AdminTestSendResponse {
+        var body: [String: Any] = [
+            "sleeper_user_id": sleeperUserId,
+            "kind": kind,
+            "channels": channels,
+        ]
+        if let email, !email.isEmpty {
+            body["email"] = email
+        }
+        return try await postDecoding("/admin/test-send", body: body)
+    }
+
     // MARK: - Private
+
+    private func get<T: Decodable>(_ path: String, queryItems: [URLQueryItem]) async throws -> T {
+        var components = URLComponents(string: "\(baseURL)\(path)")
+        components?.queryItems = queryItems
+        guard let url = components?.url else { throw XomperAPIError.invalidURL }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if !authToken.isEmpty {
+            request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+        }
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw XomperAPIError.networkError(error)
+        }
+
+        guard let http = response as? HTTPURLResponse,
+              (200...299).contains(http.statusCode) else {
+            let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+            throw XomperAPIError.httpError(statusCode: code)
+        }
+
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            throw XomperAPIError.encodingError(error)
+        }
+    }
+
+    private func postDecoding<T: Decodable>(_ path: String, body: [String: Any]) async throws -> T {
+        guard let url = URL(string: "\(baseURL)\(path)") else { throw XomperAPIError.invalidURL }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if !authToken.isEmpty {
+            request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        } catch {
+            throw XomperAPIError.encodingError(error)
+        }
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw XomperAPIError.networkError(error)
+        }
+
+        guard let http = response as? HTTPURLResponse,
+              (200...299).contains(http.statusCode) else {
+            let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+            throw XomperAPIError.httpError(statusCode: code)
+        }
+
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            throw XomperAPIError.encodingError(error)
+        }
+    }
 
     private func post(_ path: String, body: [String: Any]) async throws {
         guard let url = URL(string: "\(baseURL)\(path)") else {

--- a/Xomper/Core/Stores/AdminStore.swift
+++ b/Xomper/Core/Stores/AdminStore.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+/// Drives the iOS Admin portal. Reads the activity feed from
+/// `/admin/notifications` and fires `/admin/test-send` test sends
+/// for any of the production templates.
+///
+/// Admin gating is enforced on the backend (the `is_admin` column on
+/// `whitelisted_users`). Client-side, we use
+/// `LeagueStore.whitelistedLeague` /
+/// `UserStore.myUser.isAdminFlagFromSupabase` (when wired) to decide
+/// whether to show the destination at all — but every API call must
+/// re-check on the server.
+@Observable
+@MainActor
+final class AdminStore {
+    private(set) var entries: [AdminNotificationLogEntry] = []
+    private(set) var isLoading = false
+    private(set) var lastError: String?
+    private(set) var lastTestResult: String?
+
+    var filterKind: KindFilter = .all
+    var filterStatus: StatusFilter = .all
+
+    enum KindFilter: String, CaseIterable, Identifiable, Sendable {
+        case all
+        case push
+        case email
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .all:   "All"
+            case .push:  "Push"
+            case .email: "Email"
+            }
+        }
+        var apiValue: String? {
+            switch self {
+            case .all:   nil
+            case .push:  "push"
+            case .email: "email"
+            }
+        }
+    }
+
+    enum StatusFilter: String, CaseIterable, Identifiable, Sendable {
+        case all
+        case success
+        case failure
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .all:     "All"
+            case .success: "Success"
+            case .failure: "Failure"
+            }
+        }
+        var apiValue: String? {
+            switch self {
+            case .all:     nil
+            case .success: "success"
+            case .failure: "failure"
+            }
+        }
+    }
+
+    private let apiClient: XomperAPIClientProtocol
+
+    init(apiClient: XomperAPIClientProtocol = XomperAPIClient()) {
+        self.apiClient = apiClient
+    }
+
+    func refresh(sleeperUserId: String) async {
+        guard !sleeperUserId.isEmpty else { return }
+        isLoading = true
+        lastError = nil
+        defer { isLoading = false }
+
+        do {
+            let response = try await apiClient.adminListNotifications(
+                sleeperUserId: sleeperUserId,
+                daysBack: 7,
+                kind: filterKind.apiValue,
+                status: filterStatus.apiValue,
+                limit: 200
+            )
+            entries = response.rows
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    func sendTest(
+        kind: AdminTestKind,
+        sleeperUserId: String,
+        email: String?,
+        channels: [String]
+    ) async {
+        guard !sleeperUserId.isEmpty else {
+            lastTestResult = "Missing sleeper_user_id"
+            return
+        }
+        lastError = nil
+        do {
+            let response = try await apiClient.adminTestSend(
+                sleeperUserId: sleeperUserId,
+                email: email,
+                kind: kind.rawValue,
+                channels: channels
+            )
+            lastTestResult = "✓ \(kind.label) — push: \(response.pushSent), email: \(response.emailSent)"
+            // Refresh feed so the new send appears.
+            await refresh(sleeperUserId: sleeperUserId)
+        } catch {
+            lastTestResult = "✗ \(kind.label) — \(error.localizedDescription)"
+        }
+    }
+}
+
+/// Production templates that the admin portal can fire as test sends.
+/// Mirrors the `kind` strings the backend `api_admin_test_send` handler
+/// understands.
+enum AdminTestKind: String, CaseIterable, Identifiable, Sendable {
+    case lineupNotSet     = "lineup_not_set"
+    case weeklyRecap      = "weekly_recap"
+    case closeGameAlert   = "close_game_alert"
+    case worldcupClinched = "worldcup_clinched"
+    case worldcupEliminated = "worldcup_eliminated"
+    case worldcupLineMoved = "worldcup_line_moved"
+    case ruleProposed     = "rule_proposed"
+    case ruleAccepted     = "rule_accepted"
+    case ruleDenied       = "rule_denied"
+    case taxiSteal        = "taxi_steal"
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .lineupNotSet:       "Lineup not set"
+        case .weeklyRecap:        "Weekly recap"
+        case .closeGameAlert:     "Close game alert"
+        case .worldcupClinched:   "World Cup clinched"
+        case .worldcupEliminated: "World Cup eliminated"
+        case .worldcupLineMoved:  "World Cup line moved"
+        case .ruleProposed:       "Rule proposed"
+        case .ruleAccepted:       "Rule accepted"
+        case .ruleDenied:         "Rule denied"
+        case .taxiSteal:          "Taxi steal"
+        }
+    }
+
+    /// Whether this template has both push + email legs in production.
+    /// Drives whether the test-send button row gets a single "Push +
+    /// email" button or two separate ones.
+    var hasEmail: Bool {
+        switch self {
+        case .lineupNotSet, .weeklyRecap, .ruleProposed, .ruleAccepted, .ruleDenied:
+            return true
+        case .closeGameAlert, .worldcupClinched, .worldcupEliminated, .worldcupLineMoved, .taxiSteal:
+            return false
+        }
+    }
+}

--- a/Xomper/Core/Stores/AuthStore.swift
+++ b/Xomper/Core/Stores/AuthStore.swift
@@ -162,7 +162,7 @@ final class AuthStore {
         }
     }
 
-    private var whitelistedUser: WhitelistedUser?
+    private(set) var whitelistedUser: WhitelistedUser?
 
     func checkWhitelist() async {
         guard let email = session?.user.email else {

--- a/Xomper/Features/Admin/AdminView.swift
+++ b/Xomper/Features/Admin/AdminView.swift
@@ -1,0 +1,273 @@
+import SwiftUI
+
+/// Admin portal — only visible when the signed-in
+/// `whitelistedUser.isAdmin == true`. Two sections:
+/// 1. **Test sender** — fire any of the production push/email
+///    templates back to yourself so you can preview formatting +
+///    confirm the channel is working.
+/// 2. **Activity feed** — last 200 push + email send attempts
+///    (success + failure), filterable by channel and status.
+///
+/// Backend gating is enforced server-side via the `is_admin` flag
+/// on `whitelisted_users`; this view also hides the destination
+/// for non-admins so they never see the menu entry.
+struct AdminView: View {
+    var authStore: AuthStore
+    var leagueStore: LeagueStore
+    @State private var store = AdminStore()
+
+    var body: some View {
+        Group {
+            if !isAdmin {
+                EmptyStateView(
+                    icon: "lock.shield",
+                    title: "Admin only",
+                    message: "Your account doesn't have admin permission. Ask the commissioner to flip your is_admin flag."
+                )
+            } else {
+                content
+            }
+        }
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .task(id: callerSleeperId) {
+            await store.refresh(sleeperUserId: callerSleeperId)
+        }
+        .refreshable {
+            await store.refresh(sleeperUserId: callerSleeperId)
+        }
+    }
+
+    private var isAdmin: Bool {
+        authStore.whitelistedUser?.isAdmin == true
+    }
+
+    private var callerSleeperId: String {
+        authStore.sleeperUserId ?? ""
+    }
+
+    private var callerEmail: String? {
+        authStore.session?.user.email
+    }
+
+    // MARK: - Content
+
+    private var content: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
+                testSenderCard
+
+                if let result = store.lastTestResult {
+                    Text(result)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(result.hasPrefix("✓") ? XomperColors.successGreen : XomperColors.errorRed)
+                        .padding(.horizontal, XomperTheme.Spacing.md)
+                }
+
+                filterBar
+
+                if store.isLoading && store.entries.isEmpty {
+                    LoadingView(message: "Loading activity…")
+                        .padding(.top, XomperTheme.Spacing.xl)
+                } else if let error = store.lastError, store.entries.isEmpty {
+                    ErrorView(message: error) {
+                        Task { await store.refresh(sleeperUserId: callerSleeperId) }
+                    }
+                } else if store.entries.isEmpty {
+                    EmptyStateView(
+                        icon: "tray",
+                        title: "No activity",
+                        message: "No push or email sends recorded in the last 7 days for the current filters."
+                    )
+                    .padding(.top, XomperTheme.Spacing.lg)
+                } else {
+                    ForEach(store.entries) { entry in
+                        activityRow(entry)
+                    }
+                }
+            }
+            .padding(.vertical, XomperTheme.Spacing.sm)
+            .padding(.bottom, XomperTheme.Spacing.xl)
+        }
+    }
+
+    // MARK: - Test sender
+
+    private var testSenderCard: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Test sender")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+                Text("Fire any production template back to your account. Push titles arrive prefixed with 🧪.")
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textSecondary)
+            }
+
+            ForEach(AdminTestKind.allCases) { kind in
+                HStack(spacing: XomperTheme.Spacing.xs) {
+                    Text(kind.label)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(XomperColors.textPrimary)
+                    Spacer()
+
+                    Button {
+                        Task {
+                            await store.sendTest(
+                                kind: kind,
+                                sleeperUserId: callerSleeperId,
+                                email: kind.hasEmail ? callerEmail : nil,
+                                channels: kind.hasEmail ? ["push", "email"] : ["push"]
+                            )
+                        }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: kind.hasEmail ? "paperplane.fill" : "iphone.gen3")
+                                .font(.caption2)
+                            Text(kind.hasEmail ? "Push + email" : "Push")
+                                .font(.caption.weight(.semibold))
+                        }
+                        .foregroundStyle(XomperColors.bgDark)
+                        .padding(.horizontal, XomperTheme.Spacing.sm)
+                        .padding(.vertical, XomperTheme.Spacing.xs)
+                        .frame(minHeight: 32)
+                        .background(XomperColors.championGold)
+                        .clipShape(Capsule())
+                    }
+                    .buttonStyle(.pressableCard)
+                }
+                .padding(.vertical, 2)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    // MARK: - Filters
+
+    private var filterBar: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            Text("Activity · last 7 days")
+                .font(.caption.weight(.bold))
+                .textCase(.uppercase)
+                .tracking(0.5)
+                .foregroundStyle(XomperColors.textMuted)
+
+            HStack(spacing: XomperTheme.Spacing.sm) {
+                Picker("Channel", selection: $store.filterKind) {
+                    ForEach(AdminStore.KindFilter.allCases) { f in
+                        Text(f.label).tag(f)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Picker("Status", selection: $store.filterStatus) {
+                    ForEach(AdminStore.StatusFilter.allCases) { f in
+                        Text(f.label).tag(f)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+            .onChange(of: store.filterKind) { _, _ in
+                Task { await store.refresh(sleeperUserId: callerSleeperId) }
+            }
+            .onChange(of: store.filterStatus) { _, _ in
+                Task { await store.refresh(sleeperUserId: callerSleeperId) }
+            }
+        }
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    // MARK: - Activity row
+
+    private func activityRow(_ entry: AdminNotificationLogEntry) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                Image(systemName: entry.isPush ? "iphone.gen3" : "envelope.fill")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(entry.isPush ? Color.cyan : XomperColors.championGold)
+                Text(entry.isPush ? "PUSH" : "EMAIL")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(XomperColors.textSecondary)
+                    .tracking(0.5)
+                Text(entry.isSuccess ? "✓" : "✗")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(entry.isSuccess ? XomperColors.successGreen : XomperColors.errorRed)
+                Spacer()
+                Text(formattedTimestamp(entry.date))
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.textMuted)
+                    .monospacedDigit()
+            }
+
+            if entry.isPush {
+                if let title = entry.title, !title.isEmpty {
+                    Text(title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(XomperColors.textPrimary)
+                        .lineLimit(1)
+                }
+                if let body = entry.body, !body.isEmpty {
+                    Text(body)
+                        .font(.caption)
+                        .foregroundStyle(XomperColors.textSecondary)
+                        .lineLimit(2)
+                }
+                if let userId = entry.userId, !userId.isEmpty {
+                    Text("user: \(userId)")
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .monospacedDigit()
+                }
+            } else {
+                if let subject = entry.subject, !subject.isEmpty {
+                    Text(subject)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(XomperColors.textPrimary)
+                        .lineLimit(1)
+                }
+                if let recipient = entry.recipient, !recipient.isEmpty {
+                    Text(recipient)
+                        .font(.caption)
+                        .foregroundStyle(XomperColors.textSecondary)
+                        .lineLimit(1)
+                }
+                if let snippet = entry.bodySnippet, !snippet.isEmpty {
+                    Text(snippet)
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .lineLimit(2)
+                }
+            }
+
+            if let err = entry.error, !err.isEmpty {
+                Text(err)
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.errorRed)
+                    .lineLimit(2)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md)
+                .strokeBorder(
+                    entry.isSuccess ? Color.clear : XomperColors.errorRed.opacity(0.4),
+                    lineWidth: entry.isSuccess ? 0 : 1
+                )
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    private func formattedTimestamp(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, h:mm:ss a"
+        return formatter.string(from: date)
+    }
+}

--- a/Xomper/Features/Shell/DrawerView.swift
+++ b/Xomper/Features/Shell/DrawerView.swift
@@ -14,29 +14,40 @@ struct DrawerView: View {
     let avatarID: String?
     let displayName: String?
     let email: String?
+    /// True when the signed-in whitelisted user has `is_admin == true`.
+    /// When true, an extra "Admin" section appears below the standard
+    /// drawer entries. Backend gates the underlying API regardless.
+    let isAdmin: Bool
 
     // MARK: - Section model
 
     /// Drawer sections (top-to-bottom). `Settings` is pinned separately to the
-    /// bottom of the panel and is not in this list.
-    private let sections: [TraySection] = [
-        TraySection(
-            title: "Compete",
-            entries: [.standings, .matchups, .playoffs]
-        ),
-        TraySection(
-            title: "History",
-            entries: [.draftHistory, .matchupHistory, .worldCup]
-        ),
-        TraySection(
-            title: "Roster",
-            entries: [.myTeam, .taxiSquad, .teamAnalyzer]
-        ),
-        TraySection(
-            title: "League",
-            entries: [.payouts, .draftOrder, .rulebook, .scoring, .leagueSettings, .ruleProposals]
-        ),
-    ]
+    /// bottom of the panel and is not in this list. `Admin` is appended at
+    /// runtime when `isAdmin == true`.
+    private var sections: [TraySection] {
+        var out: [TraySection] = [
+            TraySection(
+                title: "Compete",
+                entries: [.standings, .matchups, .playoffs]
+            ),
+            TraySection(
+                title: "History",
+                entries: [.draftHistory, .matchupHistory, .worldCup]
+            ),
+            TraySection(
+                title: "Roster",
+                entries: [.myTeam, .taxiSquad, .teamAnalyzer]
+            ),
+            TraySection(
+                title: "League",
+                entries: [.payouts, .draftOrder, .rulebook, .scoring, .leagueSettings, .ruleProposals]
+            ),
+        ]
+        if isAdmin {
+            out.append(TraySection(title: "Admin", entries: [.admin]))
+        }
+        return out
+    }
 
     // MARK: - Layout
 

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -64,7 +64,8 @@ struct MainShell: View {
                 router: router,
                 avatarID: userStore.myUser?.avatar,
                 displayName: resolvedDisplayName,
-                email: authStore.session?.user.email
+                email: authStore.session?.user.email,
+                isAdmin: authStore.whitelistedUser?.isAdmin == true
             )
 
             // Edge-swipe-to-open hit area. Confined to a 20pt strip on
@@ -204,6 +205,12 @@ struct MainShell: View {
                     leagueStore: leagueStore,
                     playerStore: playerStore,
                     playerPointsStore: playerPointsStore
+                )
+
+            case .admin:
+                AdminView(
+                    authStore: authStore,
+                    leagueStore: leagueStore
                 )
 
             case .rulebook:

--- a/Xomper/Features/Shell/TrayDestination.swift
+++ b/Xomper/Features/Shell/TrayDestination.swift
@@ -25,6 +25,7 @@ enum TrayDestination: Hashable {
     case ruleProposals
     case payouts
     case draftOrder
+    case admin
     case profile
     case settings
 
@@ -47,6 +48,7 @@ enum TrayDestination: Hashable {
         case .ruleProposals:  "Rule Proposals"
         case .payouts:        "Payouts"
         case .draftOrder:     "Draft Order Proposal"
+        case .admin:          "Admin"
         case .profile:        "Profile"
         case .settings:       "Settings"
         }
@@ -70,6 +72,7 @@ enum TrayDestination: Hashable {
         case .ruleProposals:  "checkmark.bubble.fill"
         case .payouts:        "dollarsign.circle.fill"
         case .draftOrder:     "list.bullet.rectangle"
+        case .admin:          "wrench.and.screwdriver.fill"
         case .profile:        "person.crop.circle.fill"
         case .settings:       "gearshape.fill"
         }


### PR DESCRIPTION
## Summary
Adds an Admin destination (only visible when \`whitelisted_users.is_admin == true\`) with two cards:

1. **Test sender** — fire any production push/email template back to yourself. Push titles arrive prefixed with 🧪 so they're obvious in notification center.
2. **Activity feed** — last 7 days of push + email send attempts (success + failure), filterable by channel and status.

Pairs with xomper-back-end PR #56 + xomper-infrastructure PR #102 (already merged + applied — the new \`xomper-notification-log\` DynamoDB table + \`/admin/notifications\` GET + \`/admin/test-send\` POST endpoints are live).

## Manual setup required (one-time)
Set \`is_admin = true\` on your row in Supabase \`whitelisted_users\`:

\`\`\`sql
ALTER TABLE whitelisted_users ADD COLUMN IF NOT EXISTS is_admin BOOLEAN DEFAULT FALSE;
UPDATE whitelisted_users SET is_admin = true WHERE email = 'dominickj.giordano@gmail.com';
\`\`\`

Without that, the Admin entry won't appear in the drawer.

## Test plan
- [ ] Run the SQL above in Supabase
- [ ] Open the app → drawer shows new "Admin" section at the bottom
- [ ] Tap Admin → test sender lists every template
- [ ] Tap "Lineup not set → Push + email" → push arrives on device with 🧪 prefix, email lands in inbox
- [ ] Activity feed populates with the test send + a row per scheduled lambda fire
- [ ] Filter by Push only / Email only / Failure only — list updates
- [ ] Pull-to-refresh re-queries