### PR TITLE
feat(season-refocus F1): tray surgery — rename Draft History → Draft, demote proposal

### DIFF
--- a/Xomper/Features/DraftHistory/DraftHistoryView.swift
+++ b/Xomper/Features/DraftHistory/DraftHistoryView.swift
@@ -44,7 +44,7 @@ struct DraftHistoryView: View {
             } else {
                 EmptyStateView(
                     icon: "list.clipboard",
-                    title: "No Draft History",
+                    title: "No Draft Picks Yet",
                     message: "Draft picks will appear here once a draft is complete."
                 )
             }

--- a/Xomper/Features/Shell/DrawerView.swift
+++ b/Xomper/Features/Shell/DrawerView.swift
@@ -40,7 +40,7 @@ struct DrawerView: View {
             ),
             TraySection(
                 title: "League",
-                entries: [.payouts, .draftOrder, .aiReview, .rulebook, .scoring, .leagueSettings, .ruleProposals]
+                entries: [.payouts, .aiReview, .rulebook, .scoring, .leagueSettings, .ruleProposals, .draftOrder]
             ),
         ]
         if isAdmin {

--- a/Xomper/Features/Shell/TrayDestination.swift
+++ b/Xomper/Features/Shell/TrayDestination.swift
@@ -37,7 +37,7 @@ enum TrayDestination: Hashable {
         case .standings:      "Standings"
         case .matchups:       "Matchups"
         case .playoffs:       "Playoffs"
-        case .draftHistory:   "Draft History"
+        case .draftHistory:   "Draft"
         case .matchupHistory: "Matchup History"
         case .worldCup:       "World Cup"
         case .myTeam:         "My Team"


### PR DESCRIPTION
## Summary

Phase 1 of the **season-refocus** epic — pure tray/label surgery to clear clutter before the larger Landing Page work lands in F2.

- Rename `.draftHistory` drawer label from "Draft History" → "Draft" (enum case unchanged; nav title cascades automatically via `MainShell` reading `currentDestination.title`).
- Demote `.draftOrder` (Reverse-HPP proposal) from second-of-League to the **bottom** of the League section so it stops competing with Payouts for prime real estate.
- Update `DraftHistoryView` empty-state heading from "No Draft History" → "No Draft Picks Yet" to avoid a stale "Draft → No Draft History" double-take.

**Plan**: [`docs/features/season-refocus/f1-tray-surgery/PLAN.md`](../blob/feature/season-refocus-f1-tray-surgery/docs/features/season-refocus/f1-tray-surgery/PLAN.md)
**Epic**: [`docs/features/season-refocus/EPIC_PLAN.md`](../blob/feature/season-refocus-f1-tray-surgery/docs/features/season-refocus/EPIC_PLAN.md)

## File Diffs

### `Xomper/Features/Shell/TrayDestination.swift` (line ~40)

```diff
-        case .draftHistory:   "Draft History"
+        case .draftHistory:   "Draft"
```

### `Xomper/Features/Shell/DrawerView.swift` (line ~43)

```diff
-                entries: [.payouts, .draftOrder, .aiReview, .rulebook, .scoring, .leagueSettings, .ruleProposals]
+                entries: [.payouts, .aiReview, .rulebook, .scoring, .leagueSettings, .ruleProposals, .draftOrder]
```

### `Xomper/Features/DraftHistory/DraftHistoryView.swift` (line ~47)

```diff
-                    title: "No Draft History",
+                    title: "No Draft Picks Yet",
```

## Test Plan

- [x] Build green (iPhone 17 Pro sim, iOS 17 deployment target).
- [x] `XomperTests` xctest target — all 36 tests pass.
- [ ] Open drawer → HISTORY section first row reads **Draft** (not "Draft History"); icon unchanged.
- [ ] Tap the row → nav title at top of screen reads **Draft**.
- [ ] When the league has no completed drafts for the selected season, empty-state heading reads **No Draft Picks Yet** (icon + body copy unchanged).
- [ ] Open drawer → LEAGUE section ends with **Draft Order Proposal** (was previously second from the top).
- [ ] Tap Draft Order Proposal → screen title still reads "Draft Order Proposal" (unchanged).
- [ ] Quick sanity scroll: other tray destinations (Standings, Matchups, Team Analyzer, Payouts, AI Review, Rulebook, Scoring, League Settings, Rule Proposals) all still render with no regressions.

## Out of Scope

- Any change to `DraftHistoryView` internals beyond the empty-state title.
- Any change to `DraftOrderView` internals or its screen title.
- Adding/removing/renaming any `TrayDestination` enum case.
- Restructuring tray sections (deferred to F2/F4).
- Renaming the `.draftHistory` enum case to `.draft` (backward-compat wins).