### PR TITLE
feat(ai-review F0): iOS — store, archive, detail, Home banner, tray destination

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		021A039E220940CD2E12304A /* NavigationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840D50097382434B0D123ACB /* NavigationStore.swift */; };
 		02AC6FBAE68011749AA17644 /* ClinchCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3893B13276074EF6033CEA2 /* ClinchCalculatorTests.swift */; };
+		04C5B75AA224E7ED8314FBA5 /* AIReviewHomeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12507ED13C57EFA8B240301 /* AIReviewHomeCard.swift */; };
 		063FCD6AA342CA5D64ED79ED /* HistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F013CD37874EFB0FA1CB4261 /* HistoryStore.swift */; };
 		08251EFB3181B634553CDCE1 /* TaxiSquadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57940AEB84889A20016648F2 /* TaxiSquadView.swift */; };
 		0C2B77E0A46ECE55AE8CE46F /* DivisionBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B670A3A0762D22FB3202E1E /* DivisionBadge.swift */; };
@@ -18,6 +19,7 @@
 		143F0C4F56D88430BDC07B2A /* SeasonPickerBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD5AF5657020E1DBB5CB8886 /* SeasonPickerBar.swift */; };
 		16F47DD114B2470F88D007A5 /* MatchupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8521885A7FF4C6910DFBF549 /* MatchupsView.swift */; };
 		1720E856ACCE0189331605F2 /* AdminStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7839DD9CF0968986F91A58DB /* AdminStore.swift */; };
+		189F79187B5D4D5686909B2F /* AIReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A95FE8DD123C85CA39DAE13 /* AIReport.swift */; };
 		194BED1749B3F623C8D732DE /* XomperColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82B0FEAAB9BC80BA0801E98 /* XomperColors.swift */; };
 		1A9D12F3D247BD472801D26D /* XomperApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8BD31456E25771C8D7D39C9 /* XomperApp.swift */; };
 		1C4049A62CC4A443AC38E464 /* Draft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */; };
@@ -36,6 +38,7 @@
 		3E5A98150356BEB75FD87145 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = 72178EB48829A7D249085476 /* Supabase */; };
 		40C507B6FB2EF2A7E647AA3C /* TeamStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36A01820FD0F6643BBF8511D /* TeamStore.swift */; };
 		427F23653F78A52108C55692 /* XomperLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3B178733D5AF9EB7DA7189 /* XomperLoader.swift */; };
+		42BF3DEE63074148F1DF0BD1 /* AIReviewDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967DCE922FE090CE4F067587 /* AIReviewDetailView.swift */; };
 		42E7DDAD3454512247E1AFA6 /* ProposedTrade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4690614F644FE74115D0DAB6 /* ProposedTrade.swift */; };
 		4A321187068EEBA8C4E75EFE /* PayoutProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E3BE36BCEA1A7722157C37 /* PayoutProjection.swift */; };
 		4B629DB100C96EB68A6A9A41 /* SearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323F422F2D0E1C2BA5D46C0A /* SearchResults.swift */; };
@@ -53,10 +56,12 @@
 		61EBC3AC052763EAAC807AC9 /* WorldCup.swift in Sources */ = {isa = PBXBuildFile; fileRef = E969C4A894017F9D0072CCFA /* WorldCup.swift */; };
 		65444EF8D83F3582CE2FC023 /* TrophyCaseSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B94B6AD01FF1F85D81B5A5DE /* TrophyCaseSection.swift */; };
 		65DC95B6907B22347616C3D7 /* SleeperAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1FE16B5220928685DCF19E /* SleeperAPIClient.swift */; };
+		68EE3E2F11A28AD898ABB03C /* AIReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A51BC6B9389405FE754DCEB /* AIReviewView.swift */; };
 		6BC002C5DD7EF547F82CA860 /* DraftOrderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9ED150F995299D37368EDC3 /* DraftOrderView.swift */; };
 		6C89029D05AEE66FB2315616 /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C8A3FA617E9FEB48852C45 /* Profile.swift */; };
 		724482308D102AFA35AB4017 /* LeagueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56BB91320E3D5EBE1F777838 /* LeagueStore.swift */; };
 		72FF7B4516B2DCDAE4683B9D /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83A8FEFFD8FA91F498D03A0 /* EmptyStateView.swift */; };
+		73E3AB3D048A23D710376D09 /* AIReviewStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E6A6BADE3F51FA922A078F4 /* AIReviewStore.swift */; };
 		7607DB7C775FCCC3B7C3377B /* StandingsTeam.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29D510D87CD290AE7F76FBF /* StandingsTeam.swift */; };
 		76260F26A40213A62E5F22FB /* RecordBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AD376EFB7AD4A192FAB3E8F /* RecordBadge.swift */; };
 		775985FFAD33E6481C34174A /* TrophyCaseCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2908776CDAC0CACB28B4B1 /* TrophyCaseCard.swift */; };
@@ -80,6 +85,7 @@
 		98F895FBCECB23325658339C /* StandingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A47FD1CF3BE7AE0B940DEC /* StandingsView.swift */; };
 		9D9E8D2C4A8A0C623AC1EF0D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E767CD5492176E84C2092B0F /* AppDelegate.swift */; };
 		9E5C71DAB504EDCDF2084DF3 /* MyProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558164667DF7D89C4DF2F32E /* MyProfileView.swift */; };
+		A0F4E9BCA7E5D757DE8BE5B3 /* AIReviewStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08BD215787E2BFC1C57E7E7E /* AIReviewStoreTests.swift */; };
 		A28A24923C27CF0929ED97E1 /* Double+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669A80C2A9F46A0C4612388C /* Double+Formatting.swift */; };
 		A379F9D71FE84EC4F3A2499C /* SearchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C5F37100E6EBB467EBFE1C /* SearchStore.swift */; };
 		A4D93DF4C02A8DE6C695CE4D /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E94170F987E8EFE5C566B9B /* LoginView.swift */; };
@@ -130,6 +136,7 @@
 
 /* Begin PBXFileReference section */
 		01A3969B9E9E60F0C59D83C9 /* MatchupHistoryBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupHistoryBrowserView.swift; sourceTree = "<group>"; };
+		08BD215787E2BFC1C57E7E7E /* AIReviewStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewStoreTests.swift; sourceTree = "<group>"; };
 		09DF8F2FE857C55AFB1C1205 /* NFLTeamColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFLTeamColors.swift; sourceTree = "<group>"; };
 		10CD226D313FDD91E4037D8E /* SupabaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseManager.swift; sourceTree = "<group>"; };
 		18383A0375F5728A9E3FE065 /* Championship.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Championship.swift; sourceTree = "<group>"; };
@@ -143,6 +150,7 @@
 		36A01820FD0F6643BBF8511D /* TeamStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamStore.swift; sourceTree = "<group>"; };
 		3728C5F6BEF61FE509A3EA32 /* ClinchCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClinchCalculator.swift; sourceTree = "<group>"; };
 		3747C6FC769C117588F8A93E /* WhitelistedLeague.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhitelistedLeague.swift; sourceTree = "<group>"; };
+		3A51BC6B9389405FE754DCEB /* AIReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewView.swift; sourceTree = "<group>"; };
 		3E4EC7FDB93C47A9EE601BA3 /* TrayItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayItem.swift; sourceTree = "<group>"; };
 		42C8A3FA617E9FEB48852C45 /* Profile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
 		42F46A0AAE61A4E963BB15B0 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
@@ -168,6 +176,7 @@
 		669A80C2A9F46A0C4612388C /* Double+Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Formatting.swift"; sourceTree = "<group>"; };
 		67C24A12080AD428D5A40A7E /* PlayerSeasonStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerSeasonStats.swift; sourceTree = "<group>"; };
 		6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayoffBracket.swift; sourceTree = "<group>"; };
+		6E6A6BADE3F51FA922A078F4 /* AIReviewStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewStore.swift; sourceTree = "<group>"; };
 		6F2C7D74B3584D53CE601054 /* MatchupDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupDetailView.swift; sourceTree = "<group>"; };
 		6F2D6E80C100927C4C20FAD7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		71FB63BCA4BDD437FFE6D3A8 /* PressableCardButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PressableCardButtonStyle.swift; sourceTree = "<group>"; };
@@ -179,10 +188,12 @@
 		840D50097382434B0D123ACB /* NavigationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStore.swift; sourceTree = "<group>"; };
 		8521885A7FF4C6910DFBF549 /* MatchupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupsView.swift; sourceTree = "<group>"; };
 		89FC018282A1F1D8B2FD1B60 /* XomperAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperAPIClient.swift; sourceTree = "<group>"; };
+		8A95FE8DD123C85CA39DAE13 /* AIReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReport.swift; sourceTree = "<group>"; };
 		8D921732971689E8096F9549 /* DrawerScrim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerScrim.swift; sourceTree = "<group>"; };
 		94DF42654C9F48EE60C040F7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		94E125AD2AA5212D0EB4C13A /* NflStateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NflStateStore.swift; sourceTree = "<group>"; };
 		957EE31D25CFE325633622D4 /* StandingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsStore.swift; sourceTree = "<group>"; };
+		967DCE922FE090CE4F067587 /* AIReviewDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewDetailView.swift; sourceTree = "<group>"; };
 		9B7C85CB880ABD7D373E49A6 /* RuleProposal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleProposal.swift; sourceTree = "<group>"; };
 		9E94170F987E8EFE5C566B9B /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		9F49969EE42BDE6462664021 /* TradedPick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradedPick.swift; sourceTree = "<group>"; };
@@ -210,6 +221,7 @@
 		C9382BCB18DFEB416A50A039 /* RulesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesView.swift; sourceTree = "<group>"; };
 		CC3F6B5022E8151683A45F4F /* PlayerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerStore.swift; sourceTree = "<group>"; };
 		CEAEC7A4917990425085AE71 /* PushNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationManager.swift; sourceTree = "<group>"; };
+		D12507ED13C57EFA8B240301 /* AIReviewHomeCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewHomeCard.swift; sourceTree = "<group>"; };
 		D36829F2AD0FD089788B9CE1 /* PlayerPointsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerPointsStore.swift; sourceTree = "<group>"; };
 		D7F3F1A18F4EEC5A3F81FD28 /* SeasonStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonStore.swift; sourceTree = "<group>"; };
 		DB1FE16B5220928685DCF19E /* SleeperAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleeperAPIClient.swift; sourceTree = "<group>"; };
@@ -300,6 +312,7 @@
 			isa = PBXGroup;
 			children = (
 				DC10CB585B73997726A6710A /* Admin */,
+				B3EF58FFFA675A9DE32C8394 /* AIReview */,
 				390D24DCB17100460C0E682A /* Auth */,
 				EB7304EC920FBEC53F6E4CEB /* DraftHistory */,
 				680358FA986CFA519A36A85D /* DraftOrder */,
@@ -346,6 +359,7 @@
 		391A14F36D43146CBE38D666 /* XomperTests */ = {
 			isa = PBXGroup;
 			children = (
+				08BD215787E2BFC1C57E7E7E /* AIReviewStoreTests.swift */,
 				B3893B13276074EF6033CEA2 /* ClinchCalculatorTests.swift */,
 			);
 			path = XomperTests;
@@ -437,9 +451,20 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		B3EF58FFFA675A9DE32C8394 /* AIReview */ = {
+			isa = PBXGroup;
+			children = (
+				967DCE922FE090CE4F067587 /* AIReviewDetailView.swift */,
+				D12507ED13C57EFA8B240301 /* AIReviewHomeCard.swift */,
+				3A51BC6B9389405FE754DCEB /* AIReviewView.swift */,
+			);
+			path = AIReview;
+			sourceTree = "<group>";
+		};
 		B3F6F3856481009365322743 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				8A95FE8DD123C85CA39DAE13 /* AIReport.swift */,
 				AD43D54AB620DABD559F8A40 /* CareerStats.swift */,
 				18383A0375F5728A9E3FE065 /* Championship.swift */,
 				7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */,
@@ -532,6 +557,7 @@
 			isa = PBXGroup;
 			children = (
 				7839DD9CF0968986F91A58DB /* AdminStore.swift */,
+				6E6A6BADE3F51FA922A078F4 /* AIReviewStore.swift */,
 				536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */,
 				3728C5F6BEF61FE509A3EA32 /* ClinchCalculator.swift */,
 				F013CD37874EFB0FA1CB4261 /* HistoryStore.swift */,
@@ -704,6 +730,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A0F4E9BCA7E5D757DE8BE5B3 /* AIReviewStoreTests.swift in Sources */,
 				02AC6FBAE68011749AA17644 /* ClinchCalculatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -712,6 +739,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				189F79187B5D4D5686909B2F /* AIReport.swift in Sources */,
+				42BF3DEE63074148F1DF0BD1 /* AIReviewDetailView.swift in Sources */,
+				04C5B75AA224E7ED8314FBA5 /* AIReviewHomeCard.swift in Sources */,
+				73E3AB3D048A23D710376D09 /* AIReviewStore.swift in Sources */,
+				68EE3E2F11A28AD898ABB03C /* AIReviewView.swift in Sources */,
 				1720E856ACCE0189331605F2 /* AdminStore.swift in Sources */,
 				E2E0551B857C17254E9B789B /* AdminView.swift in Sources */,
 				9D9E8D2C4A8A0C623AC1EF0D /* AppDelegate.swift in Sources */,

--- a/Xomper/Core/Models/AIReport.swift
+++ b/Xomper/Core/Models/AIReport.swift
@@ -1,0 +1,207 @@
+import SwiftUI
+
+/// One LLM-generated league report.
+///
+/// Backed by the `xomper-ai-reports` DynamoDB table — see F0 plan
+/// `docs/features/ai-review/f0-shared-infra/PLAN.md`. The same struct
+/// covers the three report types (post-draft, preseason, weekly) so a
+/// single archive list + single detail view can render all of them.
+///
+/// JSON shape (snake_case from the backend):
+/// ```json
+/// {
+///   "pk": "LEAGUE#<league_id>",
+///   "sk": "REPORT#weekly#2026W04",
+///   "league_id": "1181789700187090944",
+///   "report_type": "weekly",
+///   "period": "2026W04",
+///   "body_markdown": "## Week 4 …",
+///   "metadata": { "model": "...", "token_usage_in": 1234, ... },
+///   "created_at": "2026-09-30T15:42:11Z",
+///   "model": "claude-haiku-4-5",
+///   "prompt_version": "f0-2026-05-21"
+/// }
+/// ```
+struct AIReport: Decodable, Identifiable, Sendable, Hashable {
+    /// Composite ID. Derived from `pk + sk` so the struct is stable
+    /// across decodings. Not part of the wire payload.
+    let id: String
+    let leagueId: String
+    let reportType: AIReportType
+    let period: String
+    let bodyMarkdown: String
+    let metadata: [String: String]
+    let createdAt: Date
+    let model: String?
+    let promptVersion: String?
+
+    enum CodingKeys: String, CodingKey {
+        case pk, sk
+        case leagueId = "league_id"
+        case reportType = "report_type"
+        case period
+        case bodyMarkdown = "body_markdown"
+        case metadata
+        case createdAt = "created_at"
+        case model
+        case promptVersion = "prompt_version"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let pk = (try? c.decode(String.self, forKey: .pk)) ?? ""
+        let sk = (try? c.decode(String.self, forKey: .sk)) ?? ""
+        self.id = "\(pk)|\(sk)"
+        self.leagueId = (try? c.decode(String.self, forKey: .leagueId)) ?? ""
+        let rawType = (try? c.decode(String.self, forKey: .reportType)) ?? "weekly"
+        self.reportType = AIReportType(rawValue: rawType) ?? .weekly
+        self.period = (try? c.decode(String.self, forKey: .period)) ?? ""
+        self.bodyMarkdown = (try? c.decode(String.self, forKey: .bodyMarkdown)) ?? ""
+
+        // Metadata is a Dynamo Map of mixed scalars. Decode leniently as
+        // string→string so iOS doesn't need a full Any-codable layer.
+        if let raw = try? c.decode([String: AnyScalar].self, forKey: .metadata) {
+            var out: [String: String] = [:]
+            for (k, v) in raw { out[k] = v.stringValue }
+            self.metadata = out
+        } else {
+            self.metadata = [:]
+        }
+
+        // ISO 8601 with optional fractional seconds.
+        let createdRaw = (try? c.decode(String.self, forKey: .createdAt)) ?? ""
+        self.createdAt = AIReport.parseISO(createdRaw) ?? Date(timeIntervalSince1970: 0)
+
+        self.model = try? c.decodeIfPresent(String.self, forKey: .model)
+        self.promptVersion = try? c.decodeIfPresent(String.self, forKey: .promptVersion)
+    }
+
+    /// Memberwise init for tests / previews. Not used by the decoder.
+    init(
+        id: String,
+        leagueId: String,
+        reportType: AIReportType,
+        period: String,
+        bodyMarkdown: String,
+        metadata: [String: String] = [:],
+        createdAt: Date,
+        model: String? = nil,
+        promptVersion: String? = nil
+    ) {
+        self.id = id
+        self.leagueId = leagueId
+        self.reportType = reportType
+        self.period = period
+        self.bodyMarkdown = bodyMarkdown
+        self.metadata = metadata
+        self.createdAt = createdAt
+        self.model = model
+        self.promptVersion = promptVersion
+    }
+
+    /// Human-friendly title for cards and detail headers.
+    /// e.g. "Post-Draft Recap — 2026" / "Week 4 Recap — 2026W04".
+    var displayTitle: String {
+        "\(reportType.displayName) — \(period)"
+    }
+
+    /// First ~80 chars of the markdown body, stripped of leading
+    /// markdown markers. Used by the archive list + Home card.
+    var previewSnippet: String {
+        let lines = bodyMarkdown
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { String($0) }
+        // Skip leading headings — prefer the first paragraph.
+        let firstParagraph = lines.first(where: { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("#") })
+            ?? lines.first
+            ?? ""
+        let stripped = firstParagraph
+            .replacingOccurrences(of: "**", with: "")
+            .replacingOccurrences(of: "*", with: "")
+            .replacingOccurrences(of: "`", with: "")
+            .trimmingCharacters(in: .whitespaces)
+        if stripped.count <= 120 { return stripped }
+        let idx = stripped.index(stripped.startIndex, offsetBy: 120)
+        return String(stripped[..<idx]) + "…"
+    }
+
+    private static func parseISO(_ raw: String) -> Date? {
+        guard !raw.isEmpty else { return nil }
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let d = iso.date(from: raw) { return d }
+        iso.formatOptions = [.withInternetDateTime]
+        return iso.date(from: raw)
+    }
+}
+
+/// One of the three AI report flavors the backend produces. The raw
+/// values mirror what `report_type` carries in DynamoDB / the API.
+enum AIReportType: String, Codable, Sendable, CaseIterable, Hashable {
+    case postDraft = "post-draft"
+    case preseason
+    case weekly
+
+    /// Display name used in chips and titles.
+    var displayName: String {
+        switch self {
+        case .postDraft: "Post-Draft"
+        case .preseason: "Preseason"
+        case .weekly:    "Weekly"
+        }
+    }
+
+    /// SF Symbol used as the chip glyph.
+    var systemImage: String {
+        switch self {
+        case .postDraft: "list.clipboard.fill"
+        case .preseason: "calendar"
+        case .weekly:    "sparkles"
+        }
+    }
+
+    /// Accent color used on the type chip. All three lean on the
+    /// Midnight Emerald palette; championGold is the AI Review accent
+    /// per the F0 plan.
+    var accentColor: Color {
+        switch self {
+        case .postDraft: XomperColors.championGold
+        case .preseason: XomperColors.successGreen
+        case .weekly:    XomperColors.championGold
+        }
+    }
+}
+
+// MARK: - Helpers
+
+/// Tiny shim that decodes a Dynamo Map attribute (JSON object of
+/// mixed scalars) into something string-coercible. The Anthropic
+/// metadata blob holds counts + names so this is sufficient — no
+/// nested objects to traverse.
+private enum AnyScalar: Decodable, Sendable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+    case null
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if c.decodeNil() { self = .null; return }
+        if let v = try? c.decode(String.self) { self = .string(v); return }
+        if let v = try? c.decode(Int.self)    { self = .int(v); return }
+        if let v = try? c.decode(Double.self) { self = .double(v); return }
+        if let v = try? c.decode(Bool.self)   { self = .bool(v); return }
+        self = .null
+    }
+
+    var stringValue: String {
+        switch self {
+        case .string(let s): s
+        case .int(let i):    String(i)
+        case .double(let d): String(d)
+        case .bool(let b):   String(b)
+        case .null:          ""
+        }
+    }
+}

--- a/Xomper/Core/Networking/XomperAPIClient.swift
+++ b/Xomper/Core/Networking/XomperAPIClient.swift
@@ -13,6 +13,10 @@ protocol XomperAPIClientProtocol: Sendable {
     // Admin portal
     func adminListNotifications(sleeperUserId: String, daysBack: Int, kind: String?, status: String?, limit: Int) async throws -> AdminNotificationsResponse
     func adminTestSend(sleeperUserId: String, email: String?, kind: String, channels: [String]) async throws -> AdminTestSendResponse
+
+    // AI Review
+    func fetchLatestAIReport(type: AIReportType) async throws -> AIReport?
+    func fetchAIReportsList(type: AIReportType?, limit: Int, cursor: String?) async throws -> AIReportsListResponse
 }
 
 // MARK: - Request Payloads
@@ -144,6 +148,28 @@ struct AdminNotificationLogEntry: Decodable, Identifiable, Sendable, Hashable {
 struct AdminNotificationsResponse: Decodable, Sendable {
     let rows: [AdminNotificationLogEntry]
     let count: Int
+}
+
+// MARK: - AI Review
+
+/// Wraps `/ai-reports/latest`. Backend returns
+/// `{ "report": {...} | null }` and the client unwraps `report` to a
+/// nilable `AIReport`.
+struct AIReportLatestResponse: Decodable, Sendable {
+    let report: AIReport?
+}
+
+/// Wraps `/ai-reports/list`. `rows` is newest-first via the
+/// `created-at-index` GSI; `nextCursor` is the opaque pagination
+/// token returned by Dynamo.
+struct AIReportsListResponse: Decodable, Sendable {
+    let rows: [AIReport]
+    let nextCursor: String?
+
+    enum CodingKeys: String, CodingKey {
+        case rows
+        case nextCursor = "next_cursor"
+    }
 }
 
 struct AdminTestSendResponse: Decodable, Sendable {
@@ -348,6 +374,41 @@ final class XomperAPIClient: XomperAPIClientProtocol {
             body["email"] = email
         }
         return try await postDecoding("/admin/test-send", body: body)
+    }
+
+    // MARK: - AI Review
+
+    /// Latest report of a given type for the active whitelisted
+    /// league. Backend resolves the league via Supabase, so the
+    /// caller doesn't pass a leagueId. Returns `nil` when no report
+    /// of that type exists yet (empty state on a fresh table).
+    func fetchLatestAIReport(type: AIReportType) async throws -> AIReport? {
+        let items: [URLQueryItem] = [
+            URLQueryItem(name: "type", value: type.rawValue),
+        ]
+        let response: AIReportLatestResponse = try await get("/ai-reports/latest", queryItems: items)
+        return response.report
+    }
+
+    /// Paginated archive across all report types (or filtered to one
+    /// type when `type` is non-nil). `limit` caps the per-page row
+    /// count; `cursor` is the opaque token returned by a previous
+    /// call's `nextCursor`.
+    func fetchAIReportsList(
+        type: AIReportType? = nil,
+        limit: Int = 20,
+        cursor: String? = nil
+    ) async throws -> AIReportsListResponse {
+        var items: [URLQueryItem] = [
+            URLQueryItem(name: "limit", value: String(limit)),
+        ]
+        if let type {
+            items.append(URLQueryItem(name: "type", value: type.rawValue))
+        }
+        if let cursor, !cursor.isEmpty {
+            items.append(URLQueryItem(name: "cursor", value: cursor))
+        }
+        return try await get("/ai-reports/list", queryItems: items)
     }
 
     // MARK: - Private

--- a/Xomper/Core/Stores/AIReviewStore.swift
+++ b/Xomper/Core/Stores/AIReviewStore.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+/// Drives the AI Review surfaces — Home banner, archive list, detail
+/// view. One store instance is held by `MainShell` and shared across
+/// all three views so a single fetch populates everything.
+///
+/// Data sources:
+/// - `latestByType[.weekly]` etc. — latest-per-type, populated by
+///   `loadLatest(type:)`. Home banner picks the most-recent across
+///   the three types.
+/// - `archive` — newest-first paginated list, populated by
+///   `loadArchive()`. `loadMore()` advances the cursor.
+///
+/// Freshness: `loadLatest` short-circuits when a value is already in
+/// the dictionary AND the store was fetched within the last 12 hours
+/// — mirrors `PlayerValuesStore`. `force: true` bypasses.
+@Observable
+@MainActor
+final class AIReviewStore {
+
+    // MARK: - State
+
+    /// Latest report keyed by type. Empty until first `loadLatest` lands.
+    private(set) var latestByType: [AIReportType: AIReport] = [:]
+
+    /// Newest-first archive list across all report types.
+    private(set) var archive: [AIReport] = []
+
+    /// Opaque pagination cursor for the next archive page.
+    /// `nil` means no more pages.
+    private(set) var archiveCursor: String?
+
+    private(set) var isLoading = false
+    private(set) var isLoadingMore = false
+    private(set) var error: Error?
+    private(set) var lastLoadedAt: Date?
+
+    // MARK: - Dependencies
+
+    private let apiClient: XomperAPIClientProtocol
+
+    init(apiClient: XomperAPIClientProtocol = XomperAPIClient()) {
+        self.apiClient = apiClient
+    }
+
+    // MARK: - Loaders
+
+    /// Fetch the latest report for one type. Skips re-fetch within
+    /// 12 hours unless `force` is set. Called from the Home card on
+    /// appearance (in parallel for all three types).
+    func loadLatest(type: AIReportType, force: Bool = false) async {
+        if !force,
+           latestByType[type] != nil,
+           let last = lastLoadedAt,
+           Date().timeIntervalSince(last) < 12 * 60 * 60 {
+            return
+        }
+        do {
+            if let report = try await apiClient.fetchLatestAIReport(type: type) {
+                latestByType[type] = report
+            } else {
+                // Backend returned null — explicitly clear so the UI
+                // doesn't keep showing a stale value from before this
+                // call. (No-op if it wasn't there.)
+                latestByType.removeValue(forKey: type)
+            }
+            lastLoadedAt = Date()
+        } catch {
+            self.error = error
+        }
+    }
+
+    /// Fetch the first page of the archive list. Replaces `archive`
+    /// + resets `archiveCursor`. Skips when already loaded within 12
+    /// hours unless `force` is set.
+    func loadArchive(force: Bool = false) async {
+        guard !isLoading else { return }
+        if !force,
+           !archive.isEmpty,
+           let last = lastLoadedAt,
+           Date().timeIntervalSince(last) < 12 * 60 * 60 {
+            return
+        }
+        isLoading = true
+        defer { isLoading = false }
+        error = nil
+
+        do {
+            let response = try await apiClient.fetchAIReportsList(
+                type: nil,
+                limit: 20,
+                cursor: nil
+            )
+            self.archive = response.rows
+            self.archiveCursor = response.nextCursor
+            self.lastLoadedAt = Date()
+        } catch {
+            self.error = error
+        }
+    }
+
+    /// Fetch the next page of the archive, appending to `archive`.
+    /// No-ops when `archiveCursor` is nil (no more pages) or a load
+    /// is already in flight.
+    func loadMore() async {
+        guard !isLoadingMore, !isLoading else { return }
+        guard let cursor = archiveCursor else { return }
+        isLoadingMore = true
+        defer { isLoadingMore = false }
+
+        do {
+            let response = try await apiClient.fetchAIReportsList(
+                type: nil,
+                limit: 20,
+                cursor: cursor
+            )
+            // De-dupe by id in case the cursor returns overlap.
+            let existing = Set(archive.map(\.id))
+            let fresh = response.rows.filter { !existing.contains($0.id) }
+            self.archive.append(contentsOf: fresh)
+            self.archiveCursor = response.nextCursor
+        } catch {
+            self.error = error
+        }
+    }
+
+    /// Clear all state and force a full reload — used by
+    /// pull-to-refresh.
+    func refresh() async {
+        archive = []
+        archiveCursor = nil
+        latestByType = [:]
+        lastLoadedAt = nil
+        error = nil
+        await loadArchive(force: true)
+    }
+
+    // MARK: - Convenience
+
+    /// Most-recent report across all three types — the banner card
+    /// renders this. `nil` when no reports exist yet.
+    var mostRecentLatest: AIReport? {
+        latestByType
+            .values
+            .max(by: { $0.createdAt < $1.createdAt })
+    }
+}

--- a/Xomper/Features/AIReview/AIReviewDetailView.swift
+++ b/Xomper/Features/AIReview/AIReviewDetailView.swift
@@ -1,0 +1,141 @@
+import SwiftUI
+
+/// Full read of a single AI-generated league report. Renders the
+/// markdown body natively via `AttributedString(markdown:)` (iOS 17
+/// API — no extra SPM dep). Limited to inline styling (headings,
+/// bold, lists); no tables. Per the F0 plan this is acceptable —
+/// reports lean on those styles.
+struct AIReviewDetailView: View {
+    let report: AIReport
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.lg) {
+                headerCard
+                bodyCard
+                footerMeta
+            }
+            .padding(XomperTheme.Spacing.md)
+            .padding(.bottom, XomperTheme.Spacing.xxl)
+        }
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .navigationTitle(report.reportType.displayName)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+    }
+
+    // MARK: - Header
+
+    private var headerCard: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                typeChip
+                Spacer()
+                Text(formattedDate(report.createdAt))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.textMuted)
+                    .monospacedDigit()
+            }
+
+            Text(report.period)
+                .font(.title2.weight(.bold))
+                .foregroundStyle(XomperColors.textPrimary)
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(report.reportType.accentColor.opacity(0.35), lineWidth: 1)
+        )
+    }
+
+    private var typeChip: some View {
+        HStack(spacing: 4) {
+            Image(systemName: report.reportType.systemImage)
+                .font(.caption2.weight(.bold))
+            Text(report.reportType.displayName.uppercased())
+                .font(.caption2.weight(.bold))
+                .tracking(0.5)
+        }
+        .foregroundStyle(XomperColors.bgDark)
+        .padding(.horizontal, XomperTheme.Spacing.sm)
+        .padding(.vertical, 4)
+        .background(report.reportType.accentColor)
+        .clipShape(Capsule())
+    }
+
+    // MARK: - Body
+
+    private var bodyCard: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            renderedMarkdown
+                .font(.body)
+                .foregroundStyle(XomperColors.textPrimary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+    }
+
+    /// Native iOS 17 `AttributedString(markdown:)` with full
+    /// interpreted syntax (headings, lists, bold, links). Falls back
+    /// to a plain Text if the markdown is malformed.
+    private var renderedMarkdown: some View {
+        Group {
+            if let attributed = try? AttributedString(
+                markdown: report.bodyMarkdown,
+                options: AttributedString.MarkdownParsingOptions(
+                    interpretedSyntax: .full
+                )
+            ) {
+                Text(attributed)
+            } else {
+                Text(report.bodyMarkdown)
+            }
+        }
+    }
+
+    // MARK: - Footer
+
+    @ViewBuilder
+    private var footerMeta: some View {
+        if report.model != nil || report.promptVersion != nil {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+                if let model = report.model, !model.isEmpty {
+                    metaRow(label: "Model", value: model)
+                }
+                if let version = report.promptVersion, !version.isEmpty {
+                    metaRow(label: "Prompt", value: version)
+                }
+            }
+            .padding(.horizontal, XomperTheme.Spacing.sm)
+        }
+    }
+
+    private func metaRow(label: String, value: String) -> some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            Text(label)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(XomperColors.textMuted)
+                .tracking(0.5)
+                .textCase(.uppercase)
+            Text(value)
+                .font(.caption2)
+                .foregroundStyle(XomperColors.textSecondary)
+                .monospaced()
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, yyyy"
+        return formatter.string(from: date)
+    }
+}

--- a/Xomper/Features/AIReview/AIReviewHomeCard.swift
+++ b/Xomper/Features/AIReview/AIReviewHomeCard.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+/// Discoverable banner card for the most recent AI report. Lives at
+/// the topmost position of the Home / Search surface. Tapping
+/// switches the tray destination to `.aiReview` and pushes the
+/// detail view in one motion.
+///
+/// Renders **nothing** (zero height) when the store has no latest
+/// report — so empty-state Home is unchanged until the first report
+/// lands.
+struct AIReviewHomeCard: View {
+    let store: AIReviewStore
+    let navStore: NavigationStore
+    let router: AppRouter
+
+    var body: some View {
+        if let report = store.mostRecentLatest {
+            cardContent(report: report)
+                .padding(.horizontal, XomperTheme.Spacing.md)
+                .padding(.top, XomperTheme.Spacing.md)
+        } else {
+            // Zero-height when no report exists yet. Empty-state Home
+            // sees no change.
+            EmptyView()
+        }
+    }
+
+    private func cardContent(report: AIReport) -> some View {
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            // Switch tray to AI Review, then push detail. The two
+            // happen inside the same navStore animation envelope.
+            navStore.select(.aiReview, router: router)
+            router.navigate(to: .aiReportDetail(reportId: report.id))
+        } label: {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+                HStack(spacing: XomperTheme.Spacing.xs) {
+                    typeChip(for: report)
+                    Text(report.period)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(XomperColors.textSecondary)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(XomperColors.textMuted)
+                }
+
+                Text(report.displayTitle)
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+                    .lineLimit(1)
+
+                if !report.previewSnippet.isEmpty {
+                    Text(report.previewSnippet)
+                        .font(.caption)
+                        .foregroundStyle(XomperColors.textSecondary)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                }
+            }
+            .padding(XomperTheme.Spacing.md)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+            .overlay(
+                RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                    .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Latest AI report: \(report.displayTitle)")
+        .accessibilityHint("Double tap to read")
+    }
+
+    private func typeChip(for report: AIReport) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: report.reportType.systemImage)
+                .font(.caption2.weight(.bold))
+            Text(report.reportType.displayName.uppercased())
+                .font(.caption2.weight(.bold))
+                .tracking(0.5)
+        }
+        .foregroundStyle(XomperColors.bgDark)
+        .padding(.horizontal, XomperTheme.Spacing.sm)
+        .padding(.vertical, 4)
+        .background(XomperColors.championGold)
+        .clipShape(Capsule())
+    }
+}

--- a/Xomper/Features/AIReview/AIReviewView.swift
+++ b/Xomper/Features/AIReview/AIReviewView.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+
+/// AI Review archive. Newest-first list of every report the backend
+/// has generated. Tapping a row pushes `AIReviewDetailView`. Pull-
+/// to-refresh forces a re-fetch; the last row triggers
+/// `store.loadMore()` for infinite scroll.
+///
+/// Until the backend's `/ai-reports/list` endpoint is live the call
+/// errors out — the view renders the error inline. Once the route
+/// returns an empty array the empty state appears instead.
+struct AIReviewView: View {
+    let store: AIReviewStore
+    let router: AppRouter
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+                if store.isLoading && store.archive.isEmpty {
+                    LoadingView(message: "Loading reports…")
+                        .padding(.top, XomperTheme.Spacing.xl)
+                } else if let error = store.error, store.archive.isEmpty {
+                    ErrorView(message: error.localizedDescription) {
+                        Task { await store.loadArchive(force: true) }
+                    }
+                    .padding(.top, XomperTheme.Spacing.lg)
+                } else if store.archive.isEmpty {
+                    EmptyStateView(
+                        icon: "sparkles",
+                        title: "No reports yet",
+                        message: "First one lands after the next draft."
+                    )
+                    .padding(.top, XomperTheme.Spacing.xl)
+                } else {
+                    ForEach(Array(store.archive.enumerated()), id: \.element.id) { idx, report in
+                        AIReportCardRow(report: report) {
+                            router.navigate(to: .aiReportDetail(reportId: report.id))
+                        }
+                        .padding(.horizontal, XomperTheme.Spacing.md)
+                        .onAppear {
+                            // Infinite scroll: when the last visible
+                            // row mounts, request the next page.
+                            // No-op when the cursor is nil.
+                            if idx == store.archive.count - 1 {
+                                Task { await store.loadMore() }
+                            }
+                        }
+                    }
+
+                    if store.isLoadingMore {
+                        HStack {
+                            Spacer()
+                            ProgressView()
+                                .tint(XomperColors.championGold)
+                            Spacer()
+                        }
+                        .padding(.vertical, XomperTheme.Spacing.md)
+                    }
+                }
+            }
+            .padding(.vertical, XomperTheme.Spacing.sm)
+            .padding(.bottom, XomperTheme.Spacing.xl)
+        }
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .task {
+            await store.loadArchive()
+        }
+        .refreshable {
+            await store.refresh()
+        }
+    }
+}
+
+// MARK: - Row
+
+/// Compact archive row — type chip, period, snippet, relative date.
+/// Tappable card with the standard pressable feedback.
+private struct AIReportCardRow: View {
+    let report: AIReport
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            onTap()
+        }) {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+                HStack(spacing: XomperTheme.Spacing.xs) {
+                    typeChip
+                    Text(report.period)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(XomperColors.textSecondary)
+                    Spacer()
+                    Text(relativeDate(report.createdAt))
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .monospacedDigit()
+                }
+
+                if !report.previewSnippet.isEmpty {
+                    Text(report.previewSnippet)
+                        .font(.subheadline)
+                        .foregroundStyle(XomperColors.textPrimary)
+                        .lineLimit(3)
+                        .multilineTextAlignment(.leading)
+                }
+
+                HStack {
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(XomperColors.textMuted)
+                }
+            }
+            .padding(XomperTheme.Spacing.md)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+            .overlay(
+                RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                    .strokeBorder(report.reportType.accentColor.opacity(0.25), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(report.reportType.displayName) report, \(report.period)")
+        .accessibilityHint("Double tap to read full report")
+    }
+
+    private var typeChip: some View {
+        HStack(spacing: 4) {
+            Image(systemName: report.reportType.systemImage)
+                .font(.caption2.weight(.bold))
+            Text(report.reportType.displayName.uppercased())
+                .font(.caption2.weight(.bold))
+                .tracking(0.5)
+        }
+        .foregroundStyle(XomperColors.bgDark)
+        .padding(.horizontal, XomperTheme.Spacing.sm)
+        .padding(.vertical, 4)
+        .background(report.reportType.accentColor)
+        .clipShape(Capsule())
+    }
+
+    private func relativeDate(_ date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}

--- a/Xomper/Features/Home/SearchView.swift
+++ b/Xomper/Features/Home/SearchView.swift
@@ -13,6 +13,7 @@ struct SearchView: View {
     var authStore: AuthStore
     var router: AppRouter
     var navStore: NavigationStore
+    var aiReviewStore: AIReviewStore
 
     @State private var searchStore: SearchStore
 
@@ -21,13 +22,15 @@ struct SearchView: View {
         playerStore: PlayerStore,
         authStore: AuthStore,
         router: AppRouter,
-        navStore: NavigationStore
+        navStore: NavigationStore,
+        aiReviewStore: AIReviewStore
     ) {
         self.leagueStore = leagueStore
         self.playerStore = playerStore
         self.authStore = authStore
         self.router = router
         self.navStore = navStore
+        self.aiReviewStore = aiReviewStore
         _searchStore = State(
             initialValue: SearchStore(playerStore: playerStore)
         )
@@ -35,6 +38,11 @@ struct SearchView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            AIReviewHomeCard(
+                store: aiReviewStore,
+                navStore: navStore,
+                router: router
+            )
             searchControls
             resultArea
         }
@@ -42,6 +50,15 @@ struct SearchView: View {
         .navigationTitle("Search")
         .navigationBarTitleDisplayMode(.large)
         .toolbarColorScheme(.dark, for: .navigationBar)
+        .task {
+            // Prime the latest-by-type lookup for the home banner.
+            // All three loads run in parallel; the card picks the
+            // newest. Each respects the store's 12-hour freshness.
+            async let post: () = aiReviewStore.loadLatest(type: .postDraft)
+            async let pre:  () = aiReviewStore.loadLatest(type: .preseason)
+            async let week: () = aiReviewStore.loadLatest(type: .weekly)
+            _ = await (post, pre, week)
+        }
     }
 
     // MARK: - Search Controls
@@ -295,7 +312,8 @@ struct SearchView: View {
             playerStore: PlayerStore(),
             authStore: AuthStore(),
             router: AppRouter(),
-            navStore: NavigationStore()
+            navStore: NavigationStore(),
+            aiReviewStore: AIReviewStore()
         )
     }
     .preferredColorScheme(.dark)

--- a/Xomper/Features/Shell/DrawerView.swift
+++ b/Xomper/Features/Shell/DrawerView.swift
@@ -40,7 +40,7 @@ struct DrawerView: View {
             ),
             TraySection(
                 title: "League",
-                entries: [.payouts, .draftOrder, .rulebook, .scoring, .leagueSettings, .ruleProposals]
+                entries: [.payouts, .draftOrder, .aiReview, .rulebook, .scoring, .leagueSettings, .ruleProposals]
             ),
         ]
         if isAdmin {

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -30,6 +30,7 @@ struct MainShell: View {
     @State private var seasonStore = SeasonStore()
     @State private var valuesStore = PlayerValuesStore()
     @State private var playerPointsStore = PlayerPointsStore()
+    @State private var aiReviewStore = AIReviewStore()
 
     // MARK: - Body
 
@@ -208,6 +209,12 @@ struct MainShell: View {
                     playerPointsStore: playerPointsStore,
                     userStore: userStore,
                     nflStateStore: nflStateStore
+                )
+
+            case .aiReview:
+                AIReviewView(
+                    store: aiReviewStore,
+                    router: router
                 )
 
             case .admin:
@@ -396,7 +403,8 @@ struct MainShell: View {
                 playerStore: playerStore,
                 authStore: authStore,
                 router: router,
-                navStore: navStore
+                navStore: navStore,
+                aiReviewStore: aiReviewStore
             )
 
         case .settings:
@@ -419,7 +427,29 @@ struct MainShell: View {
 
         case .leagueOverview(let leagueId):
             LeagueOverviewView(leagueId: leagueId, router: router)
+
+        case .aiReportDetail(let reportId):
+            if let report = resolveAIReport(id: reportId) {
+                AIReviewDetailView(report: report)
+            } else {
+                EmptyStateView(
+                    icon: "sparkles",
+                    title: "Report Not Found",
+                    message: "We couldn't load this report — pull to refresh the archive."
+                )
+            }
         }
+    }
+
+    /// Look up an `AIReport` from the store by its composite id. The
+    /// archive is the canonical source; if not present, fall back to
+    /// the latest-by-type cache. Returns nil if neither contains a
+    /// match.
+    private func resolveAIReport(id: String) -> AIReport? {
+        if let hit = aiReviewStore.archive.first(where: { $0.id == id }) {
+            return hit
+        }
+        return aiReviewStore.latestByType.values.first(where: { $0.id == id })
     }
 
     // MARK: - Edge swipe → drawer

--- a/Xomper/Features/Shell/TrayDestination.swift
+++ b/Xomper/Features/Shell/TrayDestination.swift
@@ -25,6 +25,7 @@ enum TrayDestination: Hashable {
     case ruleProposals
     case payouts
     case draftOrder
+    case aiReview
     case admin
     case profile
     case settings
@@ -48,6 +49,7 @@ enum TrayDestination: Hashable {
         case .ruleProposals:  "Rule Proposals"
         case .payouts:        "Payouts"
         case .draftOrder:     "Draft Order Proposal"
+        case .aiReview:       "AI Review"
         case .admin:          "Admin"
         case .profile:        "Profile"
         case .settings:       "Settings"
@@ -72,6 +74,7 @@ enum TrayDestination: Hashable {
         case .ruleProposals:  "checkmark.bubble.fill"
         case .payouts:        "dollarsign.circle.fill"
         case .draftOrder:     "list.bullet.rectangle"
+        case .aiReview:       "sparkles"
         case .admin:          "wrench.and.screwdriver.fill"
         case .profile:        "person.crop.circle.fill"
         case .settings:       "gearshape.fill"

--- a/Xomper/Navigation/AppRouter.swift
+++ b/Xomper/Navigation/AppRouter.swift
@@ -19,6 +19,10 @@ enum AppRoute: Hashable {
     /// when the user taps a non-home league in profile or search. The
     /// view fetches its own data — does NOT mutate `LeagueStore.myLeague`.
     case leagueOverview(leagueId: String)
+    /// Detail view for one AI-generated league report. `reportId`
+    /// matches `AIReport.id` (computed from `pk|sk`) and the detail
+    /// view resolves the struct from `AIReviewStore`.
+    case aiReportDetail(reportId: String)
 }
 
 /// Owns the inner `NavigationStack` path inside `MainShell`. The drawer

--- a/XomperTests/AIReviewStoreTests.swift
+++ b/XomperTests/AIReviewStoreTests.swift
@@ -1,0 +1,205 @@
+import XCTest
+@testable import Xomper
+
+@MainActor
+final class AIReviewStoreTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeReport(
+        id: String = "L1|REPORT#weekly#2026W04",
+        type: AIReportType = .weekly,
+        period: String = "2026W04",
+        createdAt: Date = Date()
+    ) -> AIReport {
+        AIReport(
+            id: id,
+            leagueId: "L1",
+            reportType: type,
+            period: period,
+            bodyMarkdown: "## Recap\nWho lost. Who won. Tough week for Tony.",
+            metadata: [:],
+            createdAt: createdAt,
+            model: "claude-haiku-4-5",
+            promptVersion: "f0-2026-05-21"
+        )
+    }
+
+    // MARK: - Test 1: loadLatest populates latestByType for postDraft
+
+    func testLoadLatest_populatesLatestByType_forPostDraft() async {
+        let report = makeReport(
+            id: "L1|REPORT#post-draft#2026-POSTDRAFT",
+            type: .postDraft,
+            period: "2026-POSTDRAFT"
+        )
+        let mock = MockXomperAPIClient(latest: [.postDraft: report])
+        let store = AIReviewStore(apiClient: mock)
+
+        await store.loadLatest(type: .postDraft)
+
+        XCTAssertEqual(store.latestByType[.postDraft]?.id, report.id)
+        XCTAssertNil(store.error)
+        XCTAssertEqual(mock.latestCalls.count, 1)
+        XCTAssertEqual(mock.latestCalls.first, .postDraft)
+    }
+
+    // MARK: - Test 2: loadArchive populates archive
+
+    func testLoadArchive_populatesArchive() async {
+        let r1 = makeReport(id: "L1|REPORT#weekly#2026W04", period: "2026W04")
+        let r2 = makeReport(id: "L1|REPORT#weekly#2026W03", period: "2026W03")
+        let mock = MockXomperAPIClient(listPages: [
+            (rows: [r1, r2], cursor: nil)
+        ])
+        let store = AIReviewStore(apiClient: mock)
+
+        await store.loadArchive()
+
+        XCTAssertEqual(store.archive.count, 2)
+        XCTAssertEqual(store.archive.map(\.id), [r1.id, r2.id])
+        XCTAssertNil(store.archiveCursor)
+        XCTAssertFalse(store.isLoading)
+    }
+
+    // MARK: - Test 3: loadMore appends without duplication and advances cursor
+
+    func testLoadMore_appendsAndAdvancesCursor() async {
+        let r1 = makeReport(id: "L1|REPORT#weekly#2026W04", period: "2026W04")
+        let r2 = makeReport(id: "L1|REPORT#weekly#2026W03", period: "2026W03")
+        let r3 = makeReport(id: "L1|REPORT#weekly#2026W02", period: "2026W02")
+        // r2 deliberately repeated across pages to verify de-dup
+        // (cursor walks back through the GSI; overlap is harmless).
+        let mock = MockXomperAPIClient(listPages: [
+            (rows: [r1, r2], cursor: "cursor-1"),
+            (rows: [r2, r3], cursor: nil)
+        ])
+        let store = AIReviewStore(apiClient: mock)
+
+        await store.loadArchive()
+        XCTAssertEqual(store.archive.count, 2)
+        XCTAssertEqual(store.archiveCursor, "cursor-1")
+
+        await store.loadMore()
+        XCTAssertEqual(store.archive.count, 3, "r2 should not be duplicated")
+        XCTAssertEqual(store.archive.map(\.id), [r1.id, r2.id, r3.id])
+        XCTAssertNil(store.archiveCursor)
+    }
+
+    // MARK: - Test 4: 12-hour freshness skip
+
+    func testLoadLatest_skipsWithinFreshnessWindow() async {
+        let report = makeReport()
+        let mock = MockXomperAPIClient(latest: [.weekly: report])
+        let store = AIReviewStore(apiClient: mock)
+
+        await store.loadLatest(type: .weekly)
+        XCTAssertEqual(mock.latestCalls.count, 1)
+
+        // Second call within 12h — must be skipped.
+        await store.loadLatest(type: .weekly)
+        XCTAssertEqual(mock.latestCalls.count, 1, "Should short-circuit inside the 12-hour window")
+
+        // Forced refresh — must re-fetch.
+        await store.loadLatest(type: .weekly, force: true)
+        XCTAssertEqual(mock.latestCalls.count, 2)
+    }
+
+    // MARK: - Test 5: loadMore no-ops when cursor is nil
+
+    func testLoadMore_noopWhenCursorIsNil() async {
+        let mock = MockXomperAPIClient(listPages: [
+            (rows: [makeReport()], cursor: nil)
+        ])
+        let store = AIReviewStore(apiClient: mock)
+
+        await store.loadArchive()
+        let listCallsBefore = mock.listCalls.count
+
+        await store.loadMore()
+        XCTAssertEqual(mock.listCalls.count, listCallsBefore, "loadMore should be a no-op when cursor is nil")
+    }
+
+    // MARK: - Test 6: mostRecentLatest picks newest across types
+
+    func testMostRecentLatest_picksNewestAcrossTypes() async {
+        let older = makeReport(
+            id: "L1|REPORT#preseason#2026-PRE",
+            type: .preseason,
+            period: "2026-PRE",
+            createdAt: Date(timeIntervalSinceNow: -86_400 * 30)
+        )
+        let newer = makeReport(
+            id: "L1|REPORT#weekly#2026W01",
+            type: .weekly,
+            period: "2026W01",
+            createdAt: Date(timeIntervalSinceNow: -86_400)
+        )
+        let mock = MockXomperAPIClient(latest: [
+            .preseason: older,
+            .weekly: newer
+        ])
+        let store = AIReviewStore(apiClient: mock)
+
+        await store.loadLatest(type: .preseason)
+        await store.loadLatest(type: .weekly)
+
+        XCTAssertEqual(store.mostRecentLatest?.id, newer.id)
+    }
+}
+
+// MARK: - Mock API Client
+
+/// Sendable mock for AI Review endpoints only. Other protocol methods
+/// throw to ensure they aren't accidentally exercised by these tests.
+final class MockXomperAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
+    var latest: [AIReportType: AIReport]
+    var listPages: [(rows: [AIReport], cursor: String?)]
+
+    private(set) var latestCalls: [AIReportType] = []
+    private(set) var listCalls: [(type: AIReportType?, limit: Int, cursor: String?)] = []
+    private var listPageIndex = 0
+
+    init(
+        latest: [AIReportType: AIReport] = [:],
+        listPages: [(rows: [AIReport], cursor: String?)] = []
+    ) {
+        self.latest = latest
+        self.listPages = listPages
+    }
+
+    // MARK: AI Review
+
+    func fetchLatestAIReport(type: AIReportType) async throws -> AIReport? {
+        latestCalls.append(type)
+        return latest[type]
+    }
+
+    func fetchAIReportsList(
+        type: AIReportType?,
+        limit: Int,
+        cursor: String?
+    ) async throws -> AIReportsListResponse {
+        listCalls.append((type, limit, cursor))
+        guard listPageIndex < listPages.count else {
+            return AIReportsListResponse(rows: [], nextCursor: nil)
+        }
+        let page = listPages[listPageIndex]
+        listPageIndex += 1
+        return AIReportsListResponse(rows: page.rows, nextCursor: page.cursor)
+    }
+
+    // MARK: Unused protocol surface — throw to catch accidental calls
+
+    func sendRuleProposalEmail(proposal: RuleProposalEmailPayload, recipients: [String], userIds: [String]) async throws { throw Unsupported.method }
+    func sendRuleAcceptedEmail(proposal: RuleProposalEmailPayload, approvedBy: [String], rejectedBy: [String], recipients: [String], userIds: [String]) async throws { throw Unsupported.method }
+    func sendRuleDeniedEmail(proposal: RuleProposalEmailPayload, approvedBy: [String], rejectedBy: [String], recipients: [String], userIds: [String]) async throws { throw Unsupported.method }
+    func sendTaxiStealEmail(stealer: TaxiStealerPayload, player: TaxiPlayerPayload, owner: TaxiOwnerPayload, recipients: [String], userIds: [String], leagueName: String) async throws { throw Unsupported.method }
+    func registerDevice(userId: String, deviceToken: String) async throws { throw Unsupported.method }
+    func unregisterDevice(userId: String, deviceToken: String) async throws { throw Unsupported.method }
+    func adminListNotifications(sleeperUserId: String, daysBack: Int, kind: String?, status: String?, limit: Int) async throws -> AdminNotificationsResponse { throw Unsupported.method }
+    func adminTestSend(sleeperUserId: String, email: String?, kind: String, channels: [String]) async throws -> AdminTestSendResponse { throw Unsupported.method }
+
+    enum Unsupported: Error { case method }
+}
+

--- a/docs/features/ai-review/BRAINSTORM.md
+++ b/docs/features/ai-review/BRAINSTORM.md
@@ -1,0 +1,300 @@
+# Brainstorm — Weekly AI Review / Draft Review (Issue #79)
+
+Status: Draft
+Date: 2026-05-21
+Author: brainstorm agent
+
+---
+
+## Problem (restated)
+
+We want Claude (Haiku) to write three personality-driven, league-aware reports for the Xomper league, each delivered through two surfaces (email-to-every-manager + iOS landing page):
+
+1. **Weekly recap** — runs on cron Tue/Wed AM during the season. Roasts every manager by name using a persistent "lore" pack (favorite teams, schools, embarrassing stories, life events). Mixes matchup results + league-wide notes + light NFL news.
+2. **Preseason blast** — one-shot before the season. Team-by-team "last year's grade + this year's outlook," dripping with league in-jokes.
+3. **Post-draft analysis** — one-shot after the rookie draft. Team-by-team grade and outlook on each manager's picks.
+
+All three are LLM-generated. The user wants the output to feel mean, funny, personal — not corporate-AI. Lore must persist (and ideally grow over the season).
+
+This is fundamentally a **content-generation pipeline** bolted onto an existing cron + email/push stack — not a model-research project. The infrastructure pattern (EventBridge → scheduled Lambda → SES + SNS + DynamoDB → API GW endpoint for iOS) already exists for `notif_weekly_recap`. The new work is: add Claude API call, persist generated content, add a personalization "lore" store, and surface in iOS.
+
+**This is a multi-repo feature.** It touches:
+- `xomper-back-end` — new lambdas + email templates + Claude helper
+- `xomper-infrastructure` — new cron triggers, new DynamoDB table, new SSM secret, new API endpoint
+- `xomper-ios` — new tray destination + API client + store + view
+
+I'd recommend planning it as an **epic** (one parent stub, three child features — one per report type plus shared infra), not a single feature. See "Shipping order" below.
+
+---
+
+## Phase 1 — Wide exploration
+
+Loose dump of every angle worth considering, no filtering:
+
+- Single mega-lambda that handles all three report types (`notif_ai_review` with a `report_type` event arg)
+- Three separate lambdas, one per report type
+- One "generator" lambda + one "deliverer" lambda, decoupled via DynamoDB
+- Use Bedrock (Anthropic-via-AWS) instead of api.anthropic.com — IAM auth, no key in SSM
+- Use direct Anthropic API — cheaper per token, easier to swap models, but key lives in SSM
+- Store reports in DynamoDB (per-league + per-period key)
+- Store reports in S3 as JSON or Markdown blobs
+- Store nothing — fire-and-forget email only
+- Pre-generate once globally vs per-manager personalization (1 LLM call vs 12)
+- Hybrid: 1 LLM call for league section + 12 cheap LLM calls for per-manager roasts, then template-stitch
+- Lore lives in a Python constant in `lambdas/common/league_lore.py` — easy to start, gated behind PR review
+- Lore lives in a new DynamoDB table `xomper-league-lore` — editable via admin endpoint without redeploy
+- Lore lives in Supabase profiles — already exists, but extending RLS-protected user schema for joke data feels off
+- Lore as a hand-authored Markdown file checked into the backend repo, loaded at lambda cold-start — diffable + reviewable + no infra
+- Weekly recap auto-appends new "memories" each week (e.g. "Greg blew an 80% win prob") so the lore grows automatically
+- Manual lore-update endpoint for the admin portal so the user can drop in real events ("Tony got engaged")
+- Push notification is just a teaser ("Your Week 4 roast is in"), email + landing page have the full content
+- Personalized email per manager (12 LLM calls) vs one league-wide newsletter (1 LLM call, identical for all)
+- Hybrid: shared league newsletter content but a personalized subject line + opening paragraph per manager
+- Use Anthropic's web_search tool for live NFL news — gated behind a feature flag, costs more, real injury context
+- Skip live NFL news in v1, lean on Sleeper's trending players + matchup numbers + Claude's training-cutoff knowledge
+- Pull a free news feed (ESPN RSS, FantasyPros) into a sidecar lambda, pass blurbs into the prompt
+- Have Claude output structured JSON (sections, roasts, headlines) so iOS can render it natively styled, not HTML
+- Have Claude output Markdown — easy to render both in email (markdown-to-HTML) and iOS (AttributedString)
+- Have Claude output HTML for email + plain text for iOS — annoying to keep aligned, rule out
+- Store the prompt template itself as a versioned constant in the repo so tone can be tuned in PRs
+- Allow the admin portal to override/tune the prompt at runtime (overkill for v1, defer)
+- Run a "dry-run" mode where the lambda generates the report and emails it only to the admin for review before broadcasting
+- Add a "regenerate" button in the iOS admin portal — fires the lambda manually, useful when the AI writes something flat
+- Add a "send now" admin button that pulls the latest stored report and re-emails the league
+- Idempotency key on the DynamoDB store: `(league_id, report_type, period_key)` — re-running the cron updates in place, no double-email
+- Make the landing page show an archive (Week 1, Week 2, ...) with a tap-to-open detail view, not just the latest
+- Inject the latest report card into the Home screen as a "What's New" banner that opens the full read view
+- Show only the most recent report (no archive) — simpler, ship faster
+- Both — Home banner + tray destination with archive
+- Make the post-draft report block-driven so each team's section can be tapped to expand into round-by-round breakdown
+- Add a "fan favorite line of the week" social-share screenshot button in iOS
+- Add CloudWatch alarms on Claude API spend (per-day token budget cap)
+- Use Haiku-3.5 for all three reports (cheapest); reserve Sonnet for explicit "premium roast" mode if cost allows
+- Use Sonnet for post-draft (richer analysis), Haiku for weekly + preseason (volume)
+- Cache an output sample in DynamoDB so the iOS landing page renders fast even on first load
+- Have the lambda write to S3 as static markdown so xomware.com web hub could surface it too (future-proof)
+- Build a "season journal" — append per-manager memorable events as JSONL each week, then feed last N entries into the next week's prompt as context
+- Manual "block list" — phrases or topics the LLM must never include (legal/safety guard for the very dark jokes the issue body hints at)
+- Have the LLM produce two passes: draft → self-critique → final, to squeeze out generic ChatGPT-isms
+- Pre-bake five "voice samples" in the prompt — paragraphs that exemplify the tone — to anchor style
+- A/B test two prompt voices on Week 1 and let the league vote which one to keep
+- Add a small "regenerate just my section" affordance in iOS (rate-limited)
+- Defer iOS landing page entirely in v1 — ship email only, add the page in v1.1 once we know the format stabilizes
+
+---
+
+## Phase 2 — Converge
+
+For each architectural question (Q1–Q6), narrow to 2–3 viable options with tradeoffs.
+
+### Q1: Where does the Claude API get called?
+
+#### Option A: Inline in the scheduled lambda
+- Same handler does Sleeper fetch → Claude call → SES send.
+- One lambda, one trigger, one log group. Reuses existing `notif_weekly_recap` pattern almost identically.
+- **Pros**: simplest; matches existing scheduled-lambda template; minimal new infra.
+- **Cons**: Claude call latency (5–30s for a long roast × 12 managers) bumps against Lambda 60s timeout — but we can raise to 5min for scheduled lambdas. If Claude API fails mid-loop, partial sends are messy to retry.
+- **Best if** the per-run wall clock stays under ~3 minutes and we accept "regenerate all on retry" semantics.
+
+#### Option B: Two lambdas — generator + deliverer, decoupled via DynamoDB
+- `notif_ai_review_generate` runs on cron, calls Claude, writes to `xomper-ai-reports` table.
+- `notif_ai_review_deliver` runs 10 min later, reads from table, sends email + push.
+- iOS reads from the same table via a new GET endpoint.
+- **Pros**: retry-friendly (generator can fail independently of delivery); idempotent on the generation side; iOS can read latest report even if delivery hasn't fired yet.
+- **Cons**: two lambdas, two crons, more moving parts; possible "report ready but not sent" gap.
+- **Best if** we want operational safety + the iOS surface to lead the email by minutes.
+
+#### Option C: Claude on the iOS client
+- Ruled out as stated. API key leak + per-user cost + no email surface.
+
+### Q2: Where does the generated report live?
+
+#### Option A: New DynamoDB table `xomper-ai-reports`
+- PK = `league_id_report_type` (e.g. `1234567890_weekly`), SK = `period_key` (e.g. `2026-W04`, `2026-preseason`, `2026-draft`).
+- Item value = `{ markdown, generated_at, model, prompt_version, sections: [...] }`.
+- iOS queries by PK with `ScanIndexForward=false` to get newest first.
+- **Pros**: matches existing Dynamo-first persistence pattern in this codebase (matchup_history, worldcup_snapshots, notification_log all follow it); cheap; PITR + KMS already wired in `dynamodb.tf` locals.
+- **Cons**: harder to expose to web hub if/when xomware.com wants to render reports too.
+
+#### Option B: S3 markdown blobs
+- One markdown file per report at `s3://xomper-ai-reports/<league_id>/<report_type>/<period>.md`, with a `latest.md` symlink object.
+- **Pros**: web-friendly; cheap; trivially diffable in console.
+- **Cons**: yet another infra surface, IAM, signed URLs for iOS, no native query API like Dynamo. Doesn't match existing patterns.
+
+#### Option C: Don't persist — email only
+- Skip the landing page. The issue explicitly asks for both surfaces, so this is a hard no.
+
+### Q3: Where does personalization "lore" live?
+
+#### Option A: Hand-authored Python module `lambdas/common/league_lore.py`
+- A dict-of-dicts keyed by `sleeper_user_id`. Reviewed in PR. Loaded at cold-start.
+- **Pros**: zero new infra; diffable; one source of truth; can include long strings of stories without DB pain; perfect for "fixed" lore (favorite team, school, life events).
+- **Cons**: every lore edit requires a PR + deploy; can't add a memory mid-week without redeploying.
+
+#### Option B: New DynamoDB table `xomper-league-lore`
+- PK = `sleeper_user_id`, item value = `{ fixed: {...}, memories: [{week, text, source}] }`.
+- Edited via an admin endpoint that the iOS admin portal calls.
+- **Pros**: editable without deploy; the "season journal" idea (auto-append memories each week) becomes trivial.
+- **Cons**: new table, new endpoints, new iOS admin UI. Heavier for v1.
+
+#### Option C: Hybrid — module for fixed lore, Dynamo for growing memories
+- Static "who this person is" stays in `league_lore.py` (PR-reviewable, biographical).
+- Growing "what happened this season" lives in a new table that the weekly lambda writes to + reads from.
+- **Pros**: each piece of data lives in the right place; static lore stays diffable; dynamic memories don't need a deploy.
+- **Cons**: two-source merge inside the prompt builder. Slightly more code but conceptually clean.
+
+### Q4: Email shape — one newsletter or 12 personalized?
+
+#### Option A: One league-wide newsletter, identical for all recipients
+- One LLM call, ~5k input + ~3k output tokens. ~$0.005 per send.
+- Each manager gets roasted in the body by name, but everyone reads the same email.
+- **Pros**: cheapest, simplest, single artifact; matches a real newsletter feel.
+- **Cons**: less "personalization magic" — but the issue mostly wants league-wide content that roasts everyone, not one secret email per manager.
+
+#### Option B: 12 personalized emails (one LLM call per manager)
+- Each manager's email leads with their own arc, then league section is appended.
+- **Pros**: feels exclusive; each manager gets a longer roast of themselves.
+- **Cons**: 12 LLM calls per recap; harder to retry; ~$0.04/run; subtle inconsistencies across emails ("Manager A's email says X about Manager B, Manager B's email says Y about Manager B").
+
+#### Option C: Hybrid — one LLM call produces full newsletter, then a thin templated personalized header per manager
+- Single LLM call generates the league newsletter body. Personalization is a static "Hey {name}, here's your Week N roast — find yours below" header that links to the manager's anchor in the email.
+- **Pros**: one source of truth, cost = 1 call, mild personalization without inconsistency risk.
+- **Cons**: less "wow" than Option B.
+
+### Q5: iOS landing page
+
+#### Option A: New tray destination `.aiReview`
+- New `TrayDestination` case with archive list + detail view that renders markdown.
+- **Pros**: matches existing nav model; archive is a real value-add ("read Week 3 roast again"); doesn't compete with Home screen.
+- **Cons**: extra clicks to discover.
+
+#### Option B: Home banner for the latest report
+- Inject a "What's New" card on Home that opens the report detail.
+- **Pros**: discoverable; users see fresh content immediately.
+- **Cons**: pushes other Home content down; only surfaces the latest.
+
+#### Option C: Both
+- Home shows latest card (tap → detail); tray destination shows the full archive.
+- **Pros**: best UX.
+- **Cons**: a bit more work, but the components are shared (one detail view, two entry points).
+
+### Q6: Live NFL news ingestion
+
+#### Option A: Skip live news in v1
+- Rely on Sleeper trending players API (free, already in `sleeper_helper`) for "who's hot" and on matchup numbers for "biggest blowout."
+- Claude's training data covers most player narratives up to its cutoff.
+- **Pros**: ship faster; zero new dependencies; cost stays predictable.
+- **Cons**: jokes about injuries / arrests / breaking news will be stale or hallucinated. Need to instruct the prompt to NOT invent news.
+
+#### Option B: Anthropic web_search beta in the prompt
+- Add `web_search` tool to the API call. Claude pulls real news mid-generation.
+- **Pros**: actually current; matches the issue's "real arrests / injuries / upsets" ask.
+- **Cons**: extra cost (~$0.01 per search), more latency, occasional flakiness. Worth doing in v2 once base pipeline works.
+
+#### Option C: Sidecar news-feed lambda
+- Pre-fetch ESPN RSS / FantasyPros headlines into a small JSON blob before the recap runs, pass into the prompt.
+- **Pros**: predictable cost, the LLM gets curated headlines instead of free-form web access.
+- **Cons**: another moving part. Defer.
+
+---
+
+## Phase 3 — Recommendations
+
+| Question | Pick | One-line reason |
+|---|---|---|
+| Q1 (where Claude runs) | **Option A** (inline scheduled lambda) | Matches `notif_weekly_recap` exactly; with timeout bumped to 5 min and Option C from Q4 (one LLM call) the runtime is well within budget. |
+| Q2 (storage) | **Option A** (DynamoDB `xomper-ai-reports`) | Matches existing persistence pattern, easy iOS query, idempotent upsert on re-run. |
+| Q3 (lore) | **Option C** (hybrid module + Dynamo memories) | Fixed bio stays diffable in PRs (where the sensitive personal data belongs); season memories grow automatically without a deploy. Start with just Option A in v1, add the Dynamo `memories` table when we get to Weekly. |
+| Q4 (email shape) | **Option C** (one LLM call + thin templated header) | Cost-efficient, no cross-email inconsistency, still feels personal in the subject + greeting. |
+| Q5 (iOS) | **Option C** (Home banner + tray archive) | Banner drives discovery, tray drives revisit. Shared detail view means it's barely more work than just one. |
+| Q6 (news) | **Option A** (skip in v1) | Defer web_search to v2; v1 leans on Sleeper trending + matchup data. Prompt instructs Claude not to invent news. |
+
+### Why this combo holds together
+
+- One scheduled lambda per report type (3 total: `notif_ai_review_weekly`, `notif_ai_review_preseason`, `notif_ai_review_postdraft`) each calling a shared `lambdas/common/claude_helper.py`.
+- All three write to the same `xomper-ai-reports` table.
+- All three pull fixed lore from `lambdas/common/league_lore.py` (and weekly additionally reads/writes the season-memory table once it exists).
+- All three send a single league-wide email via the existing `send_emails_concurrently` (one HTML body, 12 recipients) plus a teaser push.
+- iOS adds one new tray destination + one Home banner widget + one new API endpoint (`GET /api/ai-reports/latest?type=weekly|preseason|postdraft`).
+
+### Q7: Shipping order
+
+**Recommend: post-draft first**, then preseason, then weekly. Reasons:
+
+1. **Post-draft** is most time-urgent — July 6 2026 draft is ~6 weeks out. Shipping this first proves the end-to-end pipeline (Claude + Dynamo + email + iOS) with a low-stakes one-shot run.
+2. **Preseason** runs once in late August / early September. It's structurally similar to post-draft (one-shot, team-by-team outlook), so most of the lambda + prompt scaffolding is reusable. Low risk, ship next.
+3. **Weekly** is the highest-volume, most personalization-heavy, requires the season-memory store and a tighter tone — best done last, after we've calibrated voice on the two one-shots.
+
+Each ships as its own PR / feature plan, but they share the `claude_helper.py` + `xomper-ai-reports` table + `league_lore.py` + new iOS surfaces, so a parent epic doc should declare those shared pieces upfront.
+
+### Q8: Cost analysis (Haiku 3.5 pricing)
+
+- Input: $0.80/1M, Output: $4.00/1M (Haiku 3.5 current rates — sanity-check at plan time).
+- Per **weekly recap** (one LLM call, league newsletter):
+  - Input ~5k tokens (lore + matchup data + last 3 weeks of memories + prompt) = $0.004
+  - Output ~3k tokens (full newsletter) = $0.012
+  - **~$0.016 per week**, **~$0.30 per regular season**, **~$0.40 with playoffs**.
+- Per **preseason blast**: input ~6k + output ~6k = **~$0.029 once per season**.
+- Per **post-draft analysis**: input ~6k + output ~5k = **~$0.025 once per draft**.
+- **Total season cost: well under $1.** Even with 10x prompt growth or Sonnet for post-draft, under $5/season.
+- Set a CloudWatch billing alarm at $5/month against the Anthropic API integration anyway (alarm only — don't block).
+- Block-list / safety guard: keep an explicit list of named topics the prompt forbids (e.g. specific tragedies; this isn't about model refusal — it's about not letting the bot wander into actually mean territory by accident).
+
+---
+
+## Phase 4 — Open questions for `/plan` to nail down
+
+These are loose threads the brainstorm doesn't resolve:
+
+1. **Exact DynamoDB schema for `xomper-ai-reports`** — settle on PK shape (`league_id_report_type` vs `league_id#report_type` vs separate PK+SK with report_type as part of SK) before writing terraform.
+2. **Exact prompt skeleton** — system prompt, lore injection format, structured output (Markdown? JSON sections?), tone anchor examples. Worth a dedicated `prompts/` folder in `xomper-back-end`.
+3. **API endpoint shape** — `GET /api/ai-reports/latest?type=weekly` returns latest only; do we also want `GET /api/ai-reports/list?type=weekly` for archive? Probably yes, but confirm.
+4. **iOS markdown renderer** — use Swift's built-in `AttributedString(markdown:)` or pull in a third-party (e.g. swift-markdown-ui)? Built-in is simpler but doesn't render tables or headings as nicely.
+5. **Cron times** — Tue 11am ET seems right for weekly (after `notif_weekly_recap` at 9am, after `notif_worldcup_movement` at 10am). Preseason + post-draft fire via admin button or one-time cron? Probably admin button (more control over timing).
+6. **Lore module structure** — confirm shape: `{ sleeper_user_id: { display_name, real_name, nicknames, favorite_teams: {nfl, college, mlb, nba}, schools, life_events: [...], stories: [...] } }`. PR-reviewed.
+7. **Block-list / safety rails** — list of topics the prompt must never touch (specific people not in the league, specific tragedies, etc).
+8. **Anthropic API key storage** — SSM `SecureString` at `/xomper/api/ANTHROPIC_API_KEY` matches existing convention. Add to `ssm.tf`, grant lambdas read.
+9. **Push notification copy** — what does the teaser push say? ("Week 4 roast is live. Tap to find out how badly you got cooked.")
+10. **Dry-run / preview mode** — should the first run of each report fire to admin email only? Strongly yes — bake into Phase 1 lambda design.
+11. **Lore growth automation** — for weekly, does the lambda auto-mine memories from matchup results ("biggest blowout this week was X") and append them to the season-memory table for next week's prompt? Worth doing in v1.1 of weekly.
+12. **iOS read-state** — do we mark reports as "read" per user (badge unread count)? Probably yes but defer to a v1.1 polish pass.
+
+---
+
+## Concrete next steps
+
+1. **Plan as an epic.** Run `/plan ai-review --epic` to produce the parent stub. Sub-features: `ai-review-shared-infra` (claude_helper, lore module, Dynamo table, SSM key, API endpoint, iOS shared views), `ai-review-postdraft`, `ai-review-preseason`, `ai-review-weekly`. Ship in that order.
+2. **Lock the lore module first.** Before any lambda code, have the user fill in `lambdas/common/league_lore.py` with the 12 manager profiles from the issue body. This is the irreducible blocker — no AI joke is possible without it.
+3. **Spike a one-shot post-draft prototype.** Build the minimal pipeline (Claude call → write to Dynamo → email admin only → render in iOS) end-to-end for the post-draft report. Run it once against the 2025 draft to validate tone before opening it to the league. This becomes the template for the other two.
+
+---
+
+## Repo touch list (for the plan)
+
+**`xomper-back-end`**
+- `lambdas/common/claude_helper.py` (new) — wraps Anthropic API calls
+- `lambdas/common/league_lore.py` (new) — manager bio dict
+- `lambdas/common/ai_reports_store.py` (new) — Dynamo read/write helpers for `xomper-ai-reports`
+- `lambdas/common/email_templates/ai_review.py` (new) — wraps markdown → HTML using existing `base.py` chrome
+- `lambdas/notif_ai_review_postdraft/handler.py` (new)
+- `lambdas/notif_ai_review_preseason/handler.py` (new)
+- `lambdas/notif_ai_review_weekly/handler.py` (new)
+- `lambdas/api_ai_reports_latest/handler.py` (new)
+- `lambdas/api_ai_reports_list/handler.py` (new)
+
+**`xomper-infrastructure`**
+- `terraform/dynamodb.tf` — add `xomper-ai-reports` table
+- `terraform/ssm.tf` — add `/xomper/api/ANTHROPIC_API_KEY`
+- `terraform/lambdas_scheduled.tf` — add 3 cron entries (or 1 + admin-triggered for one-shots)
+- `terraform/lambdas_api.tf` — add `ai-reports-latest` and `ai-reports-list` to the `api_lambdas` local
+- `terraform/iam_lambdas.tf` — grant lambdas SSM read on the Anthropic key + Dynamo R/W on the new table
+
+**`xomper-ios`**
+- `Xomper/Features/Shell/TrayDestination.swift` — add `.aiReview`
+- `Xomper/Features/AIReview/` (new dir)
+  - `AIReviewView.swift` — archive list
+  - `AIReviewDetailView.swift` — markdown renderer
+  - `AIReviewStore.swift` — `@Observable` store
+- `Xomper/Core/Networking/XomperAPIClient.swift` — add `aiReportsLatest`, `aiReportsList` methods + response models
+- `Xomper/Features/Home/` — add latest-report banner card
+- (optional v1.1) `Xomper/Features/Admin/` — add "regenerate report" + "send now" admin actions

--- a/docs/features/ai-review/EPIC_PLAN.md
+++ b/docs/features/ai-review/EPIC_PLAN.md
@@ -1,0 +1,195 @@
+# Epic Plan: AI Review (Issue #79)
+
+**Status**: Ready
+**Created**: 2026-05-21
+**Last updated**: 2026-05-21
+**Issue**: https://github.com/Xomware/xomper-ios/issues/79
+**Brainstorm**: `docs/features/ai-review/BRAINSTORM.md`
+
+---
+
+## Orchestration
+
+Four sub-feature stubs (Draft) sequenced strictly by phase dependency. Each must be fleshed out via `/plan [stub]` and flipped to Ready before `/execute`.
+
+```
+F0 — Shared Infra (Phase 0)         docs/features/ai-review/f0-shared-infra/PLAN.md
+  │  cross-cutting pre-req: Dynamo table, SSM key, IAM, billing alarm,
+  │  common modules, read API lambdas, iOS shared surfaces
+  ▼
+F1 — Post-Draft Analysis (Phase 1)  docs/features/ai-review/f1-post-draft/PLAN.md
+  │  one-shot lambda + prompt + admin trigger, dry-run first
+  ▼
+F2 — Preseason Blast (Phase 2)      docs/features/ai-review/f2-preseason/PLAN.md
+  │  one-shot lambda + prompt + admin trigger (reuses F1 scaffolding)
+  ▼
+F3 — Weekly Recap (Phase 3)         docs/features/ai-review/f3-weekly/PLAN.md
+     cron lambda + season-memory table + memory loop, iOS archive pagination
+```
+
+Strict sequential order — no parallelization. F0 unblocks all three; F1 calibrates tone and establishes the dry-run + email pattern that F2 and F3 reuse; F3's volume + personalization risk is highest so it goes last after two one-shots have validated voice.
+
+---
+
+## Epic Overview
+
+AI Review is a content-generation pipeline that turns Sleeper league data + a hand-authored "lore" pack into three personality-driven, Claude-written reports (post-draft, preseason, weekly) delivered through two surfaces: a league-wide email + an in-app archive in `xomper-ios`. The three sub-features share the same scaffolding — Claude API helper, DynamoDB report store, lore module, SSM key, email chrome, iOS surfaces — and differ only in trigger cadence, prompt skeleton, and data inputs. Ship order is post-draft → preseason → weekly so we calibrate tone on low-stakes one-shots before tackling the volume + personalization of the weekly recap.
+
+Architectural decisions are fixed by the brainstorm (Q1–Q8). This plan exists to scaffold the work into a shape `/orchestrate` can split into per-feature plans.
+
+---
+
+## Sub-Feature Breakdown
+
+### F1 — Post-Draft Analysis (ships first)
+- **Scope**: One-shot Claude-generated team-by-team grade + outlook report fired after the rookie draft. Admin-triggered (button or one-time cron). Writes to `xomper_ai_reports`, emails the league, surfaces in iOS Home + tray.
+- **Repos touched**: `xomper-back-end` (new `notif_ai_review_postdraft` lambda + prompt skeleton), `xomper-infrastructure` (admin-trigger wiring; reuses the shared infra from Phase 0), `xomper-ios` (consumes existing shared surfaces; type-specific labels).
+- **Primary deliverables**:
+  - `lambdas/notif_ai_review_postdraft/handler.py` — fetches draft picks via Sleeper, builds prompt with lore, calls Claude, persists report, sends email + teaser push.
+  - Prompt skeleton in `lambdas/notif_ai_review_postdraft/prompt.py` (or `prompts/postdraft.md`).
+  - Dry-run mode flag (admin-only delivery on first invocation).
+  - iOS report type label `.postDraft` rendered in archive list.
+- **Depends on**: Phase 0 (shared infra) must be merged + deployed.
+- **Effort tier**: **M** — first end-to-end run through the new pipeline; tone calibration consumes more time than code.
+
+### F2 — Preseason Blast
+- **Scope**: One-shot Claude-generated "last year's grade + this year's outlook" per team. Admin-triggered before Week 1 kickoff. Structurally identical to F1, different prompt + data inputs (prior-season standings + offseason moves).
+- **Repos touched**: `xomper-back-end` (new `notif_ai_review_preseason` lambda + prompt), `xomper-ios` (type label only).
+- **Primary deliverables**:
+  - `lambdas/notif_ai_review_preseason/handler.py` — fetches prior-season final standings + current roster snapshot, builds prompt, generates + persists + sends.
+  - Prompt skeleton tuned for "year over year" tone.
+  - iOS report type label `.preseason`.
+- **Depends on**: F1 — reuses the prompt scaffolding, dry-run pattern, and email template established there.
+- **Effort tier**: **S** — mostly a remix of F1 with different data sources.
+
+### F3 — Weekly Recap
+- **Scope**: Cron-triggered (Tue/Wed AM during the season) Claude-generated league newsletter that roasts every manager by name using matchup results + season memories + lore. Auto-appends new memories to the season-memory store for next week's prompt.
+- **Repos touched**: `xomper-back-end` (new `notif_ai_review_weekly` lambda, season-memory Dynamo helpers), `xomper-infrastructure` (weekly cron trigger; optional new `xomper_ai_memories` table if not already provisioned in Phase 0), `xomper-ios` (paginated archive list once we accumulate 18+ weeks).
+- **Primary deliverables**:
+  - `lambdas/notif_ai_review_weekly/handler.py` — pulls matchup results + last N memories + lore, generates + persists report + appends new memories, sends.
+  - Season-memory store helpers (read last N entries, append new ones).
+  - Weekly cron entry in `lambdas_scheduled.tf`.
+  - Prompt skeleton with stronger tone anchors + block-list guard.
+- **Depends on**: F1 (pipeline), F2 (tone validation), and optionally an extension to Phase 0 if season memories ship as a separate table.
+- **Effort tier**: **L** — highest-volume, most personalization-heavy, tone risk is highest, season-memory loop is genuinely new work.
+
+---
+
+## Cross-Cutting Work
+
+These are shared across F1/F2/F3. Decision on each: **pre-req** (must land before any sub-feature) vs **incremental** (lands with the first sub-feature that needs it).
+
+| Item | Type | Lands in |
+|------|------|----------|
+| `lambdas/common/league_lore.py` — 12 manager profiles | **Pre-req** | Phase 0 |
+| `lambdas/common/claude_helper.py` — Anthropic API wrapper | **Pre-req** | Phase 0 |
+| `lambdas/common/ai_reports_store.py` — Dynamo R/W for `xomper_ai_reports` | **Pre-req** | Phase 0 |
+| Terraform: `xomper_ai_reports` DynamoDB table | **Pre-req** | Phase 0 |
+| Terraform: `/xomper/api/ANTHROPIC_API_KEY` SSM SecureString | **Pre-req** | Phase 0 |
+| Terraform: IAM grants (Dynamo R/W + SSM read) on a shared lambda role or per-lambda | **Pre-req** | Phase 0 |
+| Terraform: CloudWatch billing alarm ($5/month) | **Pre-req** | Phase 0 |
+| `lambdas/common/email_templates/ai_review.py` — markdown→HTML chrome | **Pre-req** | Phase 0 |
+| `lambdas/api_ai_reports_latest/handler.py` + `lambdas/api_ai_reports_list/handler.py` | **Pre-req** | Phase 0 (so iOS can ship against a real endpoint) |
+| iOS `AIReviewStore` + `XomperAPIClient` methods + response models | **Pre-req** | Phase 0 |
+| iOS `AIReviewView` (archive list) + `AIReviewDetailView` (markdown renderer) | **Pre-req** | Phase 0 |
+| iOS `TrayDestination.aiReview` case | **Pre-req** | Phase 0 |
+| iOS Home banner card for latest report | **Pre-req** | Phase 0 |
+| Per-user subject + greeting templating (hybrid email) | **Pre-req** | Phase 0 (used by all three) |
+| Season-memory store (`xomper_ai_memories` table + helpers) | **Incremental** | Lands with F3 (weekly is the only consumer) |
+| Push notification teaser copy template | **Incremental** | Lands with F1, parameterized by report type |
+| Admin "regenerate" / "send now" actions | **Deferred** | Phase 4 (v1.1) |
+
+---
+
+## Recommended Orchestration Order
+
+`/orchestrate` should produce these stubs under `docs/features/ai-review/`:
+
+- **Phase 0 — `f0-shared-infra/PLAN.md`**: lore module, claude_helper, Dynamo table + SSM key + IAM + billing alarm, email-template foundation, API endpoints, iOS shared surfaces (store, views, tray destination, Home banner). Ship as one PR per repo (3 PRs total). No sub-feature can start until this lands.
+- **Phase 1 — `f1-post-draft/PLAN.md`**: post-draft lambda + prompt + admin trigger + iOS label. End-to-end smoke test against 2025 draft data, dry-run to admin only first.
+- **Phase 2 — `f2-preseason/PLAN.md`**: preseason lambda + prompt + admin trigger + iOS label. Reuses F1 scaffolding; pure data + tone swap.
+- **Phase 3 — `f3-weekly/PLAN.md`**: weekly lambda + cron + season-memory table & helpers + prompt with block-list + iOS archive pagination.
+- **Phase 4 — deferred (no plan stubs yet)**: live NFL news ingestion (Anthropic `web_search` or RSS sidecar), admin portal regenerate/send-now actions, iOS read-state badges, lore-growth automation beyond season memories.
+
+---
+
+## Cross-Repo Dependencies
+
+For every sub-feature, the repo-level merge + deploy order is:
+
+1. **`xomper-infrastructure`** — terraform must apply first to create any new Dynamo table, SSM param, IAM grants, cron rule, or API GW route.
+2. **`xomper-back-end`** — lambda code can only ship once the infra it depends on (table, SSM key, IAM role) exists.
+3. **`xomper-ios`** — client can only ship once the API endpoint returns real data.
+
+Per-phase ordering:
+
+- **Phase 0**: infra (Dynamo + SSM + IAM + billing alarm + API GW routes) → backend (claude_helper, lore module, store helpers, email template, two API lambdas) → iOS (store + views + tray + Home banner against the new endpoints, will return empty list until F1 runs).
+- **Phase 1 (F1)**: backend-only change (admin-triggered lambda); no new infra if Phase 0 provisioned the IAM + role; iOS already renders any report type generically — only adds the `.postDraft` label.
+- **Phase 2 (F2)**: same shape as F1, backend-only.
+- **Phase 3 (F3)**: infra (weekly cron rule + optional `xomper_ai_memories` table + IAM) → backend (weekly lambda + memory helpers) → iOS (archive pagination if needed).
+
+---
+
+## Rollout Risks (Epic Level)
+
+| Risk | Mitigation |
+|------|-----------|
+| Claude API outage on cron day | Lambda retries with exponential backoff; on terminal failure, send a "report delayed" SNS to admin instead of silently dropping. Dynamo upsert is idempotent so re-runs are safe. |
+| Prompt drift over time (tone gets stale or generic) | Pin prompt skeleton as a versioned constant; store `prompt_version` on each Dynamo report row; require a tone review on any prompt change PR. |
+| Tone calibration off (too mean / too tame) | Dry-run mode mandatory on first invocation of each new prompt version — admin-only email before broadcast. Block-list of forbidden topics enforced in system prompt. |
+| Lore staleness (engagements, marriages, new jobs change) | Lore module is a PR-reviewed Python file — easy to update; season-memory table (F3) auto-grows in-season; defer a runtime lore editor to v1.1. |
+| Cost runaway from bug (e.g. infinite retry loop) | CloudWatch billing alarm at $5/month; lambda timeout capped at 5 min; Anthropic SDK retries capped at 3. |
+| Sensitive personal data in lore module leaking via repo | `league_lore.py` lives in the private `xomper-back-end` repo; PR review required; no PII beyond what league members have publicly shared in group chat. |
+
+---
+
+## Acceptance Criteria (Epic "Done")
+
+- [ ] All three reports (post-draft, preseason, weekly) generate end-to-end on their target trigger (admin-button for F1/F2, cron for F3).
+- [ ] Each report type has been dry-run reviewed by at least one human (admin) before its first broadcast.
+- [ ] Reports archive correctly in `xomper_ai_reports` and render in iOS via both Home banner (latest) and tray archive (history).
+- [ ] Hybrid email shape works: one shared body + per-user subject + per-user greeting line for all 12 managers.
+- [ ] Push notification teaser fires alongside email.
+- [ ] CloudWatch billing alarm armed at $5/month against Anthropic spend.
+- [ ] Total season cost under $5 (target under $1) as measured at end of 2026 regular season.
+- [ ] No prompt-injection / block-list violations in any shipped report (verified by admin review log).
+
+---
+
+## Open Questions (Punted to Sub-Feature Plans)
+
+Each per-feature `PLAN.md` from `/orchestrate` must resolve the items relevant to its phase. Listing them here so nothing gets lost.
+
+**Phase 0 (shared infra)**:
+- [ ] Exact `xomper_ai_reports` schema — PK shape (`league_id#report_type` composite vs PK+SK with `report_type` in SK), GSI for cross-type "latest" queries?
+- [ ] Markdown renderer choice on iOS — Apple `AttributedString(markdown:)` vs `swift-markdown-ui` (tables + headings)?
+- [ ] API endpoint shape — `GET /api/ai-reports/latest?type=X` only, or also `GET /api/ai-reports/list?type=X&limit=N`? (Brainstorm leans yes to both.)
+- [ ] Lore module exact shape — confirm fields: `display_name`, `real_name`, `nicknames`, `favorite_teams`, `schools`, `life_events`, `stories`.
+- [ ] Block-list / safety-rail content (specific forbidden topics).
+- [ ] Push teaser copy template + per-report-type variations.
+
+**Phase 1 (F1 post-draft)**:
+- [ ] Admin trigger shape — new admin-only API endpoint vs one-time EventBridge rule vs both?
+- [ ] Prompt skeleton + tone anchor paragraphs for post-draft.
+- [ ] Exact data inputs — full draft pick list, ADP comparisons, pre-draft rankings?
+
+**Phase 2 (F2 preseason)**:
+- [ ] Prior-season data source — Sleeper league history endpoint vs Dynamo snapshot from end-of-season?
+- [ ] Admin trigger reuses F1's shape (assumed yes — confirm in plan).
+
+**Phase 3 (F3 weekly)**:
+- [ ] Exact cron expression (brainstorm suggests Tue 11am ET; confirm against existing scheduled-lambda times).
+- [ ] Season-memory table schema if separate from `xomper_ai_reports`.
+- [ ] Memory auto-mining rules — which matchup events get auto-appended ("biggest blowout", "lineup-not-set loss", etc.)?
+- [ ] iOS archive pagination cutoff (e.g. lazy load after 10 items).
+- [ ] Read-state badges — deferred to v1.1 unless tackled here.
+
+---
+
+## Skills / Agents to Use
+
+- **`/orchestrate ai-review`** — once this epic plan flips to Ready, generates the four stub PLAN.md files (Phase 0 + F1 + F2 + F3) for individual planning.
+- **`/plan f0-shared-infra`** (etc.) — fills each stub with file-level steps.
+- **brainstorm agent** — already used (BRAINSTORM.md). Re-invoke only if Phase 4 (live news, lore editor) gets pulled forward.
+- **research agent** — invoke before Phase 0 if `AttributedString(markdown:)` vs `swift-markdown-ui` decision needs concrete evidence; otherwise skip.
+- **execute agent** — drives each phase's PLAN.md to merged PRs.

--- a/docs/features/ai-review/f0-shared-infra/PLAN.md
+++ b/docs/features/ai-review/f0-shared-infra/PLAN.md
@@ -1,0 +1,357 @@
+# Plan: AI Review — F0 Shared Infra (Phase 0)
+
+**Epic**: `docs/features/ai-review/EPIC_PLAN.md`
+**Phase**: 0
+**Status**: Ready
+**Created**: 2026-05-21
+**Last updated**: 2026-05-21
+**Depends on**: none (cross-cutting pre-req for F1/F2/F3)
+
+---
+
+## Summary
+F0 provisions every reusable surface F1 (post-draft), F2 (preseason), and F3 (weekly) consume: the `xomper-ai-reports` DynamoDB table + GSI, the `/xomper/api/ANTHROPIC_API_KEY` SSM SecureString, a $5/month CloudWatch billing-or-invocation alarm, two read API lambdas (`api_ai_reports_latest` + `api_ai_reports_list`), the `claude_helper.py` / `league_lore.py` / `ai_reports_store.py` / `email_templates/ai_review.py` common modules in `xomper-back-end`, and the iOS shared surfaces (`AIReviewStore`, `AIReviewView`, `AIReviewDetailView`, `XomperAPIClient` methods, `TrayDestination.aiReview`, Home banner). Ships as three coordinated PRs (infra → backend → iOS). On merge the iOS endpoints return an empty list until F1 first generates a report.
+
+Success = all three repos merged, terraform applied, iOS builds against the new endpoints showing an empty archive, all unit tests green, IAM permits the new lambda role to R/W the new Dynamo table and read the new SSM key.
+
+---
+
+## Approach
+Locks the decisions from `BRAINSTORM.md` Q1–Q8 and the per-phase open questions from `EPIC_PLAN.md` into concrete file-level changes. Pattern templates lifted from the most recently shipped admin-portal PRs (`api_admin_list_notifications` + `notification_log` + iOS `AdminStore`/`AdminView` + `.draftOrder` tray case) — those are the cleanest in-tree references for "GET endpoint + Dynamo helper + Observable store + tray destination" across the three repos.
+
+Architectural decisions resolved (rationale in **Open Design Decisions** below):
+
+| # | Decision | Pick |
+|---|----------|------|
+| 1 | Lore module shape | Dataclass `ManagerProfile` with `display_name`, `nicknames`, `favorite_teams`, `school`, `notable_stories`, `life_events` |
+| 2 | User ID lookup | Manual one-time lookup post-F0-plan-approval; commit IDs as a follow-up; placeholders `# TODO` until then |
+| 3 | API endpoint auth | Reuse existing `lambdas/authorizer/` JWT path — endpoints sit behind the same custom authorizer that gates `/admin/*` |
+| 4 | Dynamo schema | PK `LEAGUE#<league_id>` / SK `REPORT#<report_type>#<period>`; GSI1 PK `LEAGUE#<league_id>` / GSI1 SK `CREATED#<iso8601>` |
+| 5 | Report body storage | Markdown string in attribute `body_markdown`; JSON metadata in attribute `metadata` |
+| 6 | Prompt caching | `cache_control` on the *system* prompt only (lore + tone + safety rails). User prompt is per-report data + instructions and stays uncached |
+| 7 | Markdown render on iOS | Native `AttributedString(markdown:)` (iOS 17 already in our deployment target; no new SPM dep) |
+| 8 | Home card placement | Topmost banner card, above `searchControls` in `SearchView` (rebrand to `HomeView` later if needed). Pushes search down by one card height — acceptable per epic |
+
+---
+
+## Repos Touched
+- `xomper-infrastructure` — Dynamo table + GSI, SSM SecureString, billing/invocation alarm, two API GW routes + lambda stubs. (IAM already covers `${app_name}*` Dynamo + `/${app_name}/*` SSM read; no IAM file changes expected — verify in step 3.)
+- `xomper-back-end` — four new `lambdas/common/*` modules, two new API lambda dirs, tests, dependency bump for the Anthropic SDK.
+- `xomper-ios` — new `Core/Stores/AIReviewStore.swift`, response models, two `XomperAPIClient` methods, `Features/AIReview/` directory (3 views), `TrayDestination.aiReview` case + drawer entry + `MainShell` wiring, Home banner widget injected into `SearchView`. Run `xcodegen generate` after adding new files.
+
+---
+
+## Affected Files / Components
+
+### `xomper-infrastructure/terraform/`
+| File | Change | Why |
+|------|--------|-----|
+| `dynamodb.tf` | Add `aws_dynamodb_table.ai_reports` resource with PK `pk` (S), SK `sk` (S), GSI `created-at-index` on `pk` (HASH) + `created_at` (RANGE), KMS encryption, PITR, PAY_PER_REQUEST, standard tags | Storage for all three report types; GSI for "recency" queries used by `list` endpoint |
+| `ssm.tf` | Add `aws_ssm_parameter.anthropic_api_key` (SecureString) at `/${var.app_name}/api/ANTHROPIC_API_KEY`, value sourced from new `variables.tf` var `anthropic_api_key`, `ignore_changes = [tags, tags_all]` per existing convention | Anthropic key storage; matches the `SUPABASE_*` pattern |
+| `variables.tf` | Add `variable "anthropic_api_key"` (sensitive = true, no default) | Wires the secret into TF without checking in |
+| `lambdas_api.tf` | Add two entries to the `api_lambdas` local: `{ name = "ai-reports-latest", path_part = "latest", http_method = "GET", description = "AI Review: latest report by type" }` and `{ name = "ai-reports-list", path_part = "list", http_method = "GET", description = "AI Review: paginated archive" }`. Comment block describing routes `/ai-reports/latest?type=X` and `/ai-reports/list?type=X&cursor=&limit=` | Provisions the lambda stubs + API GW routes; backend repo deploys the code over the stub |
+| `api_gateway.tf` | Verify the existing path-building logic groups these under `/ai-reports/*` (read existing file to confirm — likely zero changes if the loop derives paths from `path_part`); if not, add an explicit resource group | API routing |
+| `iam_lambdas.tf` | **Verify only** — existing `DynamoDBRuntime` statement already covers `${app_name}*` tables; existing `SSMParameters` statement already covers `/${app_name}/*`. Add a comment noting `xomper-ai-reports` + `ANTHROPIC_API_KEY` are covered by the wildcards. If naming deviates from `${app_name}*`, add a tight statement | Confirms least-privilege without widening |
+| `cloudwatch.tf` (new) | `aws_cloudwatch_metric_alarm.ai_review_cost_alarm` at $5/month against the AWS/Billing `EstimatedCharges` metric scoped to the AI lambdas' tag (if available in this account); fallback alarm = invocation-count alarm against the three `notif_ai_review_*` lambdas firing more than N times/day | Cost runaway protection from the brainstorm |
+| `outputs.tf` | Add `ai_reports_table_name` + `ai_reports_table_arn` outputs for downstream reference | Future-proof; non-blocking |
+
+### `xomper-back-end/lambdas/common/`
+| File | Change | Why |
+|------|--------|-----|
+| `league_lore.py` (new) | Codifies 12 manager profiles as `LEAGUE_LORE: dict[str, ManagerProfile]` keyed by Sleeper `user_id`. Dataclass shape pinned below. Placeholders `# TODO: fill in user_id` until the manual lookup runs | Personality fuel for all three report types |
+| `claude_helper.py` (new) | `def generate(prompt: str, system: str \| None = None, model: str = "claude-haiku-4-5", max_tokens: int = 4000) -> str`. Lazy-loads Anthropic SDK client (API key from `ssm_helpers.get_parameter("/xomper/api/ANTHROPIC_API_KEY")`, module-level cache). Sets `cache_control = {"type": "ephemeral"}` on the system prompt blocks. Retries on `anthropic.APIConnectionError` and 5xx with exponential backoff (max 3). Logs token usage. Raises `ClaudeAPIError` (new entry in `errors.py`) on terminal failure | Shared LLM wrapper used by F1/F2/F3 |
+| `ai_reports_store.py` (new) | Top-of-file docstring documents schema. Functions: `write_report(league_id, report_type, period, body_markdown, metadata) -> dict` (PutItem with computed `pk`/`sk`/`created_at` + GSI fields); `get_latest(league_id, report_type) -> dict \| None` (Query on PK with SK `begins_with REPORT#<type>#`, `ScanIndexForward=False`, `Limit=1`); `list_recent(league_id, limit=20, cursor=None) -> tuple[list[dict], str \| None]` (Query GSI1 with PK, ScanIndexForward=False, optional `ExclusiveStartKey` from `cursor`) | Dynamo R/W for the new table |
+| `email_templates/ai_review.py` (new) | `def render_ai_review_email(manager_name: str, report_type: str, period_label: str, body_markdown: str, league_name: str) -> tuple[str, str, str]` returns `(subject, html_body, text_body)`. Per-user subject/greeting injection happens here (hybrid email shape from Q4). Uses `base.wrap_email_html` chrome. Markdown→HTML via a small stdlib renderer (use the `markdown` PyPI package added in `requirements.txt`) | Email rendering with per-user header on shared body |
+| `errors.py` (edit) | Add `class ClaudeAPIError(XomperError)` next to `SleeperAPIError` | Typed error path |
+| `constants.py` (edit) | Add `AI_REPORTS_TABLE = os.environ.get("APP_NAME", "xomper") + "-ai-reports"`. Add `AI_REVIEW_PROMPT_VERSION = "f0-2026-05-21"` placeholder | Centralized table name + prompt version stamp |
+
+### `xomper-back-end/lambdas/api_ai_reports_latest/`
+| File | Change | Why |
+|------|--------|-----|
+| `__init__.py` (new, empty) | Package marker | Lambda discovery |
+| `handler.py` (new) | GET handler. Reads `type` query param (validate against `{"postDraft","preseason","weekly"}`), resolves the active league via `supabase_helper.get_active_whitelisted_league`, calls `ai_reports_store.get_latest(league_id, report_type)`, returns `{"report": {...} \| None}` via `success_response`. JWT auth enforced upstream by the existing authorizer; no `require_admin` — all signed-in league members can read | Latest-by-type endpoint that iOS hits for the Home banner |
+
+### `xomper-back-end/lambdas/api_ai_reports_list/`
+| File | Change | Why |
+|------|--------|-----|
+| `__init__.py` (new, empty) | Package marker | Lambda discovery |
+| `handler.py` (new) | GET handler. Reads `type` (optional), `limit` (default 20, max 50), `cursor` (optional). Resolves active league. Calls `ai_reports_store.list_recent(league_id, limit, cursor)`. Filters by `report_type` in-process if `type` provided. Returns `{"rows": [...], "next_cursor": "..." \| None}` | Paginated archive for iOS `AIReviewView` |
+
+### `xomper-back-end/requirements.txt`
+| Change | Why |
+|--------|-----|
+| Add `anthropic==0.50.0` (pin to latest stable, sanity-check at install) and `markdown==3.6` | SDK + markdown-to-HTML renderer |
+
+### `xomper-back-end/tests/`
+| File | Change | Why |
+|------|--------|-----|
+| `tests/test_league_lore.py` (new) | Schema validation: every `ManagerProfile` has required fields, all 12 user_ids are unique (once filled in), no field is `None` where required, `notable_stories` and `life_events` are lists of strings | Catches typos before lambdas crash mid-prompt |
+| `tests/test_claude_helper.py` (new) | Mock `anthropic.Anthropic` client. Assert `generate` passes `cache_control={"type":"ephemeral"}` on system prompt blocks. Assert retry-then-raise on 5xx. Assert API key fetched from SSM exactly once (module-level cache) | Locks down the wrapper contract |
+| `tests/test_ai_reports_store.py` (new) | With moto-mocked Dynamo: `write_report` puts an item with correct PK/SK/created_at; `get_latest` returns newest of N writes; `list_recent` paginates correctly with `cursor`; out-of-range `report_type` raises | Schema and pagination guards |
+| `tests/conftest.py` (edit) | Add a fixture that creates the `xomper-ai-reports` mock table matching the terraform schema | Test infra |
+
+### `xomper-ios/Xomper/Core/Models/`
+| File | Change | Why |
+|------|--------|-----|
+| `AIReport.swift` (new) | `struct AIReport: Decodable, Identifiable, Sendable, Hashable` with fields `id`, `leagueId`, `reportType: AIReportType`, `period`, `bodyMarkdown`, `metadata: [String: AnyCodable]?`, `createdAt: Date`, `model: String?`, `promptVersion: String?`. `enum AIReportType: String, Decodable, Sendable, CaseIterable { case postDraft = "postDraft"; case preseason; case weekly }` with `displayName` + `systemImage` computed | Codable layer for the two new endpoints |
+
+### `xomper-ios/Xomper/Core/Networking/`
+| File | Change | Why |
+|------|--------|-----|
+| `XomperAPIClient.swift` (edit) | Append protocol methods + concrete impls: `aiReportsLatest(type: AIReportType) async throws -> AIReport?` (GET `/ai-reports/latest?type=...`) and `aiReportsList(type: AIReportType?, limit: Int, cursor: String?) async throws -> AIReportsListResponse` (GET `/ai-reports/list?...`). Add `AIReportsListResponse` Decodable struct with `rows: [AIReport]` and `nextCursor: String?`. Mirror the existing `adminListNotifications` pattern for query encoding | Two new API methods |
+
+### `xomper-ios/Xomper/Core/Stores/`
+| File | Change | Why |
+|------|--------|-----|
+| `AIReviewStore.swift` (new) | `@Observable @MainActor final class AIReviewStore`. State: `latestByType: [AIReportType: AIReport]`, `archive: [AIReport]`, `archiveCursor: String?`, `isLoading`, `errorMessage`. Methods: `loadLatest(type: AIReportType) async`, `loadArchive(reset: Bool = false) async`, `loadNextPage() async`. Caches via in-memory dicts; no persistence (matches `AdminStore` pattern) | Single source of truth for AI review state |
+
+### `xomper-ios/Xomper/Features/Shell/`
+| File | Change | Why |
+|------|--------|-----|
+| `TrayDestination.swift` (edit) | Add `case aiReview`. `title = "AI Review"`. `systemImage = "sparkles"` | Tray entry |
+| `DrawerView.swift` (edit) | Insert `.aiReview` into the `League` section (after `.draftOrder`, before `.rulebook`), or create a new `Reports` section sitting between `Roster` and `League` — confirm during implementation. Default = append to `League` to minimize disruption | Discoverable nav entry |
+| `MainShell.swift` (edit) | Add `case .aiReview` to `destinationRoot` switch, returning `AIReviewView(store: aiReviewStore, router: router)`. Hold `@State private var aiReviewStore = AIReviewStore(apiClient: XomperAPIClient(...))` next to existing stores | Wires the tray case to the view |
+
+### `xomper-ios/Xomper/Features/AIReview/` (new dir)
+| File | Change | Why |
+|------|--------|-----|
+| `AIReviewView.swift` (new) | Archive list view. `ScrollView` + `LazyVStack` over `store.archive`. Row = `AIReportRow` (title = `report.reportType.displayName + " — " + report.period`, subtitle = relative-date of `createdAt`, chevron). Tap pushes `AIReviewDetailView`. `.task` calls `store.loadArchive()` on first appear. Empty-state when `archive.isEmpty && !isLoading` ("No AI reports yet — your first one drops after the next draft."). Infinite-scroll trigger: when the last row appears, call `store.loadNextPage()` | Browseable history |
+| `AIReviewDetailView.swift` (new) | Title = `report.reportType.displayName + " " + report.period`. `ScrollView` rendering `Text(AttributedString(markdown: report.bodyMarkdown, options: .init(interpretedSyntax: .full)))`. Footer = `createdAt` + `model` + `promptVersion` in muted text | Markdown rendering with native iOS 17 API |
+| `AIReviewHomeCard.swift` (new) | Banner card showing latest report's title + first-paragraph snippet + "Tap to read" CTA. Driven by `store.latestByType[.weekly] ?? .preseason ?? .postDraft` resolution (most recent across types). Wrapped in `Button` that calls `navStore.select(.aiReview, router: router)` then pushes the detail view. Renders nothing when no report exists | Discovery surface on Home |
+
+### `xomper-ios/Xomper/Features/Home/`
+| File | Change | Why |
+|------|--------|-----|
+| `SearchView.swift` (edit) | Inject `AIReviewHomeCard` as the topmost element of the `VStack(spacing: 0)` body, *above* `searchControls`. Pass `aiReviewStore` + `navStore` + `router` via init. On `.task`, call `aiReviewStore.loadLatest(type: .weekly)` (and `.postDraft` / `.preseason` in parallel — pick whichever is most recent for the banner) | Home banner placement decision from Q7 |
+
+### `xomper-ios/XomperTests/`
+| File | Change | Why |
+|------|--------|-----|
+| `AIReviewStoreTests.swift` (new) | Mock `XomperAPIClientProtocol`. Test: `loadLatest` populates `latestByType[type]`; `loadArchive(reset: true)` replaces archive; `loadNextPage` appends + advances cursor; errors set `errorMessage` and clear `isLoading` | Store unit tests on the existing test target |
+
+### `xomper-ios/project.yml`
+| Change | Why |
+|--------|-----|
+| No edits needed if `xcodegen` auto-discovers new Swift files. Otherwise add `Xomper/Features/AIReview` to the source paths | Build inclusion |
+
+---
+
+## Open Design Decisions (resolved)
+
+### 1. Lore module shape — `ManagerProfile` dataclass
+```python
+@dataclass(frozen=True)
+class ManagerProfile:
+    display_name: str                # "Tony" — what the bot calls them in copy
+    nicknames: list[str]             # ["Antman", "T-Bone"]
+    favorite_teams: list[str]        # ["Eagles", "Phillies", "Penn State"] (NFL + college + other)
+    school: str | None               # "Penn State"
+    notable_stories: list[str]       # One-liners; ["Fell asleep on toilet at SEC championship"]
+    life_events: list[str]           # ["Engaged 2025", "New job at Stripe 2026"]
+```
+Justification — kept the brainstorm's seven-field spec but collapsed `real_name` into `display_name` (private repo; no separation needed) and merged `schools` (plural) into `school` (singular) since the issue body lists one per manager. `notable_stories` vs `life_events` stays split: stories are evergreen embarrassments useful for roasts, events are time-bounded context the lambda may want to re-evaluate yearly.
+
+### 2. User ID lookup
+**Pick (a) — manual one-time lookup**. After F0 plan approval, run a quick `lambdas/scripts/list_league_users.py` one-off (or `curl` the Sleeper users endpoint for the active league via `get_sleeper_league_users(league_id)`) to grab `(display_name, user_id)` pairs for all 12 managers. Commit the IDs as a follow-up PR before F1. Until then, `league_lore.py` carries `# TODO: fill in user_id` placeholders so the dataclass shape is reviewable.
+
+### 3. API endpoint auth
+Confirmed by reading `lambdas/authorizer/handler.py`: the JWT authorizer is wired to API GW at the route level via `iam_api_gateway.tf` / `lambda_authorizer.tf`. The two new GET routes (`/ai-reports/latest`, `/ai-reports/list`) inherit the same authorizer automatically — no per-lambda `require_admin` (these are league-member reads, not admin actions). Unauthenticated calls are denied at API GW before the lambda is invoked.
+
+### 4. DynamoDB key / index schema
+- **PK**: `LEAGUE#<league_id>`
+- **SK**: `REPORT#<report_type>#<period>` where `period` ∈ `{"2026-POSTDRAFT", "2026-PRE", "2026W01"..."2026W17"}`
+- **GSI1 (`created-at-index`)**:
+  - PK: `LEAGUE#<league_id>` (same as base PK)
+  - SK: `CREATED#<iso8601_utc>` (e.g. `CREATED#2026-05-21T15:42:11Z`)
+- **Attributes**: `body_markdown` (S), `metadata` (M), `model` (S), `prompt_version` (S), `created_at` (S, ISO 8601)
+
+Justification — `begins_with(SK, "REPORT#weekly#")` + `ScanIndexForward=False` yields newest weekly. GSI lets archive list query newest-first across all report types in one shot.
+
+### 5. Markdown vs JSON storage
+Body = markdown string in `body_markdown`. Metadata = Dynamo Map attribute `metadata` carrying `{prompt_version, model, token_usage_in, token_usage_out, source_data_keys}`. Claude generates markdown natively; iOS renders via `AttributedString(markdown:)`; email renders via the `markdown` PyPI lib.
+
+### 6. Prompt caching
+`claude_helper.py` always sets `cache_control={"type": "ephemeral"}` on each block of the **system prompt** (which carries lore + tone guidelines + safety rails — stable across all three report types and across calls within a 5-min window). User prompts (per-report data + instructions) are not cached. Concretely the system prompt is composed as:
+```
+[block 1, cached]   Tone + safety rails (~500 tokens)
+[block 2, cached]   League lore dump (~3000 tokens)
+[block 3, uncached] (none — user prompt carries the per-report data)
+```
+At Haiku 3.5 rates, cache hits save ~$0.003/call after the first call — material when F3 fires weekly.
+
+### 7. Markdown renderer on iOS
+Native `AttributedString(markdown: report.bodyMarkdown, options: .init(interpretedSyntax: .full))`. Pros: no SPM dep; ships on iOS 17. Cons: no table rendering — accepted (reports lean on headings + bold + lists, not tables, per the brainstorm's tone anchors). If table need surfaces in F1 dry-run review, revisit with `swift-markdown-ui`.
+
+### 8. Home card placement
+Read `Xomper/Features/Home/SearchView.swift` — the body is a `VStack(spacing: 0)` containing `searchControls` then `resultArea`. The card slots in as a new topmost child:
+```
+VStack(spacing: 0) {
+    AIReviewHomeCard(...)          // new — only renders when latest report exists
+    searchControls
+    resultArea
+}
+```
+Topmost so it's immediately visible. Renders nothing (zero height) when no reports exist, so empty-state Home is unchanged.
+
+---
+
+## Implementation Steps (dependency-ordered, file-by-file)
+
+### Repo 1: `xomper-infrastructure`
+
+- [ ] **Step 1** — In `terraform/variables.tf`, add `variable "anthropic_api_key" { type = string; sensitive = true }`. Update `terraform.tfvars` (gitignored) locally with the real key.
+- [ ] **Step 2** — In `terraform/ssm.tf`, add the `aws_ssm_parameter.anthropic_api_key` resource at `/${var.app_name}/api/ANTHROPIC_API_KEY` with `lifecycle.ignore_changes = [tags, tags_all]`.
+- [ ] **Step 3** — In `terraform/dynamodb.tf`, add the `aws_dynamodb_table.ai_reports` resource (PK `pk` S, SK `sk` S, GSI `created-at-index` on `pk` + `created_at`, KMS, PITR, PAY_PER_REQUEST, standard tags).
+- [ ] **Step 4** — In `terraform/iam_lambdas.tf`, **read only** — verify the `DynamoDBRuntime` wildcard `${var.app_name}*` covers the new table (it does) and `SSMParameters` covers `/${var.app_name}/api/ANTHROPIC_API_KEY` (it does). Add a one-line comment marking the new resources are covered. No code change.
+- [ ] **Step 5** — In `terraform/lambdas_api.tf`, append two entries to the `api_lambdas` local: `{ name = "ai-reports-latest", path_part = "latest", http_method = "GET", description = "..." }` and `{ name = "ai-reports-list", path_part = "list", http_method = "GET", description = "..." }`. Update or confirm `api_gateway.tf` builds them under `/ai-reports/*`.
+- [ ] **Step 6** — Add `terraform/cloudwatch.tf` (new file) with `aws_cloudwatch_metric_alarm.ai_review_cost_alarm`. Prefer billing dim if available in the account; fall back to a `Lambda Invocations` alarm against the three `notif_ai_review_*` function names firing > 50/day (conservative ceiling).
+- [ ] **Step 7** — In `terraform/outputs.tf`, expose `ai_reports_table_name` + `ai_reports_table_arn`.
+- [ ] **Step 8** — **terraform apply** — required before backend deploys. Verify the SSM key exists (`aws ssm get-parameter --name /xomper/api/ANTHROPIC_API_KEY --with-decryption`), the table exists, and the API GW shows the two new routes returning 502s (stub lambdas).
+
+### Repo 2: `xomper-back-end` (after Step 8)
+
+- [ ] **Step 9** — In `requirements.txt`, append `anthropic==0.50.0` and `markdown==3.6`. Run `pip install -r requirements.txt` locally + sanity-test the Anthropic SDK import.
+- [ ] **Step 10** — In `lambdas/common/errors.py`, add `class ClaudeAPIError(XomperError)` next to `SleeperAPIError`.
+- [ ] **Step 11** — In `lambdas/common/constants.py`, add `AI_REPORTS_TABLE` + `AI_REVIEW_PROMPT_VERSION`.
+- [ ] **Step 12** — Create `lambdas/common/league_lore.py` with the `ManagerProfile` dataclass + `LEAGUE_LORE` dict carrying 12 entries with `# TODO: fill in user_id` placeholders + populated `display_name`/`nicknames`/`favorite_teams`/`school`/`notable_stories`/`life_events` lifted verbatim from issue #79's body.
+- [ ] **Step 13** — Create `lambdas/common/claude_helper.py` per the spec above. Cache the Anthropic client at module load. SSM key fetched lazily via `ssm_helpers.get_parameter`.
+- [ ] **Step 14** — Create `lambdas/common/ai_reports_store.py` with `write_report` / `get_latest` / `list_recent`, schema docs at top.
+- [ ] **Step 15** — Create `lambdas/common/email_templates/ai_review.py` with `render_ai_review_email`. Use `base.wrap_email_html` + `markdown.markdown(body, extensions=["extra"])`.
+- [ ] **Step 16** — Create `lambdas/api_ai_reports_latest/__init__.py` (empty) and `handler.py` per spec. Validate `type` param against the three known values.
+- [ ] **Step 17** — Create `lambdas/api_ai_reports_list/__init__.py` (empty) and `handler.py` per spec.
+- [ ] **Step 18** — Create `tests/test_league_lore.py`, `tests/test_claude_helper.py`, `tests/test_ai_reports_store.py`. Add the mock-Dynamo fixture to `tests/conftest.py`.
+- [ ] **Step 19** — Run `pytest tests/` — all green.
+- [ ] **Step 20** — Deploy lambdas via the existing CI/CD pipeline (the two new lambda dirs get picked up by the deploy script that zips each subdir). Smoke-test the routes with `curl` and a valid JWT — both should return `{"report": null}` / `{"rows": [], "next_cursor": null}` against the empty table.
+- [ ] **Step 21** — **Follow-up PR (not part of F0 merge, but a hard pre-req for F1)**: user runs the manual Sleeper lookup, replaces `# TODO: fill in user_id` placeholders in `league_lore.py` with real IDs, opens a small follow-up PR.
+
+### Repo 3: `xomper-ios` (after Step 20)
+
+- [ ] **Step 22** — Create `Xomper/Core/Models/AIReport.swift` with `AIReport` + `AIReportType` enum.
+- [ ] **Step 23** — Edit `Xomper/Core/Networking/XomperAPIClient.swift`: extend protocol with `aiReportsLatest` + `aiReportsList`, add `AIReportsListResponse` struct, implement both methods on the concrete class. Mirror the `adminListNotifications` query-encoding pattern.
+- [ ] **Step 24** — Create `Xomper/Core/Stores/AIReviewStore.swift` per spec.
+- [ ] **Step 25** — Edit `Xomper/Features/Shell/TrayDestination.swift` — add `case aiReview` + title/icon.
+- [ ] **Step 26** — Edit `Xomper/Features/Shell/DrawerView.swift` — append `.aiReview` to the `League` section.
+- [ ] **Step 27** — Create `Xomper/Features/AIReview/` directory + three view files (`AIReviewView`, `AIReviewDetailView`, `AIReviewHomeCard`).
+- [ ] **Step 28** — Edit `Xomper/Features/Shell/MainShell.swift` — hold `@State private var aiReviewStore = AIReviewStore(apiClient: ...)`, add `case .aiReview:` to `destinationRoot` switch.
+- [ ] **Step 29** — Edit `Xomper/Features/Home/SearchView.swift` — inject `AIReviewHomeCard` as the topmost child of the body `VStack`, pipe `aiReviewStore` + `navStore` + `router` through `init`. Update `MainShell` call site accordingly.
+- [ ] **Step 30** — Add `Xomper/XomperTests/AIReviewStoreTests.swift` with mock client tests.
+- [ ] **Step 31** — Run `xcodegen generate` to pick up the new files into the Xcode project.
+- [ ] **Step 32** — Build via `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -scheme Xomper -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`. Run unit tests.
+- [ ] **Step 33** — Manual QA on simulator: drawer shows AI Review row, tap opens empty-state archive, Home renders unchanged (banner card renders nothing when no reports exist).
+
+---
+
+## Test Plan
+
+### Backend (pytest)
+- `test_league_lore.py`:
+  - All 12 entries present
+  - Every `display_name` non-empty
+  - Every `nicknames` / `favorite_teams` / `notable_stories` / `life_events` is a list of non-empty strings
+  - (Skipped until follow-up PR) every key is a real Sleeper user_id (string, non-empty)
+- `test_claude_helper.py`:
+  - `generate` injects `cache_control={"type":"ephemeral"}` on system prompt blocks
+  - SSM `get_parameter` called once per cold start
+  - Retries 3x on 5xx then raises `ClaudeAPIError`
+  - Passes through `model` + `max_tokens` overrides
+- `test_ai_reports_store.py` (moto-mocked Dynamo):
+  - `write_report` creates an item with correct PK/SK + ISO `created_at`
+  - `get_latest("L1", "weekly")` returns the most recent weekly even with other types present
+  - `list_recent("L1", limit=2)` returns 2 items + a cursor; passing cursor yields the next 2
+  - Unknown `report_type` raises `ValueError`
+
+### iOS (XCTest)
+- `AIReviewStoreTests`:
+  - `loadLatest(type: .weekly)` populates `latestByType[.weekly]` on mocked-200
+  - `loadArchive(reset: true)` resets `archive` + `archiveCursor`
+  - `loadNextPage()` appends rows and advances cursor; no-ops when `archiveCursor` is nil
+  - Error path sets `errorMessage`, clears `isLoading`
+
+### Smoke (post-deploy)
+- `curl -H "Authorization: Bearer <jwt>" "$API/ai-reports/latest?type=weekly"` returns `{"report": null}` with 200
+- `curl -H "Authorization: Bearer <jwt>" "$API/ai-reports/list?limit=20"` returns `{"rows": [], "next_cursor": null}` with 200
+- iOS app launches, drawer shows AI Review, tap → empty-state archive renders, Home banner is hidden
+
+---
+
+## Out of Scope
+- Any one of the three report generators (F1/F2/F3 own those)
+- Season-memory table (`xomper-ai-memories`) — lands with F3
+- Admin "regenerate" / "send now" actions — Phase 4
+- Live NFL news ingestion (`web_search`, RSS sidecar) — Phase 4
+- iOS read-state badges — Phase 4
+- Email recipient fan-out / per-user subject building beyond the `render_ai_review_email` helper — the *helper* ships in F0 but the actual fan-out call is in F1/F2/F3 lambdas
+- Push notification teaser dispatch — F1 wires the first one through
+
+---
+
+## Risks / Tradeoffs
+- **Lore PII risk**: `league_lore.py` carries sensitive personal jokes — mitigated because `xomper-back-end` is private and PR-reviewed. Document in a top-of-file comment.
+- **`# TODO: fill in user_id` placeholders ship to main**: acceptable because the lore module isn't imported by any deployed lambda yet — F1 is the first consumer. Add a `pytest` skip-marker that flips to failure once F1 lands.
+- **Anthropic SDK pin churn**: SDK is < 1.0 and moves fast. Pin to a specific minor and re-validate on each F1/F2/F3 entry.
+- **Cache invalidation if lore edits land mid-week**: Anthropic's ephemeral cache lives ~5 min, so a lore edit + redeploy invalidates naturally. Document the implication.
+- **`AttributedString(markdown:)` rendering quality**: limited to inline styling — no tables, no images. Accepted; revisit during F1 dry-run.
+- **GSI hot partition**: GSI1 PK `LEAGUE#<league_id>` is a single value for the active league — but volume is ~25 writes/year total, so partition heat is a non-issue.
+- **API GW route conflict**: `/ai-reports/list` and `/ai-reports/latest` are siblings — verify the existing path-builder in `api_gateway.tf` handles two distinct `path_part`s under the same parent. Likely fine since `/admin/notifications` + `/admin/test-send` already coexist.
+
+---
+
+## Open Questions (carry forward to F1)
+- [ ] Final block-list / safety-rail content (specific forbidden topics) — F1 prompt PR
+- [ ] Push teaser copy template + per-report-type variations — F1 wires the first
+- [ ] Whether the "League" drawer section is the right home for the tray entry or whether a new "Reports" section makes more sense once F1 lands — defer to UX feel after first report exists
+
+---
+
+## Acceptance Checklist — F0 Done When
+- [ ] `terraform apply` clean against main: `xomper-ai-reports` table + `created-at-index` GSI exist; SSM param `/xomper/api/ANTHROPIC_API_KEY` exists and is decryptable by the lambda role; two new API GW routes return 200 (with empty payloads); CloudWatch alarm armed
+- [ ] `lambdas/common/league_lore.py` exists with all 12 `ManagerProfile` entries (user_id `# TODO` markers OK at F0 merge; **must be filled** before F1 ships)
+- [ ] `lambdas/common/claude_helper.py` exists, exports `generate(...)`, applies `cache_control` to system prompt, retries on 5xx, fetches SSM key lazily, has passing unit tests
+- [ ] `lambdas/common/ai_reports_store.py` exists, has passing R/W tests under moto
+- [ ] `lambdas/common/email_templates/ai_review.py` exists and renders sample markdown into HTML using the existing `base.wrap_email_html` chrome
+- [ ] `lambdas/api_ai_reports_latest/handler.py` + `lambdas/api_ai_reports_list/handler.py` deployed, authenticated via the existing JWT authorizer, return correctly-shaped empty payloads against the new table
+- [ ] iOS: `AIReport` + `AIReportType` models exist; `XomperAPIClient` exposes `aiReportsLatest` + `aiReportsList`; `AIReviewStore` exists with passing unit tests; `TrayDestination.aiReview` case routes to `AIReviewView`; `AIReviewView` shows empty state; `AIReviewDetailView` renders markdown via native `AttributedString`; `AIReviewHomeCard` renders nothing when no report exists
+- [ ] `xcodegen generate` + build green on iPhone 17 Pro sim; all `XomperTests` green
+- [ ] Three PRs merged in order: infra → backend → iOS (none reference issue numbers per repo conventions)
+
+---
+
+## Skills / Agents to Use
+- **execute agent** — drives this plan to merged PRs once status flips to Ready
+- **research agent** — invoke only if the Anthropic SDK pin (`anthropic==0.50.0`) is stale at execute time; otherwise skip
+- **brainstorm agent** — not needed; all relevant decisions already locked in `BRAINSTORM.md`
+
+---
+
+## Appendix A: Sleeper user_id → manager mapping
+
+Resolved via `GET https://api.sleeper.app/v1/league/1181789700187090944/users` on 2026-05-21. Use these IDs as `LEAGUE_LORE` keys in `lambdas/common/league_lore.py`.
+
+| user_id | Sleeper handle | Manager | Confidence |
+|---|---|---|---|
+| `594625531702460416` | domgiordano | Dominick — Ravens / Orioles / Hornets / UNC | confirmed |
+| `418511574492270592` | reesegriffin | Reese — Chicago sports / UNC | confirmed |
+| `867213342836711424` | gtatich | Grant Tatich — Panthers / Braves / UNC | confirmed |
+| `1132215311643787264` | ktatich | Kyle Tatich — Wake → Notre Dame Law / Panthers / engaged / Grant's older brother | confirmed |
+| `867213779035906048` | lukenovak | Luke Novak — Pittsburgh sports / USC (South Carolina) / Alex's younger brother | confirmed |
+| `609168618525110272` | alexnovak02 | Alex Novak — USC (South Carolina) / Steelers / Luke's older brother (team name "Shane Beamer's Burner" confirms USC) | confirmed |
+| `865328062403870720` | cfolk | Connor Folk — Dolphins / UNC | confirmed |
+| `1001254799347658752` | mwynne16 | Michael Wynne — Panthers / college baseball / married Ashley | confirmed |
+| `992955241630896128` | Tibor100 | Tibor — big golfer (team name "The Goffather" confirms) | confirmed |
+| `741140723985997824` | dmurchis | Duncan Murchison — Commanders / UNC undergrad / Michigan Law | confirmed |
+| `1127420529155227648` | andrewga23 | Tony (Anthony Hendricks) — UGA / Bulldogs / fell asleep on SEC championship toilet | confirmed 2026-05-21 |
+| `866444821185843200` | gniadek | Jim / Jimbo — Hickory NC / UNC | confirmed 2026-05-21 |
+
+All 12 mappings confirmed by user 2026-05-21. Safe to commit `LEAGUE_LORE` with real Sleeper user_ids in F0.
+
+## Appendix B: Anthropic API key handling
+
+**Terraform is the single source of truth for the SSM value.** Never set via AWS CLI or console. Flow:
+
+1. User adds `ANTHROPIC_API_KEY` to GitHub Secrets on the `xomper-infrastructure` repo BEFORE merging the F0 infra PR.
+2. `.github/workflows/terraform.yml` passes it as `TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}` in both the Plan and Apply steps' `env:` blocks.
+3. `variable "anthropic_api_key"` is declared `sensitive = true`, no default — terraform apply fails fast if the GitHub Secret is missing.
+4. `aws_ssm_parameter.anthropic_api_key.value = var.anthropic_api_key`. No `ignore_changes = [value]`.
+5. Rotation = update the GitHub Secret + push to master (or workflow_dispatch the Terraform workflow) to trigger a new apply. Lambda picks up the new value on next cold start because `claude_helper.py` reads SSM lazily and caches at module level.
+
+F1 cannot be /execute'd until the GitHub Secret is set and the infra PR has merged + applied successfully.

--- a/docs/features/ai-review/f1-post-draft/PLAN.md
+++ b/docs/features/ai-review/f1-post-draft/PLAN.md
@@ -1,0 +1,24 @@
+# Plan: AI Review — F1 Post-Draft Analysis (Phase 1)
+
+**Epic**: `docs/features/ai-review/EPIC_PLAN.md`
+**Phase**: 1
+**Status**: Draft
+**Created**: 2026-05-21
+**Depends on**: F0 (shared infra must be merged + deployed)
+
+## Summary
+First end-to-end run through the new AI Review pipeline: a one-shot Claude-generated team-by-team grade + outlook report fired after the 2026 rookie draft. Admin-triggered (button or one-time EventBridge rule). New `notif_ai_review_postdraft` lambda fetches draft picks via Sleeper, builds a prompt with lore, calls Claude through the shared `claude_helper`, persists to `xomper_ai_reports`, sends the league-wide email via the shared chrome, and fires a teaser push. First invocation runs in dry-run mode (admin-only delivery) for tone calibration before broadcast. iOS already renders any report generically — F1 only adds the `.postDraft` type label in the archive list. Effort tier: **M** (tone calibration dominates).
+
+## Repos touched
+- `xomper-back-end` (new `lambdas/notif_ai_review_postdraft/handler.py` + prompt skeleton in `prompt.py` or `prompts/postdraft.md`)
+- `xomper-infrastructure` (admin trigger wiring — admin-only API endpoint or one-time EventBridge rule; reuses Phase 0 IAM + role)
+- `xomper-ios` (single-line addition: `.postDraft` label in the report-type rendering)
+
+## Open questions to resolve in `/plan`
+- [ ] Admin trigger shape — new admin-only API endpoint vs one-time EventBridge rule vs both?
+- [ ] Prompt skeleton + tone anchor paragraphs for post-draft.
+- [ ] Exact data inputs — full draft pick list, ADP comparisons, pre-draft rankings?
+- [ ] Push teaser copy for post-draft (parameterized template from F0).
+- [ ] Dry-run delivery mechanism — env flag, event payload arg, or both?
+
+<!-- /plan f1-post-draft to fill in scope, architecture, file-by-file steps, test plan -->

--- a/docs/features/ai-review/f2-preseason/PLAN.md
+++ b/docs/features/ai-review/f2-preseason/PLAN.md
@@ -1,0 +1,22 @@
+# Plan: AI Review — F2 Preseason Blast (Phase 2)
+
+**Epic**: `docs/features/ai-review/EPIC_PLAN.md`
+**Phase**: 2
+**Status**: Draft
+**Created**: 2026-05-21
+**Depends on**: F0 (shared infra), F1 (reuses prompt scaffolding, dry-run pattern, and email template established there)
+
+## Summary
+One-shot Claude-generated "last year's grade + this year's outlook" per team, admin-triggered before Week 1 kickoff. Structurally identical to F1 — different prompt skeleton + different data inputs (prior-season standings + offseason moves instead of draft picks). New `notif_ai_review_preseason` lambda pulls prior-season final standings + current roster snapshot, builds a "year over year" prompt, generates + persists + sends. iOS surface only adds the `.preseason` type label. Effort tier: **S** (remix of F1 with different data sources).
+
+## Repos touched
+- `xomper-back-end` (new `lambdas/notif_ai_review_preseason/handler.py` + preseason prompt skeleton)
+- `xomper-ios` (single-line addition: `.preseason` label)
+
+## Open questions to resolve in `/plan`
+- [ ] Prior-season data source — Sleeper league history endpoint vs Dynamo snapshot from end-of-season?
+- [ ] Admin trigger reuses F1's shape (assumed yes — confirm in plan).
+- [ ] Preseason prompt tone — how distinct from post-draft? (Year-over-year framing vs forward-looking outlook.)
+- [ ] Offseason-moves data inputs — trades log, waiver activity, keeper declarations?
+
+<!-- /plan f2-preseason to fill in scope, architecture, file-by-file steps, test plan -->

--- a/docs/features/ai-review/f3-weekly/PLAN.md
+++ b/docs/features/ai-review/f3-weekly/PLAN.md
@@ -1,0 +1,26 @@
+# Plan: AI Review — F3 Weekly Recap (Phase 3)
+
+**Epic**: `docs/features/ai-review/EPIC_PLAN.md`
+**Phase**: 3
+**Status**: Draft
+**Created**: 2026-05-21
+**Depends on**: F0 (shared infra), F1 (pipeline pattern), F2 (tone validation across two one-shots before going volume + personalization)
+
+## Summary
+Cron-triggered (Tue/Wed AM during the season) Claude-generated league newsletter that roasts every manager by name using matchup results + season memories + lore. Evolves the existing `notif_weekly_recap` lambda pattern: new `notif_ai_review_weekly` lambda pulls matchup results + last N memories + lore, generates + persists + sends, and auto-appends new memories to a season-memory store for next week's prompt. Introduces the `xomper_ai_memories` table (incremental from Phase 0) + season-memory helpers (read last N, append new). Adds weekly cron entry to `lambdas_scheduled.tf`, stronger tone anchors + block-list guard in the prompt, and iOS archive pagination once we accumulate 18+ weeks. Effort tier: **L** (highest volume, most personalization, tone risk highest, memory loop is genuinely new).
+
+## Repos touched
+- `xomper-back-end` (new `lambdas/notif_ai_review_weekly/handler.py`, season-memory Dynamo helpers, weekly prompt skeleton with block-list)
+- `xomper-infrastructure` (weekly cron trigger in `lambdas_scheduled.tf`, new `xomper_ai_memories` table + IAM grants)
+- `xomper-ios` (paginated archive list — lazy-load cutoff)
+
+## Open questions to resolve in `/plan`
+- [ ] Exact cron expression (brainstorm suggests Tue 11am ET; confirm against existing scheduled-lambda times — after `notif_weekly_recap` 9am and `notif_worldcup_movement` 10am).
+- [ ] Season-memory table schema if separate from `xomper_ai_reports` (PK = `sleeper_user_id`, SK = `week_key`? Or `league_id` PK with appended memory list?).
+- [ ] Memory auto-mining rules — which matchup events get auto-appended ("biggest blowout", "lineup-not-set loss", closest squeaker, manager-of-the-week, etc.)?
+- [ ] iOS archive pagination cutoff (e.g. lazy load after 10 items).
+- [ ] Read-state badges — deferred to v1.1 unless tackled here.
+- [ ] Block-list content — specific forbidden topics for weekly (more aggressive tone = more risk).
+- [ ] Relationship to existing `notif_weekly_recap` — sibling lambda or replacement?
+
+<!-- /plan f3-weekly to fill in scope, architecture, file-by-file steps, test plan -->


### PR DESCRIPTION
## Summary

Lands the iOS slice of AI Review F0 ahead of the backend lambdas. The
new endpoints (`/ai-reports/latest` + `/ai-reports/list`) will return
empty payloads against the fresh DynamoDB table until F1 generates the
first report — this PR's views all degrade to empty / error states
until then, so it can ship before the backend goes live.

- `AIReport` + `AIReportType` codable models (post-draft / preseason / weekly)
- `AIReviewStore` (@Observable @MainActor) with latest-by-type cache,
  paginated archive, 12-hour freshness skip, and pull-to-refresh
- `XomperAPIClient` extended with `fetchLatestAIReport` +
  `fetchAIReportsList` (mirrors the existing admin endpoint shape)
- `TrayDestination.aiReview` slotted into the League drawer section
  with the `sparkles` SF Symbol
- `AIReviewView` — archive list with infinite scroll + empty state
- `AIReviewDetailView` — native iOS 17 `AttributedString(markdown:)`
  render, no extra SPM dep
- `AIReviewHomeCard` — banner card injected at the top of `SearchView`
  that hides itself (zero height) when no report exists
- `AppRoute.aiReportDetail` wiring through `MainShell`
- `XomperTests/AIReviewStoreTests` — 6 tests covering load paths,
  cursor pagination + dedup, freshness skip, and most-recent
  resolution

Plan: `docs/features/ai-review/f0-shared-infra/PLAN.md`.

Refs #79 (partial — backend + infra ship in their own PRs; this is
the iOS slice only, do not auto-close).

## Test plan

- [x] `xcodegen generate` clean
- [x] `xcodebuild -scheme Xomper -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` — `** BUILD SUCCEEDED **`
- [x] `xcodebuild ... test` — 15 tests pass (6 new `AIReviewStoreTests`, 9 existing `ClinchCalculatorTests`)
- [ ] Drawer shows "AI Review" row in the League section with the sparkles icon
- [ ] Tapping the row pushes the archive view; empty state reads "No reports yet — first one lands after the next draft."
- [ ] Pull-to-refresh re-fires the load
- [ ] Search surface renders identically when no reports exist (banner card collapses to zero height)
- [ ] No regressions in DraftOrder, Team Analyzer, or Admin views