### PR TITLE
feat(ai-review F1): iOS — admin post-draft trigger card + AIReportType raw value fix

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		31CFADD9ECC5AC0D09B24BCF /* PayoutsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3443191E5EED3E2888F8757 /* PayoutsView.swift */; };
 		366C0075FA9F4ABA1C88C1A9 /* Championship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18383A0375F5728A9E3FE065 /* Championship.swift */; };
 		368D96609CAF02430F340657 /* MatchupHistoryBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A3969B9E9E60F0C59D83C9 /* MatchupHistoryBrowserView.swift */; };
+		37E600A31B5AA5DA5A766692 /* AdminStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ED7387DCA3E1DC5CDD7AFF /* AdminStoreTests.swift */; };
 		3B1DDBCA7B19B8703FAF717E /* DrawerScrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D921732971689E8096F9549 /* DrawerScrim.swift */; };
 		3B67875F822BE9AA9BD052EF /* DraftHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6060C3A4F2B355757F1E3A2 /* DraftHistoryView.swift */; };
 		3E5A98150356BEB75FD87145 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = 72178EB48829A7D249085476 /* Supabase */; };
@@ -167,6 +168,7 @@
 		56BB91320E3D5EBE1F777838 /* LeagueStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeagueStore.swift; sourceTree = "<group>"; };
 		57940AEB84889A20016648F2 /* TaxiSquadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiSquadView.swift; sourceTree = "<group>"; };
 		581D4F6F3EB8FC0547F49927 /* PlayoffBracketView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayoffBracketView.swift; sourceTree = "<group>"; };
+		58ED7387DCA3E1DC5CDD7AFF /* AdminStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStoreTests.swift; sourceTree = "<group>"; };
 		5CE99E9B095120FB6636FC8A /* PlayerValuesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerValuesStore.swift; sourceTree = "<group>"; };
 		5EABD25CAB8BF973C4709720 /* AppRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRouter.swift; sourceTree = "<group>"; };
 		5FDC8A9B02A2BFD83398D04F /* RulesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesStore.swift; sourceTree = "<group>"; };
@@ -359,6 +361,7 @@
 		391A14F36D43146CBE38D666 /* XomperTests */ = {
 			isa = PBXGroup;
 			children = (
+				58ED7387DCA3E1DC5CDD7AFF /* AdminStoreTests.swift */,
 				08BD215787E2BFC1C57E7E7E /* AIReviewStoreTests.swift */,
 				B3893B13276074EF6033CEA2 /* ClinchCalculatorTests.swift */,
 			);
@@ -731,6 +734,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A0F4E9BCA7E5D757DE8BE5B3 /* AIReviewStoreTests.swift in Sources */,
+				37E600A31B5AA5DA5A766692 /* AdminStoreTests.swift in Sources */,
 				02AC6FBAE68011749AA17644 /* ClinchCalculatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Xomper/Core/Models/AIReport.swift
+++ b/Xomper/Core/Models/AIReport.swift
@@ -178,6 +178,60 @@ enum AIReportType: String, Codable, Sendable, CaseIterable, Hashable {
     }
 }
 
+// MARK: - Trigger Response
+
+/// Response from `POST /admin/ai-review-postdraft-trigger`.
+///
+/// Backend returns the freshly-written `AIReport` row (so the iOS
+/// admin card can immediately reflect the new state without a second
+/// fetch) plus delivery counts and Anthropic token usage for the run.
+///
+/// Wire shape (snake_case):
+/// ```json
+/// {
+///   "report_id": "LEAGUE#...|REPORT#postDraft#2026",
+///   "dry_run": true,
+///   "delivery_count": 1,
+///   "model": "claude-haiku-4-5",
+///   "token_usage": { "input_tokens": 1234, "output_tokens": 567 },
+///   "report": { ...AIReport... }
+/// }
+/// ```
+struct AIReviewTriggerResponse: Decodable, Sendable {
+    let reportId: String
+    let dryRun: Bool
+    let deliveryCount: Int
+    let model: String
+    let tokenUsage: TokenUsage?
+    let report: AIReport?
+
+    enum CodingKeys: String, CodingKey {
+        case reportId = "report_id"
+        case dryRun = "dry_run"
+        case deliveryCount = "delivery_count"
+        case model
+        case tokenUsage = "token_usage"
+        case report
+    }
+}
+
+/// Anthropic token usage for a single Claude call. All fields land
+/// in the trigger response's `token_usage` blob; cache fields are
+/// optional because non-cached calls won't include them.
+struct TokenUsage: Decodable, Sendable {
+    let inputTokens: Int
+    let outputTokens: Int
+    let cacheReadInputTokens: Int?
+    let cacheCreationInputTokens: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case inputTokens = "input_tokens"
+        case outputTokens = "output_tokens"
+        case cacheReadInputTokens = "cache_read_input_tokens"
+        case cacheCreationInputTokens = "cache_creation_input_tokens"
+    }
+}
+
 // MARK: - Helpers
 
 /// Tiny shim that decodes a Dynamo Map attribute (JSON object of

--- a/Xomper/Core/Models/AIReport.swift
+++ b/Xomper/Core/Models/AIReport.swift
@@ -137,10 +137,16 @@ struct AIReport: Decodable, Identifiable, Sendable, Hashable {
 
 /// One of the three AI report flavors the backend produces. The raw
 /// values mirror what `report_type` carries in DynamoDB / the API.
+///
+/// Backend enforces camelCase via `REPORT_TYPES = ("postDraft",
+/// "preseason", "weekly")` in `lambdas/common/ai_reports_store.py`.
+/// `preseason` and `weekly` already default to their case names, but
+/// `postDraft` must be pinned to the camelCase wire value (was
+/// `"post-draft"` in F0, which would fail to decode).
 enum AIReportType: String, Codable, Sendable, CaseIterable, Hashable {
-    case postDraft = "post-draft"
-    case preseason
-    case weekly
+    case postDraft = "postDraft"
+    case preseason = "preseason"
+    case weekly = "weekly"
 
     /// Display name used in chips and titles.
     var displayName: String {

--- a/Xomper/Core/Networking/XomperAPIClient.swift
+++ b/Xomper/Core/Networking/XomperAPIClient.swift
@@ -17,6 +17,7 @@ protocol XomperAPIClientProtocol: Sendable {
     // AI Review
     func fetchLatestAIReport(type: AIReportType) async throws -> AIReport?
     func fetchAIReportsList(type: AIReportType?, limit: Int, cursor: String?) async throws -> AIReportsListResponse
+    func triggerPostDraftAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse
 }
 
 // MARK: - Request Payloads
@@ -409,6 +410,27 @@ final class XomperAPIClient: XomperAPIClientProtocol {
             items.append(URLQueryItem(name: "cursor", value: cursor))
         }
         return try await get("/ai-reports/list", queryItems: items)
+    }
+
+    /// Admin-only: fires the backend `notif_ai_review_postdraft`
+    /// lambda. With `dryRun = true` (default) the report is written
+    /// to Dynamo and delivered only to the admin user (single-user
+    /// SES + SNS) so tone can be reviewed before broadcast. With
+    /// `dryRun = false` + `force = true` the same row is overwritten
+    /// and broadcast to all 12 managers.
+    ///
+    /// Backend path was flattened to `/admin/ai-review-postdraft-trigger`
+    /// in infra PR #104 (API GW path-builder doesn't handle 3-segment
+    /// parents cleanly; flattening was the smallest change).
+    func triggerPostDraftAIReview(
+        dryRun: Bool,
+        force: Bool
+    ) async throws -> AIReviewTriggerResponse {
+        let body: [String: Any] = [
+            "dry_run": dryRun,
+            "force": force,
+        ]
+        return try await postDecoding("/admin/ai-review-postdraft-trigger", body: body)
     }
 
     // MARK: - Private

--- a/Xomper/Core/Stores/AdminStore.swift
+++ b/Xomper/Core/Stores/AdminStore.swift
@@ -18,6 +18,25 @@ final class AdminStore {
     private(set) var lastError: String?
     private(set) var lastTestResult: String?
 
+    // MARK: - Post-Draft AI Review state
+
+    /// Latest post-draft AI Review row from `/ai-reports/latest`.
+    /// Drives the trigger card's status line + button label.
+    /// `nil` until `loadPostDraftLatest()` runs (or if it errors).
+    private(set) var postDraftLatest: AIReport?
+    /// True while a trigger request is in flight. Disables the
+    /// button and shows a spinner.
+    private(set) var isTriggeringPostDraft = false
+    /// Last error from the trigger flow. Cleared on next trigger.
+    private(set) var postDraftError: Error?
+    /// Last successful trigger response. Surfaces delivery count +
+    /// model in the result line.
+    private(set) var postDraftResult: AIReviewTriggerResponse?
+
+    /// Two-way bound by the AdminView toggle. Defaults to true so
+    /// the first run is always dry-run for tone calibration.
+    var postDraftDryRun: Bool = true
+
     var filterKind: KindFilter = .all
     var filterStatus: StatusFilter = .all
 
@@ -86,6 +105,50 @@ final class AdminStore {
             entries = response.rows
         } catch {
             lastError = error.localizedDescription
+        }
+    }
+
+    // MARK: - Post-Draft AI Review
+
+    /// Reads the latest post-draft report so the trigger card can
+    /// reflect whether a dry-run / broadcast already happened. Silent
+    /// on failure — the card just defaults to "no report yet" copy.
+    func loadPostDraftLatest() async {
+        do {
+            postDraftLatest = try await apiClient.fetchLatestAIReport(type: .postDraft)
+        } catch {
+            postDraftLatest = nil
+        }
+    }
+
+    /// Fires the admin trigger endpoint. Surfaces the response in
+    /// `postDraftResult` on success or `postDraftError` on failure,
+    /// and re-reads `postDraftLatest` afterwards so the card label
+    /// reflects the new state.
+    ///
+    /// Throws so callers can decide whether to surface the error
+    /// further (e.g. for confirmation dialogs). Internal state is
+    /// updated regardless.
+    @discardableResult
+    func triggerPostDraft(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse {
+        isTriggeringPostDraft = true
+        postDraftError = nil
+        postDraftResult = nil
+        defer { isTriggeringPostDraft = false }
+
+        do {
+            let response = try await apiClient.triggerPostDraftAIReview(
+                dryRun: dryRun,
+                force: force
+            )
+            postDraftResult = response
+            // Refresh latest so the card label updates from "Generate"
+            // to "Regenerate (force)" on next render.
+            await loadPostDraftLatest()
+            return response
+        } catch {
+            postDraftError = error
+            throw error
         }
     }
 

--- a/Xomper/Features/Admin/AdminView.swift
+++ b/Xomper/Features/Admin/AdminView.swift
@@ -31,9 +31,11 @@ struct AdminView: View {
         .background(XomperColors.bgDark.ignoresSafeArea())
         .task(id: callerSleeperId) {
             await store.refresh(sleeperUserId: callerSleeperId)
+            await store.loadPostDraftLatest()
         }
         .refreshable {
             await store.refresh(sleeperUserId: callerSleeperId)
+            await store.loadPostDraftLatest()
         }
     }
 
@@ -54,6 +56,8 @@ struct AdminView: View {
     private var content: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
+                postDraftTriggerCard
+
                 testSenderCard
 
                 if let result = store.lastTestResult {
@@ -88,6 +92,147 @@ struct AdminView: View {
             .padding(.vertical, XomperTheme.Spacing.sm)
             .padding(.bottom, XomperTheme.Spacing.xl)
         }
+    }
+
+    // MARK: - Post-Draft AI Review trigger
+
+    private var postDraftTriggerCard: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Post-Draft AI Review")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+                Text(postDraftStatusLine)
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textSecondary)
+            }
+
+            Toggle(isOn: $store.postDraftDryRun) {
+                Text("Dry run (admin-only delivery)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.textPrimary)
+            }
+            .toggleStyle(.switch)
+            .tint(XomperColors.championGold)
+            .disabled(store.isTriggeringPostDraft)
+
+            HStack(spacing: XomperTheme.Spacing.sm) {
+                Button {
+                    Task { await triggerPostDraft(force: false) }
+                } label: {
+                    HStack(spacing: XomperTheme.Spacing.xs) {
+                        if store.isTriggeringPostDraft {
+                            ProgressView()
+                                .scaleEffect(0.7)
+                                .tint(XomperColors.bgDark)
+                        } else {
+                            Image(systemName: "sparkles")
+                                .font(.caption2)
+                        }
+                        Text(primaryButtonLabel)
+                            .font(.caption.weight(.semibold))
+                    }
+                    .foregroundStyle(XomperColors.bgDark)
+                    .padding(.horizontal, XomperTheme.Spacing.sm)
+                    .padding(.vertical, XomperTheme.Spacing.xs)
+                    .frame(minHeight: 32)
+                    .background(XomperColors.championGold)
+                    .clipShape(Capsule())
+                }
+                .buttonStyle(.pressableCard)
+                .disabled(store.isTriggeringPostDraft)
+
+                if store.postDraftLatest != nil {
+                    Button {
+                        Task { await triggerPostDraft(force: true) }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.caption2)
+                            Text("Regenerate (force)")
+                                .font(.caption.weight(.semibold))
+                        }
+                        .foregroundStyle(XomperColors.championGold)
+                        .padding(.horizontal, XomperTheme.Spacing.sm)
+                        .padding(.vertical, XomperTheme.Spacing.xs)
+                        .frame(minHeight: 32)
+                        .overlay(
+                            Capsule()
+                                .strokeBorder(XomperColors.championGold.opacity(0.6), lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(.pressableCard)
+                    .disabled(store.isTriggeringPostDraft)
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            if let result = store.postDraftResult {
+                Text(postDraftResultLine(result))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.successGreen)
+            } else if let error = store.postDraftError {
+                Text("✗ \(error.localizedDescription)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.errorRed)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    private var postDraftStatusLine: String {
+        guard let latest = store.postDraftLatest else {
+            return "No report yet — first run will be dry-run."
+        }
+        let isDryRun = latest.metadata["dry_run"] == "true"
+        let dateStr = formattedShortDate(latest.createdAt)
+        if isDryRun {
+            return "Last dry-run completed at \(dateStr)."
+        } else {
+            return "Broadcast on \(dateStr)."
+        }
+    }
+
+    private var primaryButtonLabel: String {
+        if store.postDraftLatest == nil {
+            // No prior report — first run is always dry-run.
+            return "Generate Dry Run"
+        }
+        return store.postDraftDryRun ? "Generate Dry Run" : "Generate & Broadcast"
+    }
+
+    private func postDraftResultLine(_ result: AIReviewTriggerResponse) -> String {
+        if result.dryRun {
+            let count = result.deliveryCount
+            return "✓ Generated! \(count) dry-run \(count == 1 ? "delivery" : "deliveries") sent."
+        } else {
+            return "✓ Broadcast complete — \(result.deliveryCount) \(result.deliveryCount == 1 ? "email" : "emails") sent."
+        }
+    }
+
+    private func triggerPostDraft(force: Bool) async {
+        do {
+            _ = try await store.triggerPostDraft(
+                dryRun: store.postDraftDryRun,
+                force: force
+            )
+        } catch {
+            // Error already surfaced via store.postDraftError.
+        }
+    }
+
+    private func formattedShortDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, h:mm a"
+        return formatter.string(from: date)
     }
 
     // MARK: - Test sender

--- a/XomperTests/AIReviewStoreTests.swift
+++ b/XomperTests/AIReviewStoreTests.swift
@@ -199,6 +199,7 @@ final class MockXomperAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
     func unregisterDevice(userId: String, deviceToken: String) async throws { throw Unsupported.method }
     func adminListNotifications(sleeperUserId: String, daysBack: Int, kind: String?, status: String?, limit: Int) async throws -> AdminNotificationsResponse { throw Unsupported.method }
     func adminTestSend(sleeperUserId: String, email: String?, kind: String, channels: [String]) async throws -> AdminTestSendResponse { throw Unsupported.method }
+    func triggerPostDraftAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw Unsupported.method }
 
     enum Unsupported: Error { case method }
 }

--- a/XomperTests/AIReviewStoreTests.swift
+++ b/XomperTests/AIReviewStoreTests.swift
@@ -29,7 +29,7 @@ final class AIReviewStoreTests: XCTestCase {
 
     func testLoadLatest_populatesLatestByType_forPostDraft() async {
         let report = makeReport(
-            id: "L1|REPORT#post-draft#2026-POSTDRAFT",
+            id: "L1|REPORT#postDraft#2026-POSTDRAFT",
             type: .postDraft,
             period: "2026-POSTDRAFT"
         )

--- a/XomperTests/AdminStoreTests.swift
+++ b/XomperTests/AdminStoreTests.swift
@@ -1,0 +1,220 @@
+import XCTest
+@testable import Xomper
+
+@MainActor
+final class AdminStoreTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makePostDraftReport(
+        dryRun: Bool = true,
+        createdAt: Date = Date()
+    ) -> AIReport {
+        AIReport(
+            id: "L1|REPORT#postDraft#2026",
+            leagueId: "L1",
+            reportType: .postDraft,
+            period: "2026",
+            bodyMarkdown: "## Team A\nGood draft.",
+            metadata: ["dry_run": dryRun ? "true" : "false"],
+            createdAt: createdAt,
+            model: "claude-haiku-4-5",
+            promptVersion: "f1-2026-05-21"
+        )
+    }
+
+    private func makeTriggerResponse(
+        dryRun: Bool = true,
+        deliveryCount: Int = 1,
+        report: AIReport? = nil
+    ) -> AIReviewTriggerResponse {
+        // Decode from JSON so we exercise the same path the network
+        // client does. Memberwise init isn't synthesized for these
+        // Decodable-only structs.
+        let reportJson: String
+        if let report {
+            // Tiny inline rendering — we only need report_id to satisfy
+            // the trigger response. Decoding the full AIReport is
+            // covered by AIReviewStoreTests.
+            reportJson = ", \"report\": { \"pk\": \"LEAGUE#L1\", \"sk\": \"REPORT#postDraft#2026\", \"league_id\": \"L1\", \"report_type\": \"postDraft\", \"period\": \"2026\", \"body_markdown\": \"\(report.bodyMarkdown)\", \"created_at\": \"2026-05-21T00:00:00Z\" }"
+        } else {
+            reportJson = ""
+        }
+        let json = """
+        {
+          "report_id": "L1|REPORT#postDraft#2026",
+          "dry_run": \(dryRun),
+          "delivery_count": \(deliveryCount),
+          "model": "claude-haiku-4-5",
+          "token_usage": { "input_tokens": 1234, "output_tokens": 567 }
+          \(reportJson)
+        }
+        """
+        return try! JSONDecoder().decode(
+            AIReviewTriggerResponse.self,
+            from: Data(json.utf8)
+        )
+    }
+
+    // MARK: - loadPostDraftLatest
+
+    func testLoadPostDraftLatest_populatesFromMockClient() async {
+        let report = makePostDraftReport()
+        let mock = MockAdminAPIClient(latest: report)
+        let store = AdminStore(apiClient: mock)
+
+        await store.loadPostDraftLatest()
+
+        XCTAssertEqual(store.postDraftLatest?.id, report.id)
+        XCTAssertEqual(mock.fetchLatestCalls, [.postDraft])
+    }
+
+    func testLoadPostDraftLatest_silentOnFailure() async {
+        let mock = MockAdminAPIClient(fetchLatestError: MockError.boom)
+        let store = AdminStore(apiClient: mock)
+
+        await store.loadPostDraftLatest()
+
+        XCTAssertNil(store.postDraftLatest)
+    }
+
+    // MARK: - triggerPostDraft success
+
+    func testTriggerPostDraft_returnsResultAndUpdatesState() async throws {
+        let report = makePostDraftReport()
+        let response = makeTriggerResponse(dryRun: true, deliveryCount: 1)
+        let mock = MockAdminAPIClient(
+            latest: report,
+            triggerResponse: response
+        )
+        let store = AdminStore(apiClient: mock)
+
+        let result = try await store.triggerPostDraft(dryRun: true, force: false)
+
+        XCTAssertEqual(result.reportId, "L1|REPORT#postDraft#2026")
+        XCTAssertTrue(result.dryRun)
+        XCTAssertEqual(result.deliveryCount, 1)
+        XCTAssertEqual(store.postDraftResult?.reportId, response.reportId)
+        XCTAssertNil(store.postDraftError)
+        XCTAssertFalse(store.isTriggeringPostDraft)
+        // Should refresh latest after success.
+        XCTAssertEqual(mock.fetchLatestCalls, [.postDraft])
+        XCTAssertEqual(mock.triggerCalls.count, 1)
+        XCTAssertEqual(mock.triggerCalls.first?.dryRun, true)
+        XCTAssertEqual(mock.triggerCalls.first?.force, false)
+    }
+
+    func testTriggerPostDraft_broadcastPath() async throws {
+        let response = makeTriggerResponse(dryRun: false, deliveryCount: 12)
+        let mock = MockAdminAPIClient(triggerResponse: response)
+        let store = AdminStore(apiClient: mock)
+
+        let result = try await store.triggerPostDraft(dryRun: false, force: true)
+
+        XCTAssertFalse(result.dryRun)
+        XCTAssertEqual(result.deliveryCount, 12)
+        XCTAssertEqual(mock.triggerCalls.first?.dryRun, false)
+        XCTAssertEqual(mock.triggerCalls.first?.force, true)
+    }
+
+    // MARK: - triggerPostDraft error
+
+    func testTriggerPostDraft_surfacesError() async {
+        let mock = MockAdminAPIClient(triggerError: MockError.boom)
+        let store = AdminStore(apiClient: mock)
+
+        do {
+            _ = try await store.triggerPostDraft(dryRun: true, force: false)
+            XCTFail("Expected throw")
+        } catch {
+            // Expected.
+        }
+
+        XCTAssertNotNil(store.postDraftError)
+        XCTAssertNil(store.postDraftResult)
+        XCTAssertFalse(store.isTriggeringPostDraft)
+    }
+
+    // MARK: - Wire-format guard: postDraft raw value
+
+    func testAIReportType_decodesCamelCasePostDraft() throws {
+        let json = "\"postDraft\""
+        let decoded = try JSONDecoder().decode(
+            AIReportType.self,
+            from: Data(json.utf8)
+        )
+        XCTAssertEqual(decoded, .postDraft)
+        XCTAssertEqual(decoded.rawValue, "postDraft")
+    }
+}
+
+// MARK: - Mock API Client
+
+/// Sendable mock for AdminStore tests. Implements the full protocol
+/// surface so the type checks compile; non-admin methods throw to
+/// catch accidental calls.
+final class MockAdminAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
+    var latest: AIReport?
+    var fetchLatestError: Error?
+    var triggerResponse: AIReviewTriggerResponse?
+    var triggerError: Error?
+
+    private(set) var fetchLatestCalls: [AIReportType] = []
+    private(set) var triggerCalls: [(dryRun: Bool, force: Bool)] = []
+
+    init(
+        latest: AIReport? = nil,
+        fetchLatestError: Error? = nil,
+        triggerResponse: AIReviewTriggerResponse? = nil,
+        triggerError: Error? = nil
+    ) {
+        self.latest = latest
+        self.fetchLatestError = fetchLatestError
+        self.triggerResponse = triggerResponse
+        self.triggerError = triggerError
+    }
+
+    // MARK: AI Review
+
+    func fetchLatestAIReport(type: AIReportType) async throws -> AIReport? {
+        fetchLatestCalls.append(type)
+        if let err = fetchLatestError { throw err }
+        return latest
+    }
+
+    func fetchAIReportsList(type: AIReportType?, limit: Int, cursor: String?) async throws -> AIReportsListResponse {
+        AIReportsListResponse(rows: [], nextCursor: nil)
+    }
+
+    func triggerPostDraftAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse {
+        triggerCalls.append((dryRun, force))
+        if let err = triggerError { throw err }
+        guard let response = triggerResponse else { throw MockError.notConfigured }
+        return response
+    }
+
+    // MARK: Unused protocol surface
+
+    func sendRuleProposalEmail(proposal: RuleProposalEmailPayload, recipients: [String], userIds: [String]) async throws { throw MockError.unsupported }
+    func sendRuleAcceptedEmail(proposal: RuleProposalEmailPayload, approvedBy: [String], rejectedBy: [String], recipients: [String], userIds: [String]) async throws { throw MockError.unsupported }
+    func sendRuleDeniedEmail(proposal: RuleProposalEmailPayload, approvedBy: [String], rejectedBy: [String], recipients: [String], userIds: [String]) async throws { throw MockError.unsupported }
+    func sendTaxiStealEmail(stealer: TaxiStealerPayload, player: TaxiPlayerPayload, owner: TaxiOwnerPayload, recipients: [String], userIds: [String], leagueName: String) async throws { throw MockError.unsupported }
+    func registerDevice(userId: String, deviceToken: String) async throws { throw MockError.unsupported }
+    func unregisterDevice(userId: String, deviceToken: String) async throws { throw MockError.unsupported }
+    func adminListNotifications(sleeperUserId: String, daysBack: Int, kind: String?, status: String?, limit: Int) async throws -> AdminNotificationsResponse { throw MockError.unsupported }
+    func adminTestSend(sleeperUserId: String, email: String?, kind: String, channels: [String]) async throws -> AdminTestSendResponse { throw MockError.unsupported }
+}
+
+enum MockError: Error, LocalizedError {
+    case boom
+    case unsupported
+    case notConfigured
+
+    var errorDescription: String? {
+        switch self {
+        case .boom: "boom"
+        case .unsupported: "mock method not supported"
+        case .notConfigured: "mock not configured"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ships the iOS half of the F1 post-draft AI review flow plus a critical F0 bug fix.

- **Commit 1** — `fix(ai-review F0)`: F0 backend writes `report_type: "postDraft"` (camelCase per `lambdas/common/ai_reports_store.py`), but the iOS enum was pinned to `"post-draft"` (kebab-case). That would have failed to decode the first time a real report landed. This commit re-pins `AIReportType.postDraft` to `"postDraft"` and updates the test fixture id.
- **Commit 2** — `feat(ai-review F1)`: new admin card above the existing Test sender, with dry-run toggle, dynamic button labels, and a secondary "Regenerate (force)" affordance. New `AdminStore` state + methods (`loadPostDraftLatest`, `triggerPostDraft`). New `XomperAPIClient.triggerPostDraftAIReview`. New `AIReviewTriggerResponse` + `TokenUsage` models. New `AdminStoreTests.swift`.

Plan: `docs/features/ai-review/f1-post-draft/PLAN.md` (Repo 3 section).

## Heads-up

The new admin card UI works in the simulator but the network call won't succeed until **both** dependencies merge + deploy:

- `Xomware/xomper-infrastructure#104` — adds the `/admin/ai-review-postdraft-trigger` route (path was flattened from `/admin/ai-review/post-draft/trigger` since API GW's path-builder doesn't cleanly handle 3-segment parents)
- `Xomware/xomper-back-end#58` — ships the `notif_ai_review_postdraft` + `api_admin_ai_review_postdraft_trigger` lambdas

Refs #79 (partial — this is the iOS slice; cron polling and the F2/F3 surfaces are out of scope).

## Test plan

- [x] `xcodegen generate` clean (new `AdminStoreTests.swift` picked up)
- [x] `xcodebuild build` — `** BUILD SUCCEEDED **`, no warnings
- [x] `xcodebuild test` — 21/21 tests pass (6 new `AdminStoreTests`, 6 existing `AIReviewStoreTests`, 9 `ClinchCalculatorTests`)
- [x] Unit-test wire format: `testAIReportType_decodesCamelCasePostDraft` confirms the F0 raw-value fix decodes `"postDraft"` correctly
- [ ] Manual QA on simulator with admin user: card visible only when `isAdmin == true`, toggle defaults on, button label flips between "Generate Dry Run" / "Generate & Broadcast", error path surfaces red text — pending infra + backend deploy
- [ ] Post-deploy: hit the live endpoint with the real admin JWT, verify a `412 draft-not-complete` (or whatever the backend returns pre-draft) lands in the result line — pending infra + backend deploy

## Files

- `Xomper/Core/Models/AIReport.swift` — raw-value fix + new `AIReviewTriggerResponse` / `TokenUsage`
- `Xomper/Core/Networking/XomperAPIClient.swift` — new protocol method + impl
- `Xomper/Core/Stores/AdminStore.swift` — new state + methods
- `Xomper/Features/Admin/AdminView.swift` — new `postDraftTriggerCard`
- `XomperTests/AdminStoreTests.swift` — new test file
- `XomperTests/AIReviewStoreTests.swift` — mock updated to satisfy the extended protocol