### PR TITLE
feat(season-refocus F2): Landing Page MVP — new default destination + 4 cards

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -7,11 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		007B11207486956897981421 /* LandingViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F3E6606D89CF3AEB320314 /* LandingViewTests.swift */; };
 		021A039E220940CD2E12304A /* NavigationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840D50097382434B0D123ACB /* NavigationStore.swift */; };
 		02AC6FBAE68011749AA17644 /* ClinchCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3893B13276074EF6033CEA2 /* ClinchCalculatorTests.swift */; };
 		04C5B75AA224E7ED8314FBA5 /* AIReviewHomeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12507ED13C57EFA8B240301 /* AIReviewHomeCard.swift */; };
 		063FCD6AA342CA5D64ED79ED /* HistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F013CD37874EFB0FA1CB4261 /* HistoryStore.swift */; };
 		08251EFB3181B634553CDCE1 /* TaxiSquadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57940AEB84889A20016648F2 /* TaxiSquadView.swift */; };
+		0A87A5226863819FF3884F6C /* AnnouncementsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCF4387BA57375E04A8940B /* AnnouncementsCard.swift */; };
 		0C2B77E0A46ECE55AE8CE46F /* DivisionBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B670A3A0762D22FB3202E1E /* DivisionBadge.swift */; };
 		114998283E6705D075ED2CA7 /* League.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD88B55D96BD7C519B6B65B6 /* League.swift */; };
 		11EFE5DD5C1D6DE5056597BB /* PlayerPointsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36829F2AD0FD089788B9CE1 /* PlayerPointsStore.swift */; };
@@ -41,6 +43,7 @@
 		427F23653F78A52108C55692 /* XomperLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3B178733D5AF9EB7DA7189 /* XomperLoader.swift */; };
 		42BF3DEE63074148F1DF0BD1 /* AIReviewDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967DCE922FE090CE4F067587 /* AIReviewDetailView.swift */; };
 		42E7DDAD3454512247E1AFA6 /* ProposedTrade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4690614F644FE74115D0DAB6 /* ProposedTrade.swift */; };
+		440A44095AD70A8D3D273EEE /* StandingsScrollBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1A7B1219575171DA3ABAB7 /* StandingsScrollBar.swift */; };
 		4A321187068EEBA8C4E75EFE /* PayoutProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E3BE36BCEA1A7722157C37 /* PayoutProjection.swift */; };
 		4B629DB100C96EB68A6A9A41 /* SearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323F422F2D0E1C2BA5D46C0A /* SearchResults.swift */; };
 		4DB9374CF45A69E97C02FC94 /* PlayerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC44D14381C74E97D8AF868F /* PlayerDetailView.swift */; };
@@ -48,9 +51,11 @@
 		51BD6DAC467108079C465193 /* SearchResultGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F606D0624D23D47A171D26 /* SearchResultGroup.swift */; };
 		54863F3F6ECDD3BE00083582 /* Roster.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE543CB2E49335ADD02E8000 /* Roster.swift */; };
 		556BA960B3DFFACAB2F3DFA6 /* EnvironmentValues+Season.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6504EE31A645398C41BC2ED1 /* EnvironmentValues+Season.swift */; };
+		56222F862DBF98025A2BFEFB /* LeagueAnnouncement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B7E5CBAFC3B1281D1134F0 /* LeagueAnnouncement.swift */; };
 		578172B9CCF7AD92CB66821E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D61F12E32D7C81FCA8F8CE /* ContentView.swift */; };
 		57C17293587E8DBED9A14970 /* TradedPick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F49969EE42BDE6462664021 /* TradedPick.swift */; };
 		58FD67DB9B137F1A8BE50521 /* TeamAnalyzerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8098F78566BB324ACC70FB94 /* TeamAnalyzerView.swift */; };
+		5C041F847E3239901238FD5F /* LandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7048EDD875E2582C792BE47 /* LandingView.swift */; };
 		6010F16122E110BA50642611 /* CareerStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD43D54AB620DABD559F8A40 /* CareerStats.swift */; };
 		602B6E0F6BCF1DA7E3D75F07 /* AuthStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */; };
 		60FB3A9B54EAB11F015C1828 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC24A8748C940FC57B142AFF /* ErrorView.swift */; };
@@ -84,6 +89,7 @@
 		9134D2C8A8737083C9FB8F7F /* ClinchCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3728C5F6BEF61FE509A3EA32 /* ClinchCalculator.swift */; };
 		93D8C8E352B60752D37FD0FF /* PlayerSeasonStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C24A12080AD428D5A40A7E /* PlayerSeasonStats.swift */; };
 		95DE1C46E20BF6910D4E5447 /* TrayItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E4EC7FDB93C47A9EE601BA3 /* TrayItem.swift */; };
+		98D5EE595D14742780A47B81 /* ThisWeekMatchupsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C921F3EC29B03A85D9F2A42C /* ThisWeekMatchupsCard.swift */; };
 		98F895FBCECB23325658339C /* StandingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A47FD1CF3BE7AE0B940DEC /* StandingsView.swift */; };
 		9D9E8D2C4A8A0C623AC1EF0D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E767CD5492176E84C2092B0F /* AppDelegate.swift */; };
 		9E5C71DAB504EDCDF2084DF3 /* MyProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558164667DF7D89C4DF2F32E /* MyProfileView.swift */; };
@@ -100,6 +106,7 @@
 		BBBE8D43F297A49A915AA789 /* WorldCupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F83A5F997AF6E13C98660E /* WorldCupView.swift */; };
 		BDD14CA33B905F7A31910B1D /* SupabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10CD226D313FDD91E4037D8E /* SupabaseManager.swift */; };
 		BE71F196BAB7D9E78BE94A9D /* PlayerValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE87151F7F5AAB8F12F98B91 /* PlayerValue.swift */; };
+		BFAF90EB6F36235274ECB2DC /* HeadlineAIReportCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92075E680F858F8EB156001A /* HeadlineAIReportCard.swift */; };
 		C1D86EAE02F0D6EA70291876 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC70812B3E7E07BA6658A54 /* AvatarView.swift */; };
 		C21992E2FA476C65D8D23BA8 /* HexagonChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 501B8FD2B915B3BD6568F42C /* HexagonChartView.swift */; };
 		C381DCE8472D2F88B04FCBDA /* CareerStatsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CFD764A2BA7FF93B318A7F /* CareerStatsSection.swift */; };
@@ -149,6 +156,7 @@
 		22D61F12E32D7C81FCA8F8CE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		2B670A3A0762D22FB3202E1E /* DivisionBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DivisionBadge.swift; sourceTree = "<group>"; };
 		2B6C68E1131F2BBBE625DEAF /* RuleProposalFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleProposalFormView.swift; sourceTree = "<group>"; };
+		2DCF4387BA57375E04A8940B /* AnnouncementsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsCard.swift; sourceTree = "<group>"; };
 		323F422F2D0E1C2BA5D46C0A /* SearchResults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResults.swift; sourceTree = "<group>"; };
 		36A01820FD0F6643BBF8511D /* TeamStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamStore.swift; sourceTree = "<group>"; };
 		3728C5F6BEF61FE509A3EA32 /* ClinchCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClinchCalculator.swift; sourceTree = "<group>"; };
@@ -179,6 +187,7 @@
 		6504EE31A645398C41BC2ED1 /* EnvironmentValues+Season.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+Season.swift"; sourceTree = "<group>"; };
 		669A80C2A9F46A0C4612388C /* Double+Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Formatting.swift"; sourceTree = "<group>"; };
 		67C24A12080AD428D5A40A7E /* PlayerSeasonStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerSeasonStats.swift; sourceTree = "<group>"; };
+		69B7E5CBAFC3B1281D1134F0 /* LeagueAnnouncement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeagueAnnouncement.swift; sourceTree = "<group>"; };
 		6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayoffBracket.swift; sourceTree = "<group>"; };
 		6CFEC46AB65E6E7A90E0A695 /* AdminStoreWeeklyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStoreWeeklyTests.swift; sourceTree = "<group>"; };
 		6E6A6BADE3F51FA922A078F4 /* AIReviewStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewStore.swift; sourceTree = "<group>"; };
@@ -195,6 +204,7 @@
 		89FC018282A1F1D8B2FD1B60 /* XomperAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperAPIClient.swift; sourceTree = "<group>"; };
 		8A95FE8DD123C85CA39DAE13 /* AIReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReport.swift; sourceTree = "<group>"; };
 		8D921732971689E8096F9549 /* DrawerScrim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerScrim.swift; sourceTree = "<group>"; };
+		92075E680F858F8EB156001A /* HeadlineAIReportCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadlineAIReportCard.swift; sourceTree = "<group>"; };
 		94DF42654C9F48EE60C040F7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		94E125AD2AA5212D0EB4C13A /* NflStateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NflStateStore.swift; sourceTree = "<group>"; };
 		957EE31D25CFE325633622D4 /* StandingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsStore.swift; sourceTree = "<group>"; };
@@ -224,16 +234,19 @@
 		C3AFC2ADE424F95E3121BF22 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		C82B0FEAAB9BC80BA0801E98 /* XomperColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperColors.swift; sourceTree = "<group>"; };
 		C83EF3C6C93199CF3FCBAE42 /* Matchup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Matchup.swift; sourceTree = "<group>"; };
+		C921F3EC29B03A85D9F2A42C /* ThisWeekMatchupsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThisWeekMatchupsCard.swift; sourceTree = "<group>"; };
 		C9382BCB18DFEB416A50A039 /* RulesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesView.swift; sourceTree = "<group>"; };
 		CC3F6B5022E8151683A45F4F /* PlayerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerStore.swift; sourceTree = "<group>"; };
 		CEAEC7A4917990425085AE71 /* PushNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationManager.swift; sourceTree = "<group>"; };
 		D12507ED13C57EFA8B240301 /* AIReviewHomeCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewHomeCard.swift; sourceTree = "<group>"; };
 		D36829F2AD0FD089788B9CE1 /* PlayerPointsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerPointsStore.swift; sourceTree = "<group>"; };
+		D7F3E6606D89CF3AEB320314 /* LandingViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingViewTests.swift; sourceTree = "<group>"; };
 		D7F3F1A18F4EEC5A3F81FD28 /* SeasonStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonStore.swift; sourceTree = "<group>"; };
 		DB1FE16B5220928685DCF19E /* SleeperAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleeperAPIClient.swift; sourceTree = "<group>"; };
 		DBD0F6820960B354EAB3E89D /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		DC24A8748C940FC57B142AFF /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 		DE3B178733D5AF9EB7DA7189 /* XomperLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperLoader.swift; sourceTree = "<group>"; };
+		DF1A7B1219575171DA3ABAB7 /* StandingsScrollBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsScrollBar.swift; sourceTree = "<group>"; };
 		DF491605034E9F8C00BC0572 /* MatchupHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupHistoryView.swift; sourceTree = "<group>"; };
 		E0C5F37100E6EBB467EBFE1C /* SearchStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchStore.swift; sourceTree = "<group>"; };
 		E1A497DF9DD9066BD24A1E19 /* TraySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraySection.swift; sourceTree = "<group>"; };
@@ -255,6 +268,7 @@
 		F4A254D17EF062523E09C9D4 /* MainShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainShell.swift; sourceTree = "<group>"; };
 		F51CC9357B13AB7ADD9C8586 /* TeamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamView.swift; sourceTree = "<group>"; };
 		F6F606D0624D23D47A171D26 /* SearchResultGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultGroup.swift; sourceTree = "<group>"; };
+		F7048EDD875E2582C792BE47 /* LandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingView.swift; sourceTree = "<group>"; };
 		FC09DFF48D9AAFEF0A286BAD /* TeamAnalysis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamAnalysis.swift; sourceTree = "<group>"; };
 		FD5AF5657020E1DBB5CB8886 /* SeasonPickerBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonPickerBar.swift; sourceTree = "<group>"; };
 		FD88B55D96BD7C519B6B65B6 /* League.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = League.swift; sourceTree = "<group>"; };
@@ -294,6 +308,19 @@
 			path = Profile;
 			sourceTree = "<group>";
 		};
+		1EA5925C2F4298FD2DAD1E2E /* Landing */ = {
+			isa = PBXGroup;
+			children = (
+				2DCF4387BA57375E04A8940B /* AnnouncementsCard.swift */,
+				92075E680F858F8EB156001A /* HeadlineAIReportCard.swift */,
+				F7048EDD875E2582C792BE47 /* LandingView.swift */,
+				69B7E5CBAFC3B1281D1134F0 /* LeagueAnnouncement.swift */,
+				DF1A7B1219575171DA3ABAB7 /* StandingsScrollBar.swift */,
+				C921F3EC29B03A85D9F2A42C /* ThisWeekMatchupsCard.swift */,
+			);
+			path = Landing;
+			sourceTree = "<group>";
+		};
 		258608C1F12AB1DDE8EA751F /* Networking */ = {
 			isa = PBXGroup;
 			children = (
@@ -323,6 +350,7 @@
 				EB7304EC920FBEC53F6E4CEB /* DraftHistory */,
 				680358FA986CFA519A36A85D /* DraftOrder */,
 				7DEC053904198785F4461D4A /* Home */,
+				1EA5925C2F4298FD2DAD1E2E /* Landing */,
 				47014533E72495E9E9DC8F74 /* League */,
 				2D1CA584D084FE022DC6401D /* MatchupHistory */,
 				374AF06666E690518BB92FAE /* Payouts */,
@@ -370,6 +398,7 @@
 				6CFEC46AB65E6E7A90E0A695 /* AdminStoreWeeklyTests.swift */,
 				08BD215787E2BFC1C57E7E7E /* AIReviewStoreTests.swift */,
 				B3893B13276074EF6033CEA2 /* ClinchCalculatorTests.swift */,
+				D7F3E6606D89CF3AEB320314 /* LandingViewTests.swift */,
 			);
 			path = XomperTests;
 			sourceTree = "<group>";
@@ -744,6 +773,7 @@
 				37E600A31B5AA5DA5A766692 /* AdminStoreTests.swift in Sources */,
 				6D9C0E43C329D80ED8933AD2 /* AdminStoreWeeklyTests.swift in Sources */,
 				02AC6FBAE68011749AA17644 /* ClinchCalculatorTests.swift in Sources */,
+				007B11207486956897981421 /* LandingViewTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -758,6 +788,7 @@
 				68EE3E2F11A28AD898ABB03C /* AIReviewView.swift in Sources */,
 				1720E856ACCE0189331605F2 /* AdminStore.swift in Sources */,
 				E2E0551B857C17254E9B789B /* AdminView.swift in Sources */,
+				0A87A5226863819FF3884F6C /* AnnouncementsCard.swift in Sources */,
 				9D9E8D2C4A8A0C623AC1EF0D /* AppDelegate.swift in Sources */,
 				8C67D3AAFE5A0A124BDE5F1A /* AppRouter.swift in Sources */,
 				D78D5302B3D17DE9BE7D557C /* AuthGateView.swift in Sources */,
@@ -781,10 +812,13 @@
 				556BA960B3DFFACAB2F3DFA6 /* EnvironmentValues+Season.swift in Sources */,
 				60FB3A9B54EAB11F015C1828 /* ErrorView.swift in Sources */,
 				EDDACB3FFB20E468D9D9D67D /* HeaderBar.swift in Sources */,
+				BFAF90EB6F36235274ECB2DC /* HeadlineAIReportCard.swift in Sources */,
 				C21992E2FA476C65D8D23BA8 /* HexagonChartView.swift in Sources */,
 				F66FCFE7466291137B314370 /* HighestPossibleLineup.swift in Sources */,
 				063FCD6AA342CA5D64ED79ED /* HistoryStore.swift in Sources */,
+				5C041F847E3239901238FD5F /* LandingView.swift in Sources */,
 				114998283E6705D075ED2CA7 /* League.swift in Sources */,
+				56222F862DBF98025A2BFEFB /* LeagueAnnouncement.swift in Sources */,
 				CEC2B1D5D34F80BFB3444C6F /* LeagueOverviewView.swift in Sources */,
 				8C2ABA833D6AB1C5A3017BDA /* LeaguePayouts.swift in Sources */,
 				724482308D102AFA35AB4017 /* LeagueStore.swift in Sources */,
@@ -832,6 +866,7 @@
 				BB91E92DC29E6ECA5E1F0DEC /* SeasonStore.swift in Sources */,
 				77CFB7F9C5E4975E6350662B /* SettingsView.swift in Sources */,
 				65DC95B6907B22347616C3D7 /* SleeperAPIClient.swift in Sources */,
+				440A44095AD70A8D3D273EEE /* StandingsScrollBar.swift in Sources */,
 				B48B9F6061A67CFC74A096CC /* StandingsStore.swift in Sources */,
 				7607DB7C775FCCC3B7C3377B /* StandingsTeam.swift in Sources */,
 				98F895FBCECB23325658339C /* StandingsView.swift in Sources */,
@@ -844,6 +879,7 @@
 				58FD67DB9B137F1A8BE50521 /* TeamAnalyzerView.swift in Sources */,
 				40C507B6FB2EF2A7E647AA3C /* TeamStore.swift in Sources */,
 				B7EB06298BFBF6AC76ABF53E /* TeamView.swift in Sources */,
+				98D5EE595D14742780A47B81 /* ThisWeekMatchupsCard.swift in Sources */,
 				57C17293587E8DBED9A14970 /* TradedPick.swift in Sources */,
 				78094B6DF90F54E0FA59898A /* TrayDestination.swift in Sources */,
 				95DE1C46E20BF6910D4E5447 /* TrayItem.swift in Sources */,

--- a/Xomper/Features/Home/SearchView.swift
+++ b/Xomper/Features/Home/SearchView.swift
@@ -13,6 +13,7 @@ struct SearchView: View {
     var authStore: AuthStore
     var router: AppRouter
     var navStore: NavigationStore
+    // retained for future search-AI integration — Landing now owns the AI hero.
     var aiReviewStore: AIReviewStore
 
     @State private var searchStore: SearchStore
@@ -38,11 +39,6 @@ struct SearchView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            AIReviewHomeCard(
-                store: aiReviewStore,
-                navStore: navStore,
-                router: router
-            )
             searchControls
             resultArea
         }
@@ -50,15 +46,6 @@ struct SearchView: View {
         .navigationTitle("Search")
         .navigationBarTitleDisplayMode(.large)
         .toolbarColorScheme(.dark, for: .navigationBar)
-        .task {
-            // Prime the latest-by-type lookup for the home banner.
-            // All three loads run in parallel; the card picks the
-            // newest. Each respects the store's 12-hour freshness.
-            async let post: () = aiReviewStore.loadLatest(type: .postDraft)
-            async let pre:  () = aiReviewStore.loadLatest(type: .preseason)
-            async let week: () = aiReviewStore.loadLatest(type: .weekly)
-            _ = await (post, pre, week)
-        }
     }
 
     // MARK: - Search Controls

--- a/Xomper/Features/Landing/AnnouncementsCard.swift
+++ b/Xomper/Features/Landing/AnnouncementsCard.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+/// Renders the hardcoded `LeagueAnnouncements.current` list as a
+/// stacked set of compact cards. Expired entries (`expiresAt < now`)
+/// are filtered out; remaining entries sort critical-first, then by
+/// the order they appear in the source array.
+///
+/// When the filtered list is empty, the card renders zero-height —
+/// the Landing page collapses around it instead of showing an empty
+/// state. Announcements are an opportunistic surface, not a required
+/// one.
+struct AnnouncementsCard: View {
+    /// Filtered + sorted list. Computed at render time so date-based
+    /// expiry kicks in without any timers / observers.
+    private var visible: [LeagueAnnouncement] {
+        let now = Date()
+        return LeagueAnnouncements.current
+            .filter { entry in
+                guard let expiresAt = entry.expiresAt else { return true }
+                return expiresAt > now
+            }
+            .sorted { a, b in
+                // critical (priority order 0) before info (1)
+                priorityOrder(a.priority) < priorityOrder(b.priority)
+            }
+    }
+
+    var body: some View {
+        if visible.isEmpty {
+            EmptyView()
+        } else {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+                sectionHeader
+
+                VStack(spacing: XomperTheme.Spacing.sm) {
+                    ForEach(visible) { entry in
+                        AnnouncementRow(announcement: entry)
+                    }
+                }
+            }
+        }
+    }
+
+    private var sectionHeader: some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            Image(systemName: "megaphone.fill")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(XomperColors.textSecondary)
+            Text("ANNOUNCEMENTS")
+                .font(.caption2.weight(.bold))
+                .tracking(0.5)
+                .foregroundStyle(XomperColors.textSecondary)
+            Spacer()
+        }
+        .padding(.horizontal, XomperTheme.Spacing.xs)
+        .accessibilityHidden(true)
+    }
+
+    private func priorityOrder(_ priority: LeagueAnnouncement.Priority) -> Int {
+        switch priority {
+        case .critical: 0
+        case .info:     1
+        }
+    }
+}
+
+/// Single announcement row. Critical entries get a 3pt-wide red left
+/// edge accent; info entries are plain `bgCard`.
+private struct AnnouncementRow: View {
+    let announcement: LeagueAnnouncement
+
+    var body: some View {
+        HStack(spacing: 0) {
+            if announcement.priority == .critical {
+                Rectangle()
+                    .fill(XomperColors.accentRed)
+                    .frame(width: 3)
+            }
+
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+                HStack(spacing: XomperTheme.Spacing.xs) {
+                    if announcement.priority == .critical {
+                        Text("CRITICAL")
+                            .font(.caption2.weight(.bold))
+                            .tracking(0.5)
+                            .foregroundStyle(XomperColors.accentRed)
+                    }
+                    Text(announcement.title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(XomperColors.textPrimary)
+                        .lineLimit(2)
+                    Spacer()
+                }
+
+                Text(announcement.body)
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textSecondary)
+                    .multilineTextAlignment(.leading)
+            }
+            .padding(XomperTheme.Spacing.md)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(announcement.priority == .critical ? "Critical: " : "")\(announcement.title). \(announcement.body)")
+    }
+}
+
+#Preview {
+    AnnouncementsCard()
+        .padding()
+        .background(XomperColors.bgDark)
+        .preferredColorScheme(.dark)
+}

--- a/Xomper/Features/Landing/HeadlineAIReportCard.swift
+++ b/Xomper/Features/Landing/HeadlineAIReportCard.swift
@@ -1,0 +1,163 @@
+import SwiftUI
+
+/// Hero variant of the AI Review card — the freshest report across all
+/// types in a championGold-bordered card at the top of the Landing
+/// page. Tapping switches the tray destination to `.aiReview` and
+/// pushes the detail view in the same animation envelope.
+///
+/// When the store has no latest report (cold-start or pre-draft),
+/// renders a dedicated placeholder card so the Landing hero slot is
+/// never empty — empty space here would make the page feel broken.
+struct HeadlineAIReportCard: View {
+    let store: AIReviewStore
+    let navStore: NavigationStore
+    let router: AppRouter
+
+    var body: some View {
+        if let report = store.mostRecentLatest {
+            reportCard(report: report)
+        } else {
+            placeholderCard
+        }
+    }
+
+    // MARK: - Populated hero card
+
+    private func reportCard(report: AIReport) -> some View {
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            // Switch tray to AI Review, then push detail. The two
+            // happen inside the same navStore animation envelope.
+            navStore.select(.aiReview, router: router)
+            router.navigate(to: .aiReportDetail(reportId: report.id))
+        } label: {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+                headerRow(report: report)
+
+                Text(report.displayTitle)
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+
+                if !report.previewSnippet.isEmpty {
+                    Text(report.previewSnippet)
+                        .font(.subheadline)
+                        .foregroundStyle(XomperColors.textSecondary)
+                        .lineLimit(3)
+                        .multilineTextAlignment(.leading)
+                }
+
+                readMoreRow
+            }
+            .padding(XomperTheme.Spacing.md)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+            .overlay(
+                RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                    .strokeBorder(XomperColors.championGold.opacity(0.4), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Latest AI report: \(report.displayTitle)")
+        .accessibilityHint("Double tap to read")
+    }
+
+    private func headerRow(report: AIReport) -> some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            typeChip(for: report)
+            Text(report.period)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(XomperColors.textSecondary)
+            Spacer()
+        }
+    }
+
+    private func typeChip(for report: AIReport) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: report.reportType.systemImage)
+                .font(.caption2.weight(.bold))
+            Text(report.reportType.displayName.uppercased())
+                .font(.caption2.weight(.bold))
+                .tracking(0.5)
+        }
+        .foregroundStyle(XomperColors.bgDark)
+        .padding(.horizontal, XomperTheme.Spacing.sm)
+        .padding(.vertical, 4)
+        .background(XomperColors.championGold)
+        .clipShape(Capsule())
+    }
+
+    private var readMoreRow: some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            Text("Read report")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(XomperColors.championGold)
+            Image(systemName: "chevron.right")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(XomperColors.championGold)
+            Spacer()
+        }
+    }
+
+    // MARK: - Cold-start placeholder
+
+    private var placeholderCard: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                Image(systemName: "sparkles")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold.opacity(0.5))
+                Text("AI REVIEWS")
+                    .font(.caption2.weight(.bold))
+                    .tracking(0.5)
+                    .foregroundStyle(XomperColors.textMuted)
+                Spacer()
+            }
+
+            Text("First report drops after draft day")
+                .font(.headline)
+                .foregroundStyle(XomperColors.textPrimary)
+                .multilineTextAlignment(.leading)
+
+            Text("AI reviews land here once the season kicks off — check back after July 6.")
+                .font(.subheadline)
+                .foregroundStyle(XomperColors.textSecondary)
+                .multilineTextAlignment(.leading)
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.25), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("AI reviews placeholder. First report drops after draft day.")
+    }
+}
+
+#Preview("Populated") {
+    HeadlineAIReportCard(
+        store: AIReviewStore(),
+        navStore: NavigationStore(),
+        router: AppRouter()
+    )
+    .padding()
+    .background(XomperColors.bgDark)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Empty") {
+    HeadlineAIReportCard(
+        store: AIReviewStore(),
+        navStore: NavigationStore(),
+        router: AppRouter()
+    )
+    .padding()
+    .background(XomperColors.bgDark)
+    .preferredColorScheme(.dark)
+}

--- a/Xomper/Features/Landing/LandingView.swift
+++ b/Xomper/Features/Landing/LandingView.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+/// Tiny `@Observable` shim used to drive `ThisWeekMatchupsCard.refresh()`
+/// from the outer `LandingView.refreshable` modifier.
+///
+/// Bumping `refreshToken` re-fires the card's `.task(id:)` which kicks off
+/// a fresh `fetchLeagueMatchups` call. Lives at the `LandingView` level so
+/// the pull-to-refresh handler can `await` matchups alongside the other
+/// three data sources.
+@Observable
+@MainActor
+final class ThisWeekMatchupsController {
+    /// Bump this UUID to retrigger the matchups card's load task.
+    var refreshToken: UUID = UUID()
+
+    /// Awaitable handle the card sets while a load is in flight. The
+    /// outer refresh waits on this so its spinner lingers until matchups
+    /// land — keeps all four refreshes feeling synchronous from the
+    /// user's perspective.
+    var pendingRefresh: Task<Void, Never>?
+
+    func bumpAndWait() async {
+        refreshToken = UUID()
+        await pendingRefresh?.value
+    }
+}
+
+/// New default top-level destination — the league's "home" surface.
+/// Composes four cards in a static order: Headline AI Review (hero) →
+/// Announcements → Standings scroll bar → This-week matchups.
+///
+/// Pulls from existing stores (`AIReviewStore`, `LeagueStore`,
+/// `NflStateStore`) so it bootstraps with no extra plumbing. The
+/// matchups card owns its own one-shot fetch; everything else reads
+/// state already populated by `MainShell.bootstrapPhase1/2`.
+struct LandingView: View {
+    var leagueStore: LeagueStore
+    var authStore: AuthStore
+    var nflStateStore: NflStateStore
+    var aiReviewStore: AIReviewStore
+    var navStore: NavigationStore
+    var router: AppRouter
+
+    @State private var matchupsController = ThisWeekMatchupsController()
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: XomperTheme.Spacing.md) {
+                HeadlineAIReportCard(
+                    store: aiReviewStore,
+                    navStore: navStore,
+                    router: router
+                )
+
+                AnnouncementsCard()
+
+                StandingsScrollBar(
+                    leagueStore: leagueStore,
+                    nflStateStore: nflStateStore,
+                    authStore: authStore,
+                    router: router
+                )
+
+                ThisWeekMatchupsCard(
+                    leagueStore: leagueStore,
+                    nflStateStore: nflStateStore,
+                    authStore: authStore,
+                    controller: matchupsController
+                )
+            }
+            .padding(.horizontal, XomperTheme.Spacing.md)
+            .padding(.vertical, XomperTheme.Spacing.sm)
+        }
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .refreshable {
+            await refreshAll()
+        }
+        .task {
+            // Prime the latest-by-type lookup for the hero card.
+            // All three loads run in parallel; the card picks the
+            // newest. Each respects the store's 12-hour freshness.
+            async let post: () = aiReviewStore.loadLatest(type: .postDraft)
+            async let pre:  () = aiReviewStore.loadLatest(type: .preseason)
+            async let week: () = aiReviewStore.loadLatest(type: .weekly)
+            _ = await (post, pre, week)
+        }
+    }
+
+    // MARK: - Refresh
+
+    /// Pull-to-refresh: fans out to all four data sources in parallel.
+    /// AI reports / NFL state / league reload are awaited directly;
+    /// the matchups card refresh is delegated via the controller so the
+    /// card stays self-contained.
+    private func refreshAll() async {
+        async let ai:       () = aiReviewStore.refresh()
+        async let nfl:      () = nflStateStore.fetchState()
+        async let league:   () = leagueStore.loadMyLeague()
+        async let matchups: () = matchupsController.bumpAndWait()
+        _ = await (ai, nfl, league, matchups)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        LandingView(
+            leagueStore: LeagueStore(),
+            authStore: AuthStore(),
+            nflStateStore: NflStateStore(),
+            aiReviewStore: AIReviewStore(),
+            navStore: NavigationStore(),
+            router: AppRouter()
+        )
+    }
+    .preferredColorScheme(.dark)
+}

--- a/Xomper/Features/Landing/LeagueAnnouncement.swift
+++ b/Xomper/Features/Landing/LeagueAnnouncement.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// A single league announcement surfaced on the Landing page's
+/// `AnnouncementsCard`. v1 is a hardcoded list (see
+/// `LeagueAnnouncements.current` below); v2 may move this to Supabase.
+///
+/// `expiresAt` is consulted at render time — entries past their
+/// expiry are filtered out by `AnnouncementsCard`. `nil` means the
+/// entry is permanent until removed manually.
+struct LeagueAnnouncement: Identifiable, Sendable {
+    enum Priority: Sendable {
+        case critical
+        case info
+    }
+
+    let id: UUID
+    let title: String
+    let body: String
+    let priority: Priority
+    /// Hard cutoff — when `Date() >= expiresAt`, the entry is filtered
+    /// out by the card. `nil` = always visible.
+    let expiresAt: Date?
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        body: String,
+        priority: Priority,
+        expiresAt: Date? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.body = body
+        self.priority = priority
+        self.expiresAt = expiresAt
+    }
+}
+
+/// Hardcoded league announcements for v1. Edit this array to add or
+/// retire entries — there is no admin UI for v1.
+///
+/// Filtering + sorting (critical first) happens at render time in
+/// `AnnouncementsCard.visible`.
+enum LeagueAnnouncements {
+
+    /// Returns the active list as of right now. Use a static `current`
+    /// computed property so the dates resolve once per render — there
+    /// is no Date mutation cost.
+    static var current: [LeagueAnnouncement] {
+        [
+            LeagueAnnouncement(
+                title: "Draft is July 6",
+                body: "6:30pm ET sharp. ~1 day per pick. Make sure you can be available for autopick fallback.",
+                priority: .critical,
+                expiresAt: date(year: 2026, month: 7, day: 7)
+            ),
+            LeagueAnnouncement(
+                title: "Rule Proposals open",
+                body: "Vote on this season's open proposals before draft day.",
+                priority: .info,
+                expiresAt: date(year: 2026, month: 7, day: 6)
+            ),
+            LeagueAnnouncement(
+                title: "Season starts Sept 8",
+                body: "Week 1 kicks off Mon Sept 8. Lineups lock at first kickoff.",
+                priority: .info,
+                expiresAt: date(year: 2026, month: 9, day: 9)
+            ),
+        ]
+    }
+
+    /// Construct a `Date` from y/m/d in the current calendar's local
+    /// time zone. Used only for `expiresAt` comparison cutoffs.
+    private static func date(year: Int, month: Int, day: Int) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        return Calendar.current.date(from: components) ?? Date.distantFuture
+    }
+}

--- a/Xomper/Features/Landing/StandingsScrollBar.swift
+++ b/Xomper/Features/Landing/StandingsScrollBar.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+
+/// Horizontal scroll of all 12 team chips — avatar + team name + W-L.
+/// Tapping a chip pushes the team detail route. Pure read-only surface
+/// for the Landing page; no internal state beyond the derived
+/// `[StandingsTeam]` array.
+///
+/// In offseason (`!nflStateStore.isRegularSeason`) or when standings
+/// haven't loaded yet, renders a compact empty-state card instead so
+/// the slot is always populated.
+struct StandingsScrollBar: View {
+    var leagueStore: LeagueStore
+    var nflStateStore: NflStateStore
+    var authStore: AuthStore
+    var router: AppRouter
+
+    @State private var standings: [StandingsTeam] = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            sectionHeader
+
+            if !nflStateStore.isRegularSeason {
+                offseasonEmptyState
+            } else if standings.isEmpty {
+                loadingPlaceholder
+            } else {
+                chipScroller
+            }
+        }
+        .task(id: leagueStore.myLeague?.leagueId) {
+            buildStandings()
+        }
+        .onChange(of: leagueStore.myLeagueRosters.count) { _, _ in
+            buildStandings()
+        }
+        .onChange(of: leagueStore.myLeagueUsers.count) { _, _ in
+            buildStandings()
+        }
+    }
+
+    // MARK: - Header
+
+    private var sectionHeader: some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            Image(systemName: "list.number")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(XomperColors.textSecondary)
+            Text("STANDINGS")
+                .font(.caption2.weight(.bold))
+                .tracking(0.5)
+                .foregroundStyle(XomperColors.textSecondary)
+            Spacer()
+        }
+        .padding(.horizontal, XomperTheme.Spacing.xs)
+        .accessibilityHidden(true)
+    }
+
+    // MARK: - Chip scroller
+
+    private var chipScroller: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: XomperTheme.Spacing.sm) {
+                ForEach(standings) { team in
+                    teamChip(team)
+                }
+            }
+            .padding(.horizontal, XomperTheme.Spacing.xs)
+        }
+    }
+
+    private func teamChip(_ team: StandingsTeam) -> some View {
+        let isMine = team.userId == authStore.sleeperUserId
+
+        return Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            router.navigate(to: .teamDetail(rosterId: team.rosterId))
+        } label: {
+            HStack(spacing: XomperTheme.Spacing.sm) {
+                AvatarView(
+                    avatarID: team.avatarId,
+                    size: XomperTheme.AvatarSize.sm,
+                    isTeam: true
+                )
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(team.teamName)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(XomperColors.textPrimary)
+                        .lineLimit(1)
+                    Text(team.record)
+                        .font(.caption2)
+                        .foregroundStyle(
+                            isMine ? XomperColors.championGold : XomperColors.textSecondary
+                        )
+                        .monospacedDigit()
+                }
+            }
+            .padding(.horizontal, XomperTheme.Spacing.sm)
+            .padding(.vertical, XomperTheme.Spacing.sm)
+            .frame(minWidth: 140, alignment: .leading)
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+            .overlay(
+                RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                    .strokeBorder(
+                        isMine ? XomperColors.championGold.opacity(0.4) : Color.clear,
+                        lineWidth: 1
+                    )
+            )
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(team.teamName), \(team.record)\(isMine ? ", your team" : "")")
+        .accessibilityHint("Double tap to open team")
+    }
+
+    // MARK: - Empty / loading states
+
+    private var offseasonEmptyState: some View {
+        emptyCard(
+            icon: "moon.zzz.fill",
+            message: "Standings unlock once Week 1 kicks off."
+        )
+    }
+
+    private var loadingPlaceholder: some View {
+        emptyCard(
+            icon: "list.number",
+            message: "Loading standings…"
+        )
+    }
+
+    private func emptyCard(icon: String, message: String) -> some View {
+        HStack(spacing: XomperTheme.Spacing.sm) {
+            Image(systemName: icon)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(XomperColors.textMuted)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(XomperColors.textSecondary)
+            Spacer()
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(message)
+    }
+
+    // MARK: - Build
+
+    private func buildStandings() {
+        guard let league = leagueStore.myLeague else {
+            standings = []
+            return
+        }
+        standings = StandingsBuilder.buildStandings(
+            rosters: leagueStore.myLeagueRosters,
+            users: leagueStore.myLeagueUsers,
+            league: league
+        )
+    }
+}
+
+#Preview {
+    StandingsScrollBar(
+        leagueStore: LeagueStore(),
+        nflStateStore: NflStateStore(),
+        authStore: AuthStore(),
+        router: AppRouter()
+    )
+    .padding()
+    .background(XomperColors.bgDark)
+    .preferredColorScheme(.dark)
+}

--- a/Xomper/Features/Landing/ThisWeekMatchupsCard.swift
+++ b/Xomper/Features/Landing/ThisWeekMatchupsCard.swift
@@ -1,0 +1,337 @@
+import SwiftUI
+
+/// Compact scoreboard of the current week's matchups — Team A / VS /
+/// Team B with point totals when available. Self-loading: holds its
+/// own raw `[Matchup]` state and re-fetches when `leagueId`, `week`,
+/// or the parent's `refreshToken` changes.
+///
+/// Offseason behavior: when `!nflStateStore.isRegularSeason`, renders
+/// a compact empty-state card and skips the network call.
+struct ThisWeekMatchupsCard: View {
+    var leagueStore: LeagueStore
+    var nflStateStore: NflStateStore
+    var authStore: AuthStore
+    var controller: ThisWeekMatchupsController
+
+    @State private var pairs: [PairedMatchup] = []
+    @State private var isLoading = false
+    @State private var loadError: String?
+
+    /// Lightweight API client instance — same pattern `HistoryStore`
+    /// takes. The card owns the call; no global state.
+    private let apiClient: SleeperAPIClientProtocol = SleeperAPIClient()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            sectionHeader
+
+            if !nflStateStore.isRegularSeason {
+                offseasonEmptyState
+            } else if let error = loadError, pairs.isEmpty {
+                errorState(message: error)
+            } else if pairs.isEmpty && isLoading {
+                loadingState
+            } else if pairs.isEmpty {
+                noMatchupsState
+            } else {
+                matchupsList
+            }
+        }
+        .task(id: taskKey) {
+            await loadIfNeeded()
+        }
+    }
+
+    // MARK: - Header
+
+    private var sectionHeader: some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            Image(systemName: "sportscourt.fill")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(XomperColors.textSecondary)
+            Text("WEEK \(nflStateStore.currentWeek) MATCHUPS")
+                .font(.caption2.weight(.bold))
+                .tracking(0.5)
+                .foregroundStyle(XomperColors.textSecondary)
+            Spacer()
+        }
+        .padding(.horizontal, XomperTheme.Spacing.xs)
+        .accessibilityHidden(true)
+    }
+
+    // MARK: - Matchups list
+
+    private var matchupsList: some View {
+        VStack(spacing: XomperTheme.Spacing.sm) {
+            ForEach(pairs) { pair in
+                matchupRow(pair)
+            }
+        }
+    }
+
+    private func matchupRow(_ pair: PairedMatchup) -> some View {
+        HStack(spacing: XomperTheme.Spacing.sm) {
+            teamCell(
+                teamName: pair.teamAName,
+                avatarId: pair.teamAAvatar,
+                points: pair.teamAPoints,
+                isMine: pair.teamAIsMine,
+                alignment: .leading
+            )
+
+            Text("VS")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(XomperColors.textMuted)
+                .tracking(0.5)
+
+            teamCell(
+                teamName: pair.teamBName,
+                avatarId: pair.teamBAvatar,
+                points: pair.teamBPoints,
+                isMine: pair.teamBIsMine,
+                alignment: .trailing
+            )
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(
+                    (pair.teamAIsMine || pair.teamBIsMine)
+                        ? XomperColors.championGold.opacity(0.4)
+                        : Color.clear,
+                    lineWidth: 1
+                )
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel(for: pair))
+    }
+
+    private func teamCell(
+        teamName: String,
+        avatarId: String?,
+        points: Double,
+        isMine: Bool,
+        alignment: HorizontalAlignment
+    ) -> some View {
+        VStack(alignment: alignment, spacing: XomperTheme.Spacing.xs) {
+            AvatarView(
+                avatarID: avatarId,
+                size: XomperTheme.AvatarSize.sm,
+                isTeam: true
+            )
+            Text(teamName)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(XomperColors.textPrimary)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: alignment == .leading ? .leading : .trailing)
+            Text(pointsLabel(points))
+                .font(.subheadline.weight(.bold))
+                .foregroundStyle(isMine ? XomperColors.championGold : XomperColors.textSecondary)
+                .monospacedDigit()
+        }
+        .frame(maxWidth: .infinity, alignment: alignment == .leading ? .leading : .trailing)
+    }
+
+    private func pointsLabel(_ points: Double) -> String {
+        guard points > 0 else { return "—" }
+        return String(format: "%.2f", points)
+    }
+
+    private func accessibilityLabel(for pair: PairedMatchup) -> String {
+        let a = "\(pair.teamAName) \(pointsLabel(pair.teamAPoints))"
+        let b = "\(pair.teamBName) \(pointsLabel(pair.teamBPoints))"
+        return "\(a) versus \(b)"
+    }
+
+    // MARK: - States
+
+    private var offseasonEmptyState: some View {
+        emptyCard(
+            icon: "moon.zzz.fill",
+            message: "This week's matchups appear here once games begin."
+        )
+    }
+
+    private var loadingState: some View {
+        emptyCard(
+            icon: "sportscourt",
+            message: "Loading this week's matchups…"
+        )
+    }
+
+    private var noMatchupsState: some View {
+        emptyCard(
+            icon: "sportscourt",
+            message: "No matchups scheduled for Week \(nflStateStore.currentWeek)."
+        )
+    }
+
+    private func errorState(message: String) -> some View {
+        emptyCard(
+            icon: "exclamationmark.triangle.fill",
+            message: "Couldn't load matchups: \(message)"
+        )
+    }
+
+    private func emptyCard(icon: String, message: String) -> some View {
+        HStack(spacing: XomperTheme.Spacing.sm) {
+            Image(systemName: icon)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(XomperColors.textMuted)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(XomperColors.textSecondary)
+            Spacer()
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(message)
+    }
+
+    // MARK: - Load
+
+    /// Composite key for `.task(id:)` — re-fires the load whenever the
+    /// home league, current week, or the controller's refresh token
+    /// changes. The controller is bumped by the outer Landing
+    /// pull-to-refresh.
+    private var taskKey: String {
+        let leagueId = leagueStore.myLeague?.leagueId ?? "none"
+        return "\(leagueId)-\(nflStateStore.currentWeek)-\(controller.refreshToken.uuidString)"
+    }
+
+    private func loadIfNeeded() async {
+        // Skip the network call entirely in offseason.
+        guard nflStateStore.isRegularSeason else {
+            pairs = []
+            isLoading = false
+            return
+        }
+        guard let leagueId = leagueStore.myLeague?.leagueId else {
+            pairs = []
+            isLoading = false
+            return
+        }
+
+        let task = Task { @MainActor in
+            await performLoad(leagueId: leagueId, week: nflStateStore.currentWeek)
+        }
+        controller.pendingRefresh = task
+        await task.value
+        controller.pendingRefresh = nil
+    }
+
+    private func performLoad(leagueId: String, week: Int) async {
+        isLoading = true
+        loadError = nil
+        defer { isLoading = false }
+
+        do {
+            let raw = try await apiClient.fetchLeagueMatchups(leagueId, week: week)
+            pairs = Self.pair(
+                raw,
+                rosters: leagueStore.myLeagueRosters,
+                users: leagueStore.myLeagueUsers,
+                myUserId: authStore.sleeperUserId
+            )
+        } catch {
+            loadError = error.localizedDescription
+            pairs = []
+        }
+    }
+
+    // MARK: - Pairing helper
+
+    /// Groups raw matchups by `matchupId` into pairs and resolves
+    /// owner names / team names / avatars from the home-league users
+    /// and rosters. Replicates `HistoryStore.pairMatchupsStatic`'s
+    /// grouping inline — the upstream helper is private.
+    private static func pair(
+        _ matchups: [Matchup],
+        rosters: [Roster],
+        users: [SleeperUser],
+        myUserId: String?
+    ) -> [PairedMatchup] {
+        var grouped: [Int: [Matchup]] = [:]
+        for matchup in matchups {
+            guard let mid = matchup.matchupId else { continue }
+            grouped[mid, default: []].append(matchup)
+        }
+
+        let rosterById = Dictionary(uniqueKeysWithValues: rosters.map { ($0.rosterId, $0) })
+        let userById = Dictionary(uniqueKeysWithValues: users.compactMap { user -> (String, SleeperUser)? in
+            guard let id = user.userId else { return nil }
+            return (id, user)
+        })
+
+        func resolve(_ matchup: Matchup) -> (name: String, avatar: String?, isMine: Bool) {
+            let roster = rosterById[matchup.rosterId]
+            let ownerId = roster?.ownerId
+            let user = ownerId.flatMap { userById[$0] }
+            let name = user?.teamName
+                ?? user?.resolvedDisplayName
+                ?? "Team \(matchup.rosterId)"
+            let isMine = ownerId != nil && ownerId == myUserId
+            return (name, user?.avatar, isMine)
+        }
+
+        return grouped.values.compactMap { pair -> PairedMatchup? in
+            guard pair.count >= 2 else { return nil }
+            let a = pair[0]
+            let b = pair[1]
+            let infoA = resolve(a)
+            let infoB = resolve(b)
+            return PairedMatchup(
+                matchupId: a.matchupId ?? 0,
+                teamAName: infoA.name,
+                teamAAvatar: infoA.avatar,
+                teamAPoints: a.resolvedPoints,
+                teamAIsMine: infoA.isMine,
+                teamBName: infoB.name,
+                teamBAvatar: infoB.avatar,
+                teamBPoints: b.resolvedPoints,
+                teamBIsMine: infoB.isMine
+            )
+        }
+        .sorted { lhs, rhs in
+            // My matchup first if present; then by matchupId.
+            if lhs.teamAIsMine || lhs.teamBIsMine { return true }
+            if rhs.teamAIsMine || rhs.teamBIsMine { return false }
+            return lhs.matchupId < rhs.matchupId
+        }
+    }
+}
+
+/// View-local matchup model — denormalized for one-shot rendering.
+/// Kept private to the file so the public API of the card is just
+/// `init` + `body`.
+private struct PairedMatchup: Identifiable, Sendable {
+    let matchupId: Int
+    let teamAName: String
+    let teamAAvatar: String?
+    let teamAPoints: Double
+    let teamAIsMine: Bool
+    let teamBName: String
+    let teamBAvatar: String?
+    let teamBPoints: Double
+    let teamBIsMine: Bool
+
+    var id: Int { matchupId }
+}
+
+#Preview {
+    ThisWeekMatchupsCard(
+        leagueStore: LeagueStore(),
+        nflStateStore: NflStateStore(),
+        authStore: AuthStore(),
+        controller: ThisWeekMatchupsController()
+    )
+    .padding()
+    .background(XomperColors.bgDark)
+    .preferredColorScheme(.dark)
+}

--- a/Xomper/Features/Shell/DrawerView.swift
+++ b/Xomper/Features/Shell/DrawerView.swift
@@ -27,6 +27,10 @@ struct DrawerView: View {
     private var sections: [TraySection] {
         var out: [TraySection] = [
             TraySection(
+                title: "Home",
+                entries: [.landing]
+            ),
+            TraySection(
                 title: "Compete",
                 entries: [.standings, .matchups, .playoffs]
             ),

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -125,6 +125,16 @@ struct MainShell: View {
     private var destinationRoot: some View {
         Group {
             switch navStore.currentDestination {
+            case .landing:
+                LandingView(
+                    leagueStore: leagueStore,
+                    authStore: authStore,
+                    nflStateStore: nflStateStore,
+                    aiReviewStore: aiReviewStore,
+                    navStore: navStore,
+                    router: router
+                )
+
             case .standings:
                 StandingsView(
                     leagueStore: leagueStore,

--- a/Xomper/Features/Shell/NavigationStore.swift
+++ b/Xomper/Features/Shell/NavigationStore.swift
@@ -18,8 +18,10 @@ final class NavigationStore {
     var isDrawerOpen: Bool = false
 
     /// Top-level destination rendered inside `MainShell`'s NavigationStack root.
-    /// Default landing destination on cold open is `.standings`.
-    var currentDestination: TrayDestination = .standings
+    /// Default landing destination on cold open is `.landing` — the new Home
+    /// surface composing the AI hero + announcements + standings bar +
+    /// this-week matchups. Standings remains accessible via the drawer.
+    var currentDestination: TrayDestination = .landing
 
     // MARK: - Drawer toggling
 

--- a/Xomper/Features/Shell/TrayDestination.swift
+++ b/Xomper/Features/Shell/TrayDestination.swift
@@ -4,12 +4,14 @@ import Foundation
 /// `currentDestination` on `NavigationStore` is always one of these.
 ///
 /// Cases are grouped logically by the drawer sections:
+/// - Home:     landing
 /// - Compete:  standings, matchups, playoffs
 /// - History:  draftHistory, matchupHistory, worldCup
 /// - Roster:   myTeam, taxiSquad
 /// - Rules:    rulebook, scoring, leagueSettings, ruleProposals
 /// - Profile/Settings are surfaced via the profile card and pinned footer.
 enum TrayDestination: Hashable {
+    case landing
     case standings
     case matchups
     case playoffs
@@ -34,6 +36,7 @@ enum TrayDestination: Hashable {
     /// title when the destination is rendered.
     var title: String {
         switch self {
+        case .landing:        "Home"
         case .standings:      "Standings"
         case .matchups:       "Matchups"
         case .playoffs:       "Playoffs"
@@ -59,6 +62,7 @@ enum TrayDestination: Hashable {
     /// SF Symbol used both for the drawer row icon and any external pickers.
     var systemImage: String {
         switch self {
+        case .landing:        "house.fill"
         case .standings:      "list.number"
         case .matchups:       "sportscourt.fill"
         case .playoffs:       "trophy.fill"

--- a/XomperTests/LandingViewTests.swift
+++ b/XomperTests/LandingViewTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import Xomper
+
+@MainActor
+final class LandingViewTests: XCTestCase {
+
+    // MARK: - LeagueAnnouncements filter
+
+    /// Entries with `expiresAt` strictly in the past are filtered out.
+    /// Entries with `expiresAt == nil` always survive.
+    func testLeagueAnnouncements_filtersExpiredEntries() {
+        // The hardcoded list uses absolute calendar dates. We can't
+        // mutate Date, but the priority sort is deterministic and the
+        // filter logic mirrors what `AnnouncementsCard.visible` does.
+        let now = Date()
+        let visible = LeagueAnnouncements.current
+            .filter { entry in
+                guard let expiresAt = entry.expiresAt else { return true }
+                return expiresAt > now
+            }
+        // All entries should either be permanent (nil) or expire in
+        // the future relative to `now` — none should have an expiry
+        // already in the past.
+        for entry in visible {
+            if let expiresAt = entry.expiresAt {
+                XCTAssertGreaterThan(
+                    expiresAt,
+                    now,
+                    "Visible announcement '\(entry.title)' has past expiresAt \(expiresAt)"
+                )
+            }
+        }
+    }
+
+    /// Critical announcements sort before info ones.
+    func testLeagueAnnouncements_criticalSortsBeforeInfo() {
+        let entries = LeagueAnnouncements.current
+        let sorted = entries.sorted { a, b in
+            priorityRank(a.priority) < priorityRank(b.priority)
+        }
+
+        var sawInfo = false
+        for entry in sorted {
+            if entry.priority == .info {
+                sawInfo = true
+            } else if entry.priority == .critical && sawInfo {
+                XCTFail("Critical announcement '\(entry.title)' followed an info entry")
+            }
+        }
+    }
+
+    /// `LeagueAnnouncements.current` ships at least 2 entries — the
+    /// draft date and the season start — per plan v1 scope.
+    func testLeagueAnnouncements_hasAtLeastTwoEntries() {
+        XCTAssertGreaterThanOrEqual(
+            LeagueAnnouncements.current.count,
+            2,
+            "v1 plan calls for 2-3 hardcoded announcements"
+        )
+    }
+
+    // MARK: - Smoke: LandingView constructs
+
+    /// Smoke test: the view initializes with stub stores without
+    /// trapping. Doesn't render — that requires a host — but catches
+    /// init-time crashes from missing optional unwraps.
+    func testLandingView_constructsWithStubStores() {
+        let _ = LandingView(
+            leagueStore: LeagueStore(),
+            authStore: AuthStore(),
+            nflStateStore: NflStateStore(),
+            aiReviewStore: AIReviewStore(),
+            navStore: NavigationStore(),
+            router: AppRouter()
+        )
+        // Nothing thrown — that's the contract.
+    }
+
+    // MARK: - Helpers
+
+    private func priorityRank(_ priority: LeagueAnnouncement.Priority) -> Int {
+        switch priority {
+        case .critical: 0
+        case .info:     1
+        }
+    }
+}

--- a/docs/features/season-refocus/BRAINSTORM.md
+++ b/docs/features/season-refocus/BRAINSTORM.md
@@ -1,0 +1,360 @@
+# Brainstorm: Season Refocus + Landing Page
+
+**Status**: Draft
+**Created**: 2026-05-21
+**Scope**: One combined epic covering (a) UI/UX restructure to face forward into the 2026 season, and (b) a new Landing Page surfacing AI Reviews as headline news.
+**Related epic**: `docs/features/ai-review/` (F0/F1/F2/F3 shipping this session)
+**Backfill assumption**: 2024 + 2025 AI reports will be populated into the archive in parallel — treat the archive as eventually-full.
+
+---
+
+## Problem Statement
+
+It's offseason May 2026. Draft is July 6 2026; season starts Sept 2026. The app still looks mid-2025:
+
+- Standings tab proudly displays 2025 final standings (stale and demoralizing on cold open).
+- Draft History is the only "draft" surface — it conflates last year's data with the upcoming draft.
+- The Reverse-HPP rule idea ("Draft Order Proposal") sits in the League nav section as if it were a committed thing, when it's just a proposal.
+- The Live + Mocks + Proposal sub-tabs live on the Draft Order screen, not where users would intuitively look (the Draft tab).
+- AI Reviews — the big new content investment landing this session — are surfaced via a single banner card embedded in SearchView. They deserve top billing, not an ambient drop-zone above a search box.
+- The app has no concept of a "landing page" / news surface — it opens onto Standings, which after Sept 2026 will be inert in May.
+
+The user wants the app to feel like *"what's coming next"* not *"what just happened,"* and AI Reviews to be the central new artifact users come back for.
+
+---
+
+## Phase 1 — Explore (raw idea pool)
+
+Loose dump of angles before converging:
+
+- Make Landing Page the new default destination; relegate Standings to a deeper tray entry.
+- Use the AI Review home card as the heart of the Landing Page — full-bleed hero treatment, not a 60pt strip.
+- Year-pill picker at the top of a unified Draft tab (2026 | 2025 | 2024 | ...) with sub-tabs that vary per year.
+- Draft tab = "this year's draft is the live one; older years are post-mortems."
+- Demote Draft Order Proposal into a new "Ideas" or "Proposals" subsection nested under League with the rule proposals it actually relates to.
+- Rename Draft Order Proposal to something honest: "Reverse-HPP Proposal" or "Rule Idea: Draft Order".
+- Add a "History" / "Archive" tray section at the bottom that holds all stale-after-this-year surfaces: prior Standings, prior Matchup History, prior Drafts (linked-in).
+- Standings becomes a live-only widget — empty state in offseason ("Season starts Sept 8 — see you then"); historical standings auto-shunt to Archive.
+- Or: Standings keeps a season picker like Draft does, so the same surface shows live or historical based on chip.
+- Pluck the AI Review home card out of SearchView entirely — Search reverts to pure search.
+- Landing Page composed of "stripes" — each stripe is a different surface (announcements, latest AI report, scoreboard, standings tickertape, news).
+- Landing Page as a vertical scroll feed (Instagram-style) of mixed card types ordered by recency.
+- Hardcoded announcements via a Swift constant `LeagueAnnouncements.current` in v1; defer admin-driven announcements to v2.
+- Pull league announcements from existing `xomper_announcements` table if one exists (it doesn't — would need infra).
+- Use the existing Sleeper trending API for "News" (most adds/drops this week).
+- Skip news entirely v1 — not enough signal in offseason.
+- Scrolling horizontal standings strip = small commitment, big "league heartbeat" feel.
+- Countdown card: "67 days until draft" / "112 days until Week 1" — cheap and high-value during offseason.
+- Phase the rollout: demote + rename first (low-risk), then build Landing Page MVP, then restructure Draft, then wipe Standings + create Archive.
+- One big bang PR — would touch every nav touchpoint and need full QA pass; risky but cohesive.
+- Per-year Draft sub-tab structure: "Live" (upcoming-draft view, this year only), "Picks" (rounds + board, the existing view), "Mocks" (this year only), "Recap" (AI post-draft report, any year that has one).
+- Could fold Mocks into Live (one screen with a "this is mocked from BPA" pill) — but user explicitly named Mocks as a sub-tab, leave it.
+- Past-year Draft sub-tabs: just "Picks" + "Recap" (no Live, no Mocks).
+- Year selector implementations: dropdown menu, horizontal pill scroller, segmented control, or "season chip" matching the existing SeasonStore pattern (HeaderBar already has a season picker — could reuse it).
+- Reusing the existing SeasonStore season chip in HeaderBar is the cleanest — fewer year selectors on screen.
+- "Recap" tab for past years requires the backfilled AI reports to actually exist; if backfill is incomplete, render empty state per year ("No recap generated for 2024 draft yet").
+- Landing Page card priority order needs spelling out — what's at the top changes through the calendar year. Offseason: AI report + countdown. Preseason: AI report + draft countdown + mocks. In-season: This week's matchup + last week's weekly recap + standings stripe. Playoffs: bracket card. Could be dynamic and time-aware.
+- Single Card prioritization function that takes a date + report set and returns ordered card list — extracted into something testable.
+- Reconciling the existing `AIReviewHomeCard` inside `SearchView`: kill it there once Landing Page exists, since Search is no longer the cold-open home.
+- Cold-open performance: Landing Page composes ~5 cards each with their own data dependency — need to make sure they degrade gracefully (each card loads independently, shows skeleton + own retry).
+- Empty state for landing page during offseason when no AI report has run yet: hero card becomes "Stay tuned — first report after the July 6 draft."
+- Should Landing Page have a refresh control? Yes — pull-to-refresh re-fetches all stripes in parallel.
+- "Things to check out" copy from the user — could be a hand-picked "you might want to see" card that rotates through Team Analyzer, Trade Analyzer, Rule Proposals, etc. Like a feature spotlight.
+- Onboarding-ish: surface unread rule proposals as a CTA card ("3 open proposals — vote by Sat").
+- Tray reordering: move Standings out of the top "Compete" section once it's gutted; replace it with the new Landing Page entry. Or keep Standings up top but make it offseason-aware (renders countdown when no live data).
+- New section in tray: "League HQ" containing Landing Page, Announcements; "Compete" reserved for in-season live surfaces (Matchups, Standings, Playoffs).
+
+---
+
+## Phase 2 — Converge (per-question options)
+
+### Q1 — Draft tab restructure
+
+**Current**: `TrayDestination.draftHistory` → "Draft History", renders `DraftHistoryView` which already auto-switches into an "upcoming draft" mode when the selected season chip equals `nflStateStore.currentSeason` and no picks have been ingested yet. The Live / Mocks / Proposal sub-tabs live on a *separate* tray entry (`.draftOrder` → "Draft Order Proposal" → `DraftOrderView`).
+
+**Target**: Rename to "Draft". Per-year experience. This year = Live + Mocks + Recap. Past years = Picks + Recap.
+
+#### Option A — Reuse HeaderBar SeasonStore chip + dynamic sub-tabs
+Rename `.draftHistory` → `.draft`. Keep using the existing season chip in `HeaderBar` (already powered by `SeasonStore` and bound to many feature views). When the selected season equals `nflStateStore.currentSeason`, render sub-tabs `[Live, Mocks, Recap]`; otherwise render `[Picks, Recap]`. The `DraftOrderView` proposal mode moves out entirely (see Q2).
+
+- Pros: Reuses existing season picker — no new chrome. Consistent with how Matchup History etc. already work. Low net new UI.
+- Cons: HeaderBar chip is global — selecting "2024" for Draft will also drift other views looking at the same store. (Already true today; not a regression.)
+- Best if: We want minimum new navigation surface and tight integration with the existing season state.
+
+#### Option B — In-tab year pill scroller + sub-tabs
+Replace the global chip dependency in the Draft tab with a Draft-local horizontal pill scroller (`2026 | 2025 | 2024 | 2023 | ...`). Sub-tabs change per year as above. Keeps the season chip in HeaderBar for other views unaffected.
+
+- Pros: Draft tab feels self-contained — moving inside Draft doesn't side-effect other tray destinations.
+- Cons: Two season selectors visible at once (HeaderBar chip + Draft pill scroller) is confusing. Net new component to build + maintain.
+- Best if: We discover that the global SeasonStore chip is causing too many cross-view side effects.
+
+#### Option C — Year as primary nav (collapsible accordion of all years)
+One long scrolling page: 2026 expanded by default at top, prior years collapsed below. Each year has its own embedded sub-tabs.
+
+- Pros: Everything in one place — no picker UI at all.
+- Cons: Heavy scrolling. Sub-tabs nested inside each year section are noisy. Mock list could be very long. Less discoverable than chips.
+- Best if: Years are very few (≤3) and content per year is short.
+
+### Q2 — Draft Order Proposal (Reverse-HPP) demotion
+
+**Current**: `.draftOrder` lives in the "League" section right next to Payouts, AI Review, Rulebook etc. — looks like an established feature.
+
+**Target**: Demote and re-frame as a rule idea, not a fact.
+
+#### Option A — Move into Rule Proposals as a sub-page
+`DraftOrderView` becomes a linked sub-page of `RulesView(page: .ruleProposals)`. The dedicated tray entry disappears. Live / Mocks / Recap sub-tabs absorb into the new Draft tab; Proposal sub-tab becomes its own linked screen inside Rule Proposals.
+
+- Pros: Cleanest IA — proposals live with proposals. Frees a tray slot. Strongest signal that this is "just an idea."
+- Cons: Buries it more than just "down the sidebar." Requires `RulesView` work to add a sub-page anchor.
+- Best if: We want the strongest demotion + tight conceptual grouping.
+
+#### Option B — Rename + sink to bottom of League section
+Rename `.draftOrder` → "Reverse-HPP (Idea)" or "Draft Order Idea". Keep it in the tray but move it to the bottom of the League section (after `.ruleProposals`).
+
+- Pros: Cheap. Still discoverable. Doesn't require restructuring Rule Proposals page.
+- Cons: Still pretends to be a top-level destination.
+- Best if: We don't want to touch `RulesView` in this epic.
+
+#### Option C — Kill the tray entry entirely; only reachable from Rule Proposals
+Same as A but no soft landing — `DraftOrderView` only reachable by tapping the corresponding Rule Proposal card.
+
+- Pros: Maximum demotion.
+- Cons: User said "move further down the sidebar" not "remove from sidebar." Risks under-shooting their intent.
+- Best if: We confirm with the user that out-of-sidebar is acceptable.
+
+### Q3 — Standings wipe
+
+**Current**: `StandingsView` builds standings from `myLeagueRosters` + `myLeagueUsers`. Whenever the league is live (in-season), it shows live records; in offseason it shows the *final* records from the previous season (which is exactly the staleness the user is calling out).
+
+**Target**: "Standings needs to be wiped. Historical data on seasons past is shown somewhere in app."
+
+#### Option A — Standings = live-only with offseason empty state
+`StandingsView` checks `nflStateStore.season` vs `leagueStore.myLeague.season` and renders an offseason empty state when there are no live records. Historical standings move to an Archive tray entry (see Q6).
+
+- Pros: Standings stays in the same tray slot for in-season muscle memory. Offseason state can be informative (countdown + "Season starts...").
+- Cons: Need infra to detect "is there live data yet" — Sleeper rosters carry last season's W-L until Week 1 rolls over, so this isn't trivial.
+- Best if: We want one canonical "Standings" surface that's offseason-smart.
+
+#### Option B — Delete Standings outright; replace with offseason-aware tile on Landing Page
+Remove `.standings` from the tray. Landing Page shows a "Standings Tickertape" stripe in-season; absent in offseason. Historical Standings live in Archive.
+
+- Pros: Forces the user to the new front door (Landing Page) for league pulse. Tray gets simpler.
+- Cons: In-season users will hunt for the dedicated screen. Lose the full-screen detail view.
+- Best if: We're confident the Landing Page tickertape + drilling into team detail covers everyone's needs.
+
+#### Option C — Keep Standings but auto-route to History when offseason
+`.standings` tray entry stays, but tapping it during offseason renders the *latest-season-with-completed-data* view (essentially the Archive view inline). Once Week 1 ships, it auto-rolls over to live.
+
+- Pros: Single entry point. No "missing screen" feeling.
+- Cons: Confusing — same tray label, different behavior. Hides the "wipe."
+- Best if: We don't want to give up tray real estate.
+
+### Q4 — Landing Page composition
+
+**Target**: "Quick league hitters. Announcements, weekly reports, things to check out. Voting CTAs. Standings tickertape. News. Scores."
+
+#### Option A — Static stripe order
+Vertical scroll of cards in a fixed order:
+1. **AI Report Hero** — full-bleed card for the most recent post-draft / preseason / weekly report (the right one bubbles up by recency).
+2. **Announcements** — hardcoded constants for v1 (`LeagueAnnouncements.current`), 1-3 short cards with optional CTA (link to a rule proposal, payment reminder, draft date).
+3. **Countdown** — days until draft / Week 1 / playoffs.
+4. **Standings Tickertape** — horizontal scroll, only in-season.
+5. **This Week's Matchups** — horizontal scroll of cards, only in-season.
+6. **Spotlight** — "Try out: Team Analyzer" rotating CTA into another feature.
+7. **AI Report Archive teaser** — "Read past reports →" linking to `.aiReview`.
+
+- Pros: Predictable layout, easy to QA, easy to grow.
+- Cons: Off-season Landing Page is sparse if there's nothing live (just AI hero + countdown + spotlight).
+
+#### Option B — Time-aware ordering function
+Same stripes as A but ordered by a `LandingCardPriority` function that takes today's date + league state and reorders. Offseason: AI report + countdown + spotlight up top. Preseason: AI report + mocks + draft countdown. In-season: matchups + AI weekly recap + standings + report archive. Playoffs: bracket card.
+
+- Pros: Always feels relevant. Encodes the "what's coming next" mission directly.
+- Cons: More complex; testing/QA matrix grows; needs the priority function itself to be testable.
+
+#### Option C — Single hero + linear archive list
+Hero = latest AI report. Below it, a flat newest-first list of past reports + announcement cards interleaved by date. Standings/matchups deferred entirely; users open the dedicated tabs.
+
+- Pros: Cleanest implementation. Closest to the existing `AIReviewView` archive — could be a fast iteration.
+- Cons: Loses the "league heartbeat" feeling the user described (no tickertape, no scores).
+
+### Q5 — New default landing destination
+
+**Current**: `NavigationStore.currentDestination = .standings` is the cold-open default (per `NavigationStore.swift` line 22).
+
+#### Option A — New `.landing` becomes the default
+Add `case landing` to `TrayDestination`. Set `currentDestination = .landing` by default. Map it to a new `LandingView`. Pin it at the top of the tray (above "Compete" section, or as its own pinned section).
+
+- Pros: Honors the user's intent that AI reviews are headline news. The first thing users see is the new front door.
+- Cons: Wholesale change to first-load behavior — heavy QA touch point.
+- Best if: This is the right answer; user explicitly described it as "front page news."
+
+#### Option B — Make Landing reachable only via tray, keep Standings as default
+Add `.landing` but don't change the default. Users navigate to it explicitly.
+
+- Pros: Lowest blast radius.
+- Cons: Defeats the entire purpose. Reject.
+
+### Q6 — Historical data archival
+
+#### Option A — New `.archive` (or `.history`) tray section at bottom
+Add a new tray destination(s) that aggregate stale-after-this-year content:
+- Prior-season Standings (year-pick → renders historical `StandingsView`).
+- Prior-season Drafts (already covered by the new Draft tab's year picker — link out from Archive into Draft tab pre-selected on a year).
+- Prior-season Matchup History (already exists as `.matchupHistory`).
+- Past AI Reports archive (already exists as `.aiReview`).
+
+Could be a single "Archive" tray entry that opens a hub view, or a new "Archive" *section* at the bottom of the drawer with multiple entries.
+
+- Pros: Centralizes "stale stuff" under one roof, reduces clutter in the active sections.
+- Cons: Requires net-new "Archive" view if we go with a hub model. If just a section, it's mostly relabeling existing entries.
+
+#### Option B — Each historical surface stays where it is; Standings flips to live-only
+No new Archive. `.matchupHistory` stays in History section, `.aiReview` stays in League, Standings becomes offseason-aware. Past drafts live inside the new Draft tab year picker.
+
+- Pros: Minimum tray churn.
+- Cons: User's wording ("historical data on seasons pasts is shown somewhere in app") suggests they want it grouped, not scattered.
+
+### Q7 — Implementation strategy
+
+#### Option A — Phased sub-features under one epic (orchestrate-friendly)
+Split into 4 ordered phases:
+1. **F1 — Demote + rename**: Rename `draftHistory` → `draft`, demote `.draftOrder`. Pure cosmetic + tray surgery. (~S)
+2. **F2 — Landing Page MVP**: New `.landing` destination + LandingView + cards. Reconcile/remove `AIReviewHomeCard` from `SearchView`. Set default destination. (~M-L)
+3. **F3 — Draft tab restructure**: Per-year sub-tabs (Live/Mocks/Recap for current, Picks/Recap for past). Wire AI report into Recap tab. (~M)
+4. **F4 — Standings wipe + Archive**: Offseason-aware Standings, new Archive tray entry/section, historical drilldowns. (~M)
+
+- Pros: Each phase ships independently; we can pause / revisit after F1 with the user. Matches the `/orchestrate` pattern. Easier QA at each step.
+- Cons: Multi-week elapsed time; partial states (e.g., post-F1, post-F2 but pre-F3) might feel incomplete.
+
+#### Option B — Big bang single PR
+One PR that rewrites nav + adds Landing + restructures Draft + wipes Standings.
+
+- Pros: One coherent change. No "weird intermediate state."
+- Cons: Massive QA surface. Hard to bisect regressions. Hard to review. Hard to roll back partial wins.
+
+### Q8 — Backfill content surface
+
+Once 2024+2025 reports are populated:
+
+#### Option A — Recap sub-tab in Draft tab per year + Archive in tray
+Each year's Draft tab Recap sub-tab queries the AI archive for `type=postDraft AND season=<year>`. Weekly reports for past years live in `.aiReview` (already paginated, already capable). Preseason reports surface the same way.
+
+- Pros: Reuses already-shipping infra. No new endpoints.
+- Cons: Past-year Weekly Report surfacing is "scroll the archive" which is fine but not a dedicated per-year view.
+
+#### Option B — Per-year report hub in Archive
+New view in the Archive section that groups all reports by season. "2024 Reports → [Post-Draft] [Preseason] [Week 1] [Week 2]...". Landing within Draft tab still pulls in the post-draft recap.
+
+- Pros: Per-year browse is nice for retrospection.
+- Cons: Net-new view; AI archive already does newest-first; this is a power-user surface.
+
+---
+
+## Phase 3 — Recommendation (winners per question)
+
+| Q | Pick | Why |
+|---|------|-----|
+| Q1 — Draft restructure | **Option A** — Reuse HeaderBar season chip + dynamic sub-tabs | Lowest new chrome; consistent with existing season-aware screens. Already-implemented "upcoming draft" mode in `DraftHistoryView` becomes the Live sub-tab basically free. |
+| Q2 — Proposal demote | **Option A** — Fold into Rule Proposals | User said "it's just an idea we are thinking of" — that's literally what Rule Proposals is for. Strongest demotion + clean IA. |
+| Q3 — Standings wipe | **Option A** — Live-only with offseason empty state | Keeps muscle memory for the in-season slot, but stops lying in May. Offseason empty state = countdown card. Historical drilldowns live in Archive. |
+| Q4 — Landing composition | **Option B** — Time-aware ordering | Matches user's "what's coming next" intent — landing changes through the year. Worth the extra complexity. Implement the priority function with a unit test for each calendar phase. |
+| Q5 — Default destination | **Option A** — `.landing` becomes default | Non-negotiable per user's "front page news" framing. |
+| Q6 — Archive | **Option A** — New Archive section in tray | Groups stale-after-this-year content. Pin at the bottom. Two entries to start: Archive → Past Standings (by year) and Archive → Past Reports (link to `.aiReview`). Past drafts reachable inside Draft tab itself, no Archive entry needed. |
+| Q7 — Strategy | **Option A** — Phased sub-features | Orchestrate-friendly. Phase 1 ships in a day, immediate UX win. Each subsequent phase is independently reviewable. |
+| Q8 — Backfill surface | **Option A** — Recap tab in Draft + existing archive | Reuses shipping infra. No new endpoints. |
+
+**One-line summary of the recommended path**: Phased epic — rename + demote first, then build a time-aware Landing Page that becomes the default, then restructure Draft tab around the HeaderBar season chip, then wipe Standings and add an Archive section.
+
+---
+
+## Phasing Recommendation for `/orchestrate`
+
+Four sub-features, sequenced strictly. Each gets its own `/plan` pass before `/execute`.
+
+```
+F1 — Tray Surgery: Rename + Demote          docs/features/season-refocus/f1-tray-surgery/PLAN.md
+  │  rename .draftHistory → .draft, fold .draftOrder into Rule Proposals, demote out of League section
+  │  Effort: S. Pure SwiftUI relabeling + enum case rename + RulesView sub-page anchor.
+  ▼
+F2 — Landing Page MVP                       docs/features/season-refocus/f2-landing/PLAN.md
+  │  new .landing TrayDestination + LandingView, time-aware card priority,
+  │  remove AIReviewHomeCard injection from SearchView,
+  │  set default destination to .landing
+  │  Effort: M-L. New top-level view + several card components + priority logic.
+  ▼
+F3 — Draft Tab Restructure                  docs/features/season-refocus/f3-draft-tab/PLAN.md
+  │  per-year sub-tabs (Live/Mocks/Recap | Picks/Recap), reuse SeasonStore,
+  │  wire AI post-draft report into Recap, port DraftOrderView's live/mocks
+  │  modes into sub-tabs of Draft
+  │  Effort: M. Mostly refactor + new sub-tab control + recap wiring.
+  ▼
+F4 — Standings Wipe + Archive Section       docs/features/season-refocus/f4-standings-archive/PLAN.md
+     offseason-aware StandingsView, new Archive tray section,
+     historical Standings drilldown
+     Effort: M. New tray section + per-year standings view.
+```
+
+F2 unblocks the user-visible win (Landing Page is the headline change). F1 ships first because it's the lowest-risk groundwork that won't bite us during F2/F3.
+
+---
+
+## Epic-Level Risks
+
+- **Wholesale nav restructure means everywhere has regression potential**: deep-link routes, drawer state, default destination, edge-swipe gesture all touch the same surface. Mitigate with phased rollout (F1 first, then halt and QA before F2).
+- **`AIReviewHomeCard` reconciliation**: F0 of the ai-review epic placed this card inside `SearchView`. F2 of this epic needs to remove it and migrate the visual treatment to the Landing Page hero card. Coordinate timing so we don't end up with the card in *both* places or *neither*.
+- **`NavigationStore.currentDestination = .standings` is the cold-open default**: changing this is high blast radius. Make sure F2 ships with the new default and a fallback path if the Landing view crashes (don't trap users on a broken landing surface).
+- **Backfill timing**: F3's Draft Recap sub-tab depends on backfilled 2024+2025 AI reports existing. If backfill hasn't landed when F3 ships, the past-year Recap tabs will show empty states. Plan for empty-state copy that doesn't look like a bug.
+- **User may dislike new home layout**: this is a wholesale UX rethink. Recommend asking the user to walk through the F2 mockup *before* `/execute` runs.
+- **Time-aware priority function is testable but date-dependent**: unit tests need to inject `Date` rather than read `Date()`. Easy to get wrong on first pass. Build it with explicit injection from day one.
+- **HeaderBar season chip side-effects**: switching the chip to a past year in Draft will change other views' selected season too. Already true today, but the Draft restructure makes this more visible. Consider whether F3 needs a Draft-local season picker (Q1 Option B) instead — open question for `/plan`.
+- **Tray real estate**: tray is already 17 entries deep (per `TrayDestination`). Adding `.landing` + `.archive` brings it past 19. Consider whether some current entries fold together (e.g., is `.worldCup` worth a top-level slot or could it move into Archive?).
+
+---
+
+## Open Questions for `/plan`
+
+These need user confirmation or `/plan`-level decisions:
+
+1. **Exact tray ordering after this epic**: where does `.landing` pin (top section called "Home"? new "League HQ" section?)? Where does Archive section live (bottom of tray, above or below Settings footer)?
+2. **Landing Page exact card priority order per calendar phase** — need a concrete spec for what shows in each window (offseason / preseason / in-season / playoffs / post-season). User mentioned scores, announcements, weekly reports, standings, news; rank them in each phase.
+3. **Announcements model**: hardcoded constants for v1 confirmed in our recommendation — but who maintains them? Commit to repo + ship updates via app store? Or punt to v2 with admin-managed table?
+4. **News stripe**: confirm with user — pull from Sleeper trending API (waiver activity), skip entirely v1, or hardcode an "NFL news" RSS source?
+5. **Scores card**: this week's matchups inline on Landing, or just a deep link to `.matchups`?
+6. **Draft tab sub-tab naming**: "Live" / "Picks" / "Mocks" / "Recap" — confirm exact wording. Past years would have "Picks" (the existing rounds/board view) and "Recap" (AI report).
+7. **DraftOrder Proposal sub-page location**: which page inside `RulesView` does it nest under — `.ruleProposals`? Or its own anchor inside that page?
+8. **Standings offseason copy**: what exactly does the empty state say? Countdown component? "Season starts Sept 8" hardcoded date?
+9. **Archive entry shape**: single `.archive` hub OR multi-entry section ("Past Standings", "Past Drafts", "All AI Reports")?
+10. **Cold-open destination override**: should we honor a stored "last visited" destination on next launch, or always cold-open to `.landing`? (Currently `NavigationStore` doesn't persist; this is a freebie if we want it.)
+11. **`AIReviewHomeCard` removal timing in F2**: does it stay in SearchView until F2 ships and then both move together? Or do we strip it from SearchView in F1 and leave Search bare for a phase?
+12. **Header season chip vs. Draft-local picker** — Q1 picked Option A (reuse HeaderBar chip) but `/plan` should sanity-check whether cross-view side effects bite us in practice.
+13. **Per-year season list in Draft tab** — does it match `SeasonStore.availableSeasons` exactly, or do we filter (e.g., only years with completed drafts + this year)?
+
+---
+
+## Files Touched (preview for `/plan`)
+
+The phases below will touch (at least) these:
+
+- `Xomper/Features/Shell/TrayDestination.swift` (add `.landing`, `.archive`; rename `.draftHistory` → `.draft`; remove `.draftOrder`)
+- `Xomper/Features/Shell/DrawerView.swift` (sections rebuild)
+- `Xomper/Features/Shell/NavigationStore.swift` (default destination flip)
+- `Xomper/Features/Shell/MainShell.swift` (new `destinationRoot` cases)
+- `Xomper/Features/DraftHistory/DraftHistoryView.swift` (becomes the new Draft tab with sub-tab control)
+- `Xomper/Features/DraftOrder/DraftOrderView.swift` (sub-tabs split: Live/Mocks move into Draft tab, Proposal mode becomes sub-page of `RulesView`)
+- `Xomper/Features/Home/SearchView.swift` (remove `AIReviewHomeCard` injection)
+- `Xomper/Features/AIReview/AIReviewHomeCard.swift` (repurpose as the Landing Page hero or fork into a `LandingAIReportHero`)
+- `Xomper/Features/League/StandingsView.swift` (offseason-aware empty state)
+- **NEW**: `Xomper/Features/Landing/LandingView.swift` + landing card components + `LandingCardPriority.swift`
+- **NEW**: `Xomper/Features/Archive/ArchiveView.swift` (or section-level wiring only)
+- **NEW**: `Xomper/Core/Config/LeagueAnnouncements.swift` (hardcoded constants for v1)
+
+---
+
+## Out of Scope (explicit non-goals)
+
+- Backfilling 2024 + 2025 AI reports — running in parallel as separate work.
+- Building an admin UI to edit announcements — v2 if dynamic announcements prove worth it.
+- News stripe pulling from external feeds — defer until we know it's wanted.
+- Push notifications for new Landing Page cards — separate concern.
+- Light mode anything — app remains dark-only.

--- a/docs/features/season-refocus/EPIC_PLAN.md
+++ b/docs/features/season-refocus/EPIC_PLAN.md
@@ -1,0 +1,209 @@
+# Epic Plan: Season Refocus + Landing Page
+
+**Status**: Ready
+**Created**: 2026-05-21
+**Last updated**: 2026-05-21
+**Brainstorm**: `docs/features/season-refocus/BRAINSTORM.md`
+**Related epic**: `docs/features/ai-review/` (F0/F1/F2/F3 shipping in parallel)
+
+---
+
+## Orchestration
+
+Strict sequential — F1 → F2 → F3 → F4. Each sub-feature gets its own `/plan` pass before `/execute`.
+
+```
+F1 (Tray Surgery, S)
+  │  docs/features/season-refocus/f1-tray-surgery/PLAN.md
+  ▼
+F2 (Landing Page MVP, M-L)
+  │  docs/features/season-refocus/f2-landing/PLAN.md
+  ▼
+F3 (Draft Tab Restructure, M)
+  │  docs/features/season-refocus/f3-draft-tab/PLAN.md
+  ▼
+F4 (Standings Wipe + Archive, M)
+     docs/features/season-refocus/f4-standings-archive/PLAN.md
+```
+
+All 4 sub-feature stubs are `Status: Draft`. Run `/plan f<n>-<name>` against each in order to flesh out scope, architecture, file-by-file steps, and test plan, then flip to `Ready` before `/execute`.
+
+---
+
+## Summary
+
+It's offseason May 2026. The app still looks like mid-2025 — Standings shows stale final records, Draft History conflates last year with the upcoming July 6 draft, Reverse-HPP sits in League nav as if it were a committed feature, and AI Reviews (the big new content investment) get a 60pt strip above the search box.
+
+This epic refocuses the app forward into the 2026 season: a new Landing Page becomes the default destination with AI Reviews as headline news, the Draft tab gets per-year sub-tabs, Standings goes live-only with an offseason countdown, and historical content moves into a new Archive section. Success = on cold open, the app feels like *what's coming next* rather than *what just happened*.
+
+---
+
+## Approach
+
+Phased sub-features under one epic — orchestrate-friendly. Four sub-features, sequenced strictly smallest-first. Each gets its own `/plan` pass before `/execute`. F1 ships in a day to clear tray clutter, F2 delivers the headline UX win, F3 restructures Draft once Landing exists to reference it, F4 wipes Standings and adds Archive last (depends on focus already having shifted away from Standings via F2).
+
+User picks from this session (locked, not relitigated):
+
+- Single combined epic (Season Refocus + Landing Page together).
+- Landing Page = new default destination, headline AI report card.
+- Standings = wipe / live-only with offseason empty state.
+- Draft History → renamed "Draft", per-year sub-tabs with Live/Mocks (this year only) + Recap (all years).
+- Draft Order Proposal demoted to **bottom of League section** (lighter option) — NOT folded into Rule Proposals, NOT hidden in Rulebook.
+- 2024 + 2025 AI report backfill is in flight separately — treat archive as eventually-full.
+
+---
+
+## Sub-Feature Breakdown
+
+### F1 — Tray Surgery (S)
+
+**Path**: `docs/features/season-refocus/f1-tray-surgery/`
+**Effort**: S (1-file PR, mostly label + ordering tweaks)
+**Blast radius**: Minimal
+
+Scope:
+- Relabel the existing `.draftHistory` tray destination to "Draft" (enum case stays as `.draftHistory` for backward-compat — only the user-facing label changes).
+- Reorder `.draftOrder` to the bottom of the League section in `DrawerView.swift`.
+- "Draft Order Proposal" remains the screen title on `DraftOrderView` — it's an honest description of what the screen is.
+
+Out of scope for F1: any change to `DraftHistoryView` or `DraftOrderView` internals. This is pure tray/label surgery.
+
+### F2 — Landing Page MVP (M-L)
+
+**Path**: `docs/features/season-refocus/f2-landing/`
+**Effort**: M-L (new top-level view, several card components, default destination flip)
+**Blast radius**: High — first-load behavior changes for all users
+
+Scope:
+- Add `TrayDestination.landing` case.
+- New `Xomper/Features/Landing/LandingView.swift` composing cards:
+  - Headline AI Review card (latest report across all types; tap → detail).
+  - Announcements card (hardcoded `LeagueAnnouncements.current` for v1).
+  - Scrolling standings bar (horizontal scroll, empty-state copy in offseason).
+  - This-week matchups card (scoreboard-style during games, empty when offseason).
+- Flip `NavigationStore.swift:22` default `currentDestination` from `.standings` → `.landing`.
+- Remove `AIReviewHomeCard` injection from `SearchView` (it now lives on Landing as the hero).
+- Add a "Home" tray slot pointing at `.landing` at the top of the tray.
+
+Out of scope for F2: time-aware card priority function (defer to v2 if needed; v1 ships with static order locked at `/plan` time), news stripe, scores deep-link work, spotlight rotator.
+
+### F3 — Draft Tab Restructure (M)
+
+**Path**: `docs/features/season-refocus/f3-draft-tab/`
+**Effort**: M (refactor + sub-tab control + recap wiring)
+**Blast radius**: Medium — touches existing Draft surfaces
+
+Scope:
+- Reuse existing `HeaderBar` season chip + `SeasonStore` for year switching (no new picker chrome).
+- When viewing 2026 (current season): show 3 sub-tabs — **Live order**, **Mocks**, **Recap** (Recap loads AIReport `type=postDraft` for that year).
+- When viewing past year (2024, 2025): show 2 sub-tabs — **Picks**, **Recap**.
+- Move `DraftOrderView`'s `.mocks` content into the Mocks sub-tab.
+- Move `DraftOrderView`'s `.live` content into the Live sub-tab.
+- After this refactor, `DraftOrderView` only renders the reverse-HPP Proposal — single view, no internal tabs.
+
+Out of scope for F3: building per-year picker chips (reusing HeaderBar chip is the call), backfilling reports.
+
+### F4 — Standings Wipe + Archive (M)
+
+**Path**: `docs/features/season-refocus/f4-standings-archive/`
+**Effort**: M (offseason-aware Standings + new Archive section)
+**Blast radius**: Medium — historical drilldowns move to a new home
+
+Scope:
+- `StandingsView` becomes live-only — shows current-season standings during regular season; otherwise renders an **offseason countdown** empty state with hardcoded dates: **July 6 6:30pm ET (draft)** and **Sept 8 (Week 1)**.
+- New `TrayDestination.archive` at the bottom of the tray, housing sub-sections:
+  - Past standings (per year).
+  - Past matchup history (link to existing `.matchupHistory`).
+  - Past drafts (link into per-year Draft tab from F3).
+- Use `nflStateStore` to detect "is there live data yet" for the offseason switch.
+
+Out of scope for F4: rewriting `MatchupHistory` (it's already per-season and works); admin-driven announcement infra.
+
+---
+
+## Cross-Cutting Work
+
+- **`AIReviewHomeCard` migration**: currently injected into `SearchView` (from ai-review F0). F2 must remove it from SearchView cleanly. Coordinate timing — F2's `/plan` should explicitly list the `SearchView.swift` diff.
+- **`MatchupHistory` view stays as-is** — already per-season, F4 just links into it from Archive.
+- **`HistoryStore` season chain** — F3 reuses it for the per-year selector; no new store work needed.
+- **`nflStateStore`** — F2 (matchup empty state) and F4 (Standings offseason switch) both depend on it.
+
+---
+
+## Sequencing
+
+Strict sequential. Each sub-feature gets its own `/plan` → `/execute` → review before the next starts.
+
+```
+F1 (Tray Surgery, S)
+  │  ships first — clears tray clutter, zero risk
+  ▼
+F2 (Landing Page MVP, M-L)
+  │  biggest user-visible change; default destination flips
+  ▼
+F3 (Draft Tab Restructure, M)
+  │  Landing card from F2 deep-links into this surface
+  ▼
+F4 (Standings Wipe + Archive, M)
+     last — needs F2 to have moved focus away from Standings
+```
+
+Rationale: F1 is 1-file groundwork. F2 delivers the headline win. F3 reorganizes Draft once Landing references it. F4 is safe to land last because by then Standings is no longer the cold-open default.
+
+---
+
+## Risks / Tradeoffs
+
+- **Default destination flip**: existing users open the app and see a new home screen. Mitigate by ensuring Landing renders gracefully with empty AI report archive (backfill is the contingency).
+- **`AIReviewHomeCard` migration**: F0 wired it into SearchView; F2 must remove it cleanly. Mitigate by F2's `/plan` explicitly listing the file diff before `/execute`.
+- **Per-year Draft tabs**: 2024 + 2025 historical drafts need data sources. Mitigate by reusing existing `HistoryStore` season chain — no new store work.
+- **Standings empty state**: offseason countdown depends on knowing NFL state. Mitigate by reading `nflStateStore` which already tracks this.
+- **HeaderBar season chip side-effects**: switching chip to a past year in Draft changes other views' selected season too. Already true today; not a regression — but F3 `/plan` should sanity-check.
+- **Tray real estate**: adding `.landing` + `.archive` pushes tray past 19 entries. F1 + F4 `/plan`s should each audit whether anything folds.
+
+---
+
+## Acceptance Criteria
+
+- App opens to Landing Page by default.
+- Landing Page surfaces latest AI Review as a tappable card (deep-links to detail).
+- Draft tab (renamed label) has per-year selection; current year shows Live / Mocks / Recap; past years show Picks / Recap.
+- Draft Order Proposal still accessible but at the bottom of the League section.
+- Standings shows an offseason countdown empty state when out of season (July 6 draft + Sept 8 Week 1 dates).
+- New Archive tray destination at the bottom of the tray houses historical data.
+- No regressions in existing features (Trade Analyzer, Admin, Team Analyzer, World Cup, Taxi, etc.).
+- All `XomperTests` pass; build green; manual QA across all nav destinations.
+
+---
+
+## Open Questions for Sub-Feature Plans
+
+(Each gets resolved at the corresponding sub-feature's `/plan` time, not at epic time.)
+
+- [ ] **F2**: Exact Landing Page card priority order (lock at F2 `/plan` time).
+- [ ] **F2**: `AIReviewHomeCard` removal — does it strip from SearchView in F2 or earlier?
+- [ ] **F3**: Year switcher in Draft — HeaderBar chip (planned) or local control? Sanity-check cross-view side effects.
+- [ ] **F3**: Exact sub-tab labels — "Live" / "Picks" / "Mocks" / "Recap" wording confirm.
+- [ ] **F2**: What "live games" lookup currently exists vs. needs new work (research at F2 `/plan` time).
+- [ ] **F4**: Whether Archive section needs its own brand of empty state per sub-page (lock at F4 `/plan` time).
+- [ ] **F4**: Archive entry shape — single `.archive` hub OR multi-entry section?
+
+---
+
+## Skills / Agents to Use
+
+- **planner**: invoked per sub-feature (F1 → F4) to turn this scaffolding into executable `/plan` documents.
+- **executor**: invoked per sub-feature after its `/plan` flips to Ready.
+- **swiftui-reviewer** (if available): post-`/execute` for F2 and F3 since those touch real view composition.
+- **/orchestrate**: next command — splits this epic into the 4 sub-feature stubs.
+
+---
+
+## Out of Scope (Epic-Level Non-Goals)
+
+- Backfilling 2024 + 2025 AI reports (running separately).
+- Admin UI for editing announcements (v2).
+- News stripe pulling from external feeds.
+- Push notifications for new Landing cards.
+- Time-aware Landing card priority function (defer — v1 ships static order).
+- Light mode (app stays dark-only).

--- a/docs/features/season-refocus/f1-tray-surgery/PLAN.md
+++ b/docs/features/season-refocus/f1-tray-surgery/PLAN.md
@@ -1,0 +1,127 @@
+# Plan: Season Refocus — F1 Tray Surgery
+
+**Epic**: season-refocus
+**Phase**: 1 of 4
+**Status**: Ready
+**Created**: 2026-05-21
+**Last updated**: 2026-05-21
+**Depends on**: none (first sub-feature)
+**Repos touched**: xomper-ios
+
+---
+
+## Summary
+
+Pure tray/label surgery to clear clutter before the bigger Landing Page work lands in F2. Two user-visible changes:
+
+1. Rename the `.draftHistory` tray entry from **"Draft History"** to **"Draft"** (enum case stays `.draftHistory` for backward-compat — only the display string changes; the nav title cascades for free because `MainShell` reads `navStore.currentDestination.title`).
+2. Demote `.draftOrder` (Reverse-HPP proposal) to the **bottom of the League section** in the drawer. No tray entry removed, no rename of the screen title — only the row position changes.
+
+Success = open the drawer, see "Draft" under History; open the League section, find "Draft Order Proposal" as the last row.
+
+---
+
+## Approach
+
+Locked decisions from `BRAINSTORM.md` + epic `/orchestrate` review:
+
+- **Lighter demote** of `.draftOrder` (NOT folded into Rule Proposals as `BRAINSTORM` Q2 Option A originally proposed; NOT hidden in Rulebook). Just sink to bottom of League section.
+- **Keep enum case** `.draftHistory` — only user-facing label flips. Avoids churn in `AppRouter`, `HistoryStore`, `MainShell` switches, and any preserved nav state.
+- **`DraftOrderView` screen title stays "Draft Order Proposal"** — it's an honest description of what the screen is.
+
+This is a single-iOS-PR change. Expected diff: ~3 files, < 10 lines.
+
+---
+
+## Affected Files / Components
+
+| File | Change | Why |
+|------|--------|-----|
+| `Xomper/Features/Shell/TrayDestination.swift` | Line 40: `case .draftHistory: "Draft History"` → `case .draftHistory: "Draft"` | User-facing label for the drawer row + the nav title (since `MainShell.swift:253` calls `navigationTitle(navStore.currentDestination.title)`). |
+| `Xomper/Features/Shell/DrawerView.swift` | Line 43: reorder League section `entries` array. Current: `[.payouts, .draftOrder, .aiReview, .rulebook, .scoring, .leagueSettings, .ruleProposals]`. New: `[.payouts, .aiReview, .rulebook, .scoring, .leagueSettings, .ruleProposals, .draftOrder]`. | Demotes Reverse-HPP proposal without removing it from the tray. |
+| `Xomper/Features/DraftHistory/DraftHistoryView.swift` | Line 47: `EmptyStateView(... title: "No Draft History", ...)` → `title: "No Draft Picks Yet"` | The empty-state heading inside the view repeats the old screen name. Since the screen is now labeled "Draft", swap the empty-state title to a string that doesn't reuse the old surface name. (Defensive — the user already noticed the staleness; we don't want a "Draft → No Draft History" double-take.) |
+
+**Files NOT touched** (deliberately, verified by search):
+- `Xomper/Navigation/AppRouter.swift` — `case draftHistory` is an internal route token, no user-facing string.
+- `Xomper/Core/Stores/HistoryStore.swift` — `draftHistory` property + "Draft History" code comments are internal API surface, no UX impact.
+- `Xomper/Features/Shell/MainShell.swift` — all `.draftHistory` switch cases stay; nav title is driven by `TrayDestination.title` so the rename cascades automatically.
+- `Xomper/Features/Shell/HeaderBar.swift` — the season-scoped destinations list `[.matchups, .draftHistory, .worldCup]` is by enum case, unaffected.
+- Test files — no user-facing "Draft History" strings to update (verified via grep).
+
+---
+
+## Implementation Steps
+
+- [ ] Step 1 — Edit `TrayDestination.swift`: in the `title` switch (line 40), change `"Draft History"` to `"Draft"`. Leave the enum case, the `systemImage` (`list.clipboard.fill`), and the file-top section-grouping comment as-is (the comment naming "History: draftHistory" still accurately describes the enum case grouping).
+- [ ] Step 2 — Edit `DrawerView.swift`: in the `sections` computed property (line 43), reorder the League section's `entries` array to move `.draftOrder` to the end. Final order: `[.payouts, .aiReview, .rulebook, .scoring, .leagueSettings, .ruleProposals, .draftOrder]`.
+- [ ] Step 3 — Edit `DraftHistoryView.swift`: change the `EmptyStateView` `title` argument from `"No Draft History"` to `"No Draft Picks Yet"` (line 47). Leave the `icon` and `message` props untouched.
+- [ ] Step 4 — Build green: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -scheme Xomper -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`.
+- [ ] Step 5 — Manual QA in simulator (see Test Plan below).
+- [ ] Step 6 — Commit `#<issue> tray label + draftOrder demote (F1 of season-refocus)` and open PR using `Closes #<issue>` in body.
+
+---
+
+## Test Plan
+
+**Build**: green via the xcodebuild command above.
+
+**Manual QA** (single 60-second pass on iPhone 17 Pro sim):
+
+1. Cold launch → swipe right (or tap hamburger) to open the drawer.
+2. Under **HISTORY** section: row reads **Draft** (not "Draft History"). Icon unchanged (`list.clipboard.fill`).
+3. Tap the row → screen pushes; nav title at top reads **Draft**.
+4. (If the league has no completed drafts for the selected season) confirm empty-state heading reads **No Draft Picks Yet** with unchanged icon + body copy.
+5. Open the drawer again, scroll to **LEAGUE** section. Confirm order top-to-bottom: Payouts → AI Review → Rulebook → Scoring → League Settings → Rule Proposals → Draft Order Proposal.
+6. Tap **Draft Order Proposal** → screen title still reads "Draft Order Proposal" (unchanged).
+7. Verify other tray destinations (Standings, Matchups, Team Analyzer, etc.) still render — quick sanity scroll, no regressions expected since only label + array order changed.
+
+**Automated tests**: none required. This is label + ordering. No new logic to cover. (Agent may add a trivial XCTAssertEqual against `TrayDestination.draftHistory.title == "Draft"` if it costs < 2 minutes to wire into the existing `XomperTests` target; otherwise skip.)
+
+---
+
+## Acceptance Checklist
+
+- [ ] Drawer "HISTORY" section's first row reads "Draft" (not "Draft History").
+- [ ] Tapping that row pushes a screen whose nav title is "Draft".
+- [ ] Empty-state heading on `DraftHistoryView` (when there are no picks for the selected season) reads "No Draft Picks Yet".
+- [ ] Drawer "LEAGUE" section ends with the "Draft Order Proposal" row (was previously second from the top of that section).
+- [ ] `DraftOrderView` opens normally from its new tray position; its own screen title is unchanged ("Draft Order Proposal").
+- [ ] Build is green.
+- [ ] No regressions to any other tray destination (visual spot-check).
+
+---
+
+## Out of Scope
+
+- Any change to `DraftHistoryView` internals beyond the empty-state title string.
+- Any change to `DraftOrderView` internals.
+- Adding, removing, or renaming any tray destination case.
+- Restructuring tray sections (no new "Home" or "Archive" section here — those land in F2 / F4).
+- Renaming the `.draftHistory` enum case to `.draft` (deferred indefinitely; backward-compat win outweighs naming purity).
+- Folding `.draftOrder` into Rule Proposals as a sub-page (was Brainstorm Q2 Option A; superseded by the locked "lighter demote" decision).
+- Wiring AI post-draft Recap into the Draft surface (that's F3).
+
+---
+
+## Risks / Tradeoffs
+
+- **"Draft" label collides with the future `.draftOrder` row in the same drawer** (two League-section rows mentioning "Draft"). Accepted — they're in different sections (History vs. League) and `.draftOrder`'s full label "Draft Order Proposal" is distinct enough. F3 will further differentiate when Live/Mocks/Recap sub-tabs land inside the Draft surface.
+- **Drawer screenshot tests (if any exist) will fail on the label diff**. Mitigation: update snapshots as part of this PR if hits surface during build.
+- **Comment drift**: `TrayDestination.swift` file-top comment groups cases by section ("History: draftHistory, matchupHistory, worldCup"). The comment still references the case name, not the label, so it remains accurate.
+
+---
+
+## Open Questions
+
+None remaining. All locked at brainstorm + epic review:
+- Label = "Draft" (singular).
+- `.draftOrder` stays in tray, sinks to bottom of League section.
+- `DraftOrderView` screen title stays "Draft Order Proposal".
+- Enum case stays `.draftHistory`.
+
+---
+
+## Skills / Agents to Use
+
+- **ios-specialist**: invoke directly via `/execute f1-tray-surgery` once status flips to Ready. This is small enough to skip a delegation preview — single agent, < 10-line diff, no branching decisions.
+- No swiftui-reviewer needed (no view composition changes).

--- a/docs/features/season-refocus/f2-landing/PLAN.md
+++ b/docs/features/season-refocus/f2-landing/PLAN.md
@@ -1,0 +1,286 @@
+# Plan: Season Refocus — F2 Landing Page MVP
+
+**Epic**: season-refocus
+**Phase**: 2 of 4
+**Status**: Ready
+**Created**: 2026-05-21
+**Last updated**: 2026-05-21
+**Depends on**: F1 (Tray Surgery) — merged
+**Repos touched**: xomper-ios
+
+---
+
+## Summary
+
+Add a new `TrayDestination.landing` case and a new `LandingView` composing four cards: headline AI Review (hero, tappable to detail), Announcements (hardcoded `LeagueAnnouncements.current` for v1), scrolling standings bar (horizontal team chips with W-L, offseason empty state), and this-week matchups (scoreboard style, offseason empty state). Flip `NavigationStore.currentDestination` default from `.standings` → `.landing`. Migrate `AIReviewHomeCard` out of `SearchView` (the AI hero on Landing takes its place). Pin a new "Home" section at the top of the drawer holding the Landing entry. Success = cold-open lands on a new home screen that reads as "what's coming next" with the freshest AI report in hero position.
+
+---
+
+## Approach
+
+Implements **Q4 Option A (static stripe order)** and **Q5 Option A (.landing becomes default)** from the brainstorm. Time-aware card priority (Q4 Option B) is explicitly deferred per the epic out-of-scope list — v1 ships a locked static order. Each card is its own SwiftUI view file for testability and clarity. All data sources reuse existing stores (`AIReviewStore`, `LeagueStore`, `StandingsBuilder`, `NflStateStore`); the only new persistent value is `Matchup` data for the current week, which already has a Sleeper API route + decoded model — fetched lazily inside the matchups card via a small task-scoped state holder. No new top-level store, no new networking layer.
+
+Visual reference: match the recent **DraftOrderView Live tab** chip-on-card pattern — `XomperColors.bgCard` rounded rect, championGold accent line/border on the hero, caption2 uppercased chip headers, `.pressableCard` button style throughout.
+
+---
+
+## Resolved Design Questions
+
+These were open in the F2 stub; all locked below before any code is written.
+
+### 1. Headline AI Review card — which report wins when multiple exist?
+
+**Pick: Option A — most recent across all types.** Reuses the existing `AIReviewStore.mostRecentLatest` accessor (already used by `AIReviewHomeCard`). Freshest content wins; the user shouldn't see a stale postDraft once a Week 4 weekly lands. The hero card flavors itself via the report's `reportType` chip (postDraft / Preseason / Weekly), so the type is never hidden — just not prioritized.
+
+### 2. Announcements data shape
+
+Pinned. Both types live in a single new file `Xomper/Features/Landing/LeagueAnnouncement.swift`:
+
+```swift
+struct LeagueAnnouncement: Identifiable, Sendable {
+    let id: UUID = UUID()
+    let title: String           // "Draft is July 6"
+    let body: String            // "6:30pm ET sharp. ~1 day per pick."
+    let priority: Priority      // .critical, .info
+    let expiresAt: Date?        // nil = always show
+}
+enum Priority { case critical, info }
+
+enum LeagueAnnouncements {
+    static let current: [LeagueAnnouncement] = [ /* 2-3 entries */ ]
+}
+```
+
+v1 ships 2-3 entries:
+- **Critical**: "Draft is July 6" — body: "6:30pm ET sharp. ~1 day per pick. Make sure you can be available for autopick fallback."  expiresAt: 2026-07-07.
+- **Info**: "Season starts Sept 8" — body: "Week 1 kicks off Mon Sept 8. Lineups lock at first kickoff."  expiresAt: 2026-09-09.
+- (Optional) **Info**: "Rule Proposals open" — body: "Vote on this season's open proposals before draft day."  expiresAt: 2026-07-06.
+
+`AnnouncementsCard` filters out entries where `expiresAt != nil && expiresAt < Date()`, sorts critical-first then by insertion order, and renders the resulting list. If the filtered list is empty, the card renders zero-height (no empty state — just absent).
+
+### 3. Scrolling standings bar — data source
+
+Reuse `StandingsBuilder.buildStandings(rosters:users:league:)` from `Xomper/Core/Stores/StandingsBuilder.swift` (lines 9-62). Same pure-function call `StandingsView.buildStandings()` already uses. Inputs (`leagueStore.myLeague`, `myLeagueRosters`, `myLeagueUsers`) are already loaded by `MainShell.bootstrapPhase1/2`, so no extra fetch — the card just maps the resulting `[StandingsTeam]` into a horizontal chip layout.
+
+### 4. This-week matchups — data source
+
+Use `SleeperAPIClient.fetchLeagueMatchups(_:week:)` (existing — `Xomper/Core/Networking/SleeperAPIClient.swift:89-91`) with `nflStateStore.currentWeek`. Pair raw matchups via the existing static helper `HistoryStore.pairMatchupsStatic` (returns `[MatchupPair]` — see `HistoryStore.swift:791-794`). Resolve owner names + team names from `leagueStore.myLeagueUsers` + `myLeagueRosters` the same way `MatchupCardView` does inside `MatchupsView.swift`.
+
+To avoid a new global store, `ThisWeekMatchupsCard` keeps its own `@State` for `[MatchupPair]` + `isLoading` + `error`, loads on `.task` keyed by `(leagueId, week)`, and exposes a `refresh()` method the LandingView can call from pull-to-refresh.
+
+### 5. Offseason detection
+
+`nflStateStore.isRegularSeason` (returns `seasonType == "regular"`). When false, the standings bar and this-week matchups card render empty states; the AI hero + announcements always render regardless.
+
+- Standings bar offseason copy: "Standings unlock once Week 1 kicks off."
+- Matchups card offseason copy: "This week's matchups appear here once games begin."
+
+### 6. Card priority order in offseason vs. in-season
+
+**Static for v1.** Locked order top-to-bottom: `[Headline AI, Announcements, Standings Bar, This-Week Matchups]`. Offseason cards still render — just in their empty states — so vertical layout is consistent across calendar phases. Time-aware reordering (Q4 Option B) deferred per epic out-of-scope.
+
+### 7. Pull-to-refresh behavior
+
+Yes. `LandingView` exposes a single `.refreshable` modifier on its outer `ScrollView`. The refresh handler calls all four data-source refreshes in parallel:
+
+```swift
+async let ai:       () = aiReviewStore.refresh()         // existing
+async let nfl:      () = nflStateStore.fetchState()      // existing
+async let league:   () = leagueStore.loadMyLeague()      // existing — rebuilds standings inputs
+async let matchups: () = matchupsCardRef.refresh()       // delegate to the card's own task
+_ = await (ai, nfl, league, matchups)
+```
+
+The matchups card refresh is wired by reading a private `@State var matchupsCardController = ThisWeekMatchupsController()` (a tiny `@Observable` shim with `var lastRefreshToken = UUID()` — bumping the token re-triggers the `.task(id:)` inside the card). Alternative: pass an `await` closure to the card; the controller approach keeps the card self-contained and is the cleaner SwiftUI pattern.
+
+### 8. Empty state for the headline AI card (cold-start)
+
+When `aiReviewStore.mostRecentLatest == nil`: render a small placeholder hero card (same outer frame + championGold border, smaller content area) with title **"First report drops after draft day"** and body **"AI reviews land here once the season kicks off — check back after July 6."** Icon: `sparkles` muted. This replaces the current `AIReviewHomeCard` behavior of rendering `EmptyView` — Landing always needs *something* in the hero slot or the page feels broken.
+
+### 9. Tray ordering after F2
+
+Read `DrawerView.swift` lines 27-50 — sections currently are: Compete / History / Roster / League (+ optional Admin). Landing goes in a **new section "HOME"** pinned at the very top, above Compete. Section title uppercased in caption (same style as existing sections via `sectionView(_:)` line 134-142). Just one entry: `.landing`. This is purely additive — does not require swapping anything out of the existing Compete entries (`.standings` stays where it is for users navigating manually).
+
+Final drawer order:
+- **HOME**: `.landing`
+- **COMPETE**: `.standings`, `.matchups`, `.playoffs`
+- **HISTORY**: `.draftHistory`, `.matchupHistory`, `.worldCup`
+- **ROSTER**: `.myTeam`, `.taxiSquad`, `.teamAnalyzer`
+- **LEAGUE**: `.payouts`, `.aiReview`, `.rulebook`, `.scoring`, `.leagueSettings`, `.ruleProposals`, `.draftOrder` (post-F1 order)
+- **ADMIN** (conditional): `.admin`
+- **Settings** (pinned footer): unchanged
+
+Tray entry count: 17 → 18 (within tolerance — epic risk callout was about 19+, this stays under).
+
+### 10. SearchView changes — exactly what's removed
+
+`SearchView.swift` (lines 41-45) injects `AIReviewHomeCard` into the body's top `VStack`. Remove the `AIReviewHomeCard(...)` call and the surrounding zero-overhead — leave the rest of the view intact. The card-priming `.task` block at lines 53-61 (the three `aiReviewStore.loadLatest(type:)` calls) also goes — Landing's `.task` now owns that bootstrapping.
+
+The `aiReviewStore` constructor parameter on `SearchView` stays (it's no longer needed by Search itself, but it's invoked from `MainShell.destinationView(for:)` at line 401-408 with the store injected; keeping the parameter avoids a churnier diff). Mark the unused param with a `// retained for future search-AI integration` line comment.
+
+**Decision**: `AIReviewHomeCard.swift` stays in the codebase as-is — it's still useful as a reusable component, and `HeadlineAIReportCard` is the hero variant (separate file, distinct visual treatment). No deletion. No mutation. No new style parameter on the existing card.
+
+---
+
+## Affected Files / Components
+
+| File / Component | Change | Why |
+|------|--------|-----|
+| `Xomper/Features/Landing/LandingView.swift` | **NEW** — root view composing 4 cards in a single `ScrollView` with `.refreshable`. | Top-level surface for the new default destination. |
+| `Xomper/Features/Landing/HeadlineAIReportCard.swift` | **NEW** — hero variant of the AI report card (larger padding, championGold accent stripe, full-bleed body preview to 3 lines, separate empty-state card when no report). | Distinct visual weight from `AIReviewHomeCard`. Tap → `navStore.select(.aiReview)` + `router.navigate(to: .aiReportDetail(reportId:))`. |
+| `Xomper/Features/Landing/LeagueAnnouncement.swift` | **NEW** — struct, Priority enum, hardcoded `LeagueAnnouncements.current` array. | Locked data shape for v1 announcements. |
+| `Xomper/Features/Landing/AnnouncementsCard.swift` | **NEW** — renders filtered announcements list. Critical entries get a red accent stripe; info entries plain bgCard. | Static league reminders surface. |
+| `Xomper/Features/Landing/StandingsScrollBar.swift` | **NEW** — horizontal `ScrollView` of avatar + team name + "W-L" chips. Tap a chip → `router.navigate(to: .teamDetail(rosterId:))`. Offseason empty state when `!nflStateStore.isRegularSeason`. | League-heartbeat surface; offseason-aware. |
+| `Xomper/Features/Landing/ThisWeekMatchupsCard.swift` | **NEW** — scoreboard list of paired matchups for `nflStateStore.currentWeek`. Holds its own `@State` for `[MatchupPair]`, `isLoading`, `error`, refresh token. Offseason empty state. | This-week scoreboard; self-loading. |
+| `Xomper/Features/Shell/TrayDestination.swift` | Add `case landing`; add `title` → `"Home"`; add `systemImage` → `"house.fill"`. Update file-top section comment to add "Home: landing". | New tray destination wired in. |
+| `Xomper/Features/Shell/DrawerView.swift` | Add new `TraySection(title: "Home", entries: [.landing])` at index 0 of the `sections` array. | Drawer renders the new section at top. |
+| `Xomper/Features/Shell/NavigationStore.swift` | Line 22: `var currentDestination: TrayDestination = .standings` → `= .landing`. Update doc comment on line 21. | Cold-open default. |
+| `Xomper/Features/Shell/MainShell.swift` | Add `case .landing:` to the `destinationRoot` switch (after the existing first case). Wire `LandingView` with the stores it needs: `leagueStore`, `authStore`, `nflStateStore`, `aiReviewStore`, `navStore`, `router`. | Renders Landing when selected. |
+| `Xomper/Features/Home/SearchView.swift` | Remove `AIReviewHomeCard(...)` injection (lines 41-45). Remove the prime `.task` block (lines 53-61). Leave the rest of the view intact. | Search reverts to pure search; AI hero moved to Landing. |
+| `XomperTests/LandingViewTests.swift` (optional) | **NEW** — one-shot smoke test that instantiates `LandingView` with stub stores and asserts it renders without throwing. Plus a `LeagueAnnouncement` filter test for expiry. | Cheap regression safety. |
+| `Xomper.xcodeproj/project.pbxproj` | Regenerated by `xcodegen generate`. | New `.swift` files must register with the target. |
+
+**Files explicitly NOT touched** (verified by grep):
+- `Xomper/Features/AIReview/AIReviewHomeCard.swift` — unchanged; remains a reusable component.
+- `Xomper/Features/League/StandingsView.swift` — F4 scope; this PR leaves it alone.
+- `Xomper/Features/League/MatchupsView.swift` — unchanged; the Landing card reuses pairing logic but does not push into this view.
+- `Xomper/Navigation/AppRouter.swift` — no new route. Landing pushes to `.aiReportDetail`, `.teamDetail` — both already exist.
+- `Xomper/Core/Networking/SleeperAPIClient.swift` — uses existing `fetchLeagueMatchups` route.
+
+---
+
+## Implementation Steps
+
+Order is dependency-driven. Each step is a discrete commit-worthy unit; the build should pass after every step.
+
+- [ ] **Step 1 — Data shapes first.** Create `Xomper/Features/Landing/LeagueAnnouncement.swift` with the `LeagueAnnouncement` struct, `Priority` enum, and `LeagueAnnouncements.current` hardcoded array (2-3 entries with the exact copy from Resolved Q2). No view code yet.
+
+- [ ] **Step 2 — Tray destination plumbing.** Edit `Xomper/Features/Shell/TrayDestination.swift`: add `case landing` to the enum, plus its `title` (`"Home"`) and `systemImage` (`"house.fill"`) switch arms. Update the file-top section comment to add `- Home: landing`. Build green (Landing still has no view, but the enum + nav store changes compile).
+
+- [ ] **Step 3 — Cold-open default flip.** Edit `Xomper/Features/Shell/NavigationStore.swift` line 22: change default to `.landing`. Update the doc comment on line 21 to reflect "Default landing destination on cold open is `.landing`." App will *crash* on launch until Step 6 wires the switch case — proceed straight to Step 4.
+
+- [ ] **Step 4 — Stub `LandingView`.** Create `Xomper/Features/Landing/LandingView.swift` with a minimal body that returns `Text("Landing")` placeholder + the constructor signature it will need (`leagueStore`, `authStore`, `nflStateStore`, `aiReviewStore`, `navStore`, `router`). This unblocks the next step.
+
+- [ ] **Step 5 — Drawer entry.** Edit `Xomper/Features/Shell/DrawerView.swift`: prepend a new section `TraySection(title: "Home", entries: [.landing])` to the `sections` array (index 0). Confirm the rest of the section order is unchanged.
+
+- [ ] **Step 6 — Wire MainShell switch.** Edit `Xomper/Features/Shell/MainShell.swift`: add `case .landing:` to `destinationRoot` (place it before `.standings` so reading the switch follows drawer order). Instantiate `LandingView` with the stores. **Regen project** (`xcodegen generate`) and **build green** — app now boots to Landing with the placeholder text.
+
+- [ ] **Step 7 — `HeadlineAIReportCard`.** Create `Xomper/Features/Landing/HeadlineAIReportCard.swift`. Mirror `AIReviewHomeCard`'s tap action (select `.aiReview` then push `.aiReportDetail`), but use a larger frame, 3-line preview snippet, championGold gradient overlay, and the empty-state placeholder card when `store.mostRecentLatest == nil`. Plumb the prime task into `LandingView.task` (the three `aiReviewStore.loadLatest(type:)` calls).
+
+- [ ] **Step 8 — `AnnouncementsCard`.** Create `Xomper/Features/Landing/AnnouncementsCard.swift`. Filter `LeagueAnnouncements.current` against `Date()` via `expiresAt`, sort critical-first, render. Critical entries get a left-edge red accent bar (`XomperColors.accentRed` 3pt wide); info entries are plain `bgCard`. Render zero-height when the filtered list is empty.
+
+- [ ] **Step 9 — `StandingsScrollBar`.** Create `Xomper/Features/Landing/StandingsScrollBar.swift`. Build `[StandingsTeam]` via `StandingsBuilder.buildStandings` on appear + on `myLeagueRosters/Users` changes (same `.task(id:)` + `.onChange(of:)` pattern as `StandingsView.swift:50-58`). Render horizontal `ScrollView` of avatar + team name + "W-L" pill. Tap → `router.navigate(to: .teamDetail(rosterId: team.rosterId))`. When `!nflStateStore.isRegularSeason` OR the standings array is empty: render the offseason empty state copy.
+
+- [ ] **Step 10 — `ThisWeekMatchupsCard`.** Create `Xomper/Features/Landing/ThisWeekMatchupsCard.swift`. Holds `@State var pairs: [MatchupPair]`, `@State var isLoading`, `@State var error`, `@State var refreshToken: UUID`. `.task(id: "\(leagueId)-\(week)-\(refreshToken)")` calls `SleeperAPIClient.fetchLeagueMatchups(_:week:)` directly (instantiate a `SleeperAPIClient()` locally — same approach `HistoryStore` takes). Pair via `HistoryStore.pairMatchupsStatic`. Render `[MatchupPair]` as a scoreboard list (team A / VS / team B per row, point totals if present else "—"). When `!nflStateStore.isRegularSeason`: offseason empty state copy. Expose a `refresh()` method that bumps `refreshToken`.
+
+- [ ] **Step 11 — Compose `LandingView` for real.** Replace the placeholder with the actual layout: `ScrollView` → `VStack(spacing: XomperTheme.Spacing.md)` containing the four cards in static order (Headline AI → Announcements → Standings Bar → This-Week Matchups). Wire `.refreshable` to call the parallel refresh closures from Resolved Q7. Set `.navigationTitle("Home")` and the standard dark `toolbarColorScheme`.
+
+- [ ] **Step 12 — Cleanup `SearchView`.** Edit `Xomper/Features/Home/SearchView.swift`: remove `AIReviewHomeCard(...)` injection (lines 41-45) and the prime `.task` block (lines 53-61). Add a `// retained for future search-AI integration` line comment next to the `aiReviewStore` constructor parameter to flag why it's kept.
+
+- [ ] **Step 13 — Regen + build.** Run `xcodegen generate`. Build green via:
+      `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -scheme Xomper -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`
+
+- [ ] **Step 14 — Optional smoke test.** Add `XomperTests/LandingViewTests.swift` with (a) a `LeagueAnnouncement` expiry filter test and (b) a render-doesn't-throw smoke test using stub stores. Run the full test target.
+
+- [ ] **Step 15 — Manual QA pass** (see Test Plan).
+
+- [ ] **Step 16 — Commit + PR.** Single commit. PR description: `Closes #<issue>`; mention "F2 of season-refocus epic". No co-author tag.
+
+---
+
+## Test Plan
+
+**Build**: green via the xcodebuild command above.
+
+**Automated**:
+- `LeagueAnnouncementTests` (if added in Step 14): expired announcements filtered out; critical sorts before info; never-expiring entries always present.
+- Existing `AIReviewStoreTests` etc. continue to pass.
+
+**Manual QA** on iPhone 17 Pro sim (90-second pass):
+
+1. **Cold launch**: app boots to a "Home" screen with the new four-card layout. No "Standings" first impression.
+2. **Hero card** renders the most recent AI report (or, if no reports yet, the "First report drops after draft day" placeholder). Tap → drawer-side selection moves to `.aiReview` and detail view pushes in the same animation envelope. Back button returns to Landing (not Standings) — verify the navStore stays on `.aiReview` not `.landing` after detail is dismissed.
+3. **Announcements** show the 2-3 hardcoded entries. Critical entries have the red accent stripe. Past-`expiresAt` entries are absent.
+4. **Standings bar** renders in current season: horizontal scroll of all 12 team chips with avatar + team name + W-L. Tap a chip → team detail pushes. Offseason copy ("Standings unlock once Week 1 kicks off") is verified by temporarily forcing `nflStateStore.nflState?.seasonType = "off"` in a debug build (or trust the empty-state branch via code review since we're literally in offseason).
+5. **This-week matchups**: in regular season, scoreboard shows current week's 6 matchups. In offseason (today's reality), the empty-state copy renders ("This week's matchups appear here once games begin").
+6. **Pull to refresh** on the Landing scroll view triggers a single spinner; all four data sources refresh in parallel (AI store, NFL state, league reload, matchups card). Verify no flash of empty hero during the refresh — the prior values stay rendered until the new ones land.
+7. **Drawer**: open it; new "HOME" section is pinned above "COMPETE" with the single "Home" row. "Home" row is highlighted (`isSelected`) on cold open. Tap "Standings" → standings still renders correctly (no regression from default flip).
+8. **Search**: navigate to Search (existing entry point from `HeaderBar`); confirm the AI banner card is *gone* and the search field sits directly under the nav title.
+9. **No regressions**: spot-check Matchups, Playoffs, Team Analyzer, AI Review (full archive), Admin, Settings.
+
+---
+
+## Acceptance Checklist
+
+- [ ] Cold launch lands on the new `LandingView` (not `StandingsView`).
+- [ ] Drawer has a new "HOME" section at the top with a single "Home" entry mapped to `.landing`.
+- [ ] Landing renders four cards in this order: Headline AI Review → Announcements → Standings bar → This-week matchups.
+- [ ] Headline AI card shows the most recent report (any type) and pushes to `AIReviewDetailView` on tap.
+- [ ] Headline AI card shows the cold-start placeholder when `aiReviewStore.mostRecentLatest == nil`.
+- [ ] `LeagueAnnouncements.current` hardcoded array exists with 2-3 entries (draft date + season start at minimum); expired entries are filtered.
+- [ ] Standings scroll bar tapping a chip pushes the team detail route.
+- [ ] In offseason, standings bar + matchups card render empty-state copy (not crash, not blank space).
+- [ ] In regular season, standings bar shows all 12 teams and matchups card shows the 6 current-week matchups.
+- [ ] Pull-to-refresh on Landing reloads all four data sources in parallel.
+- [ ] `SearchView` no longer renders `AIReviewHomeCard`; the search field is at the top of the body.
+- [ ] `xcodegen generate` is committed (`project.pbxproj` diff is part of the PR).
+- [ ] Build is green via the canonical xcodebuild command.
+- [ ] All `XomperTests` pass.
+- [ ] No regressions across other tray destinations.
+
+---
+
+## Out of Scope
+
+- Time-aware Landing card priority function (deferred per epic — v1 ships static order).
+- News stripe / Sleeper trending feed integration.
+- Push notifications for new Landing cards.
+- Admin UI for editing announcements (v2; v1 is hardcoded).
+- Scores card deep-linking to the existing `.matchups` view (deferred; matchups card is read-only for v1).
+- Spotlight rotator / feature CTAs (deferred — would belong to a v2 "Spotlight" card).
+- Persisting `NavigationStore.currentDestination` across app launches (separate concern; brainstorm Q10).
+- Any change to `StandingsView` itself (F4 owns the offseason wipe of the dedicated screen).
+- Any change to `AIReviewHomeCard.swift` internals — it stays as a reusable component.
+- Renaming `AIReviewHomeCard` or factoring shared styling into a `HomeCardStyle` enum.
+
+---
+
+## Risks / Tradeoffs
+
+- **Default destination flip is high blast radius.** Mitigation: Landing renders gracefully when no AI report exists (cold-start placeholder card), and the standings/matchups cards both have offseason empty states. Worst case is sparse-but-functional. Fallback: if Landing crashes on first launch, the user can manually select another destination from the drawer (which itself does not depend on `.landing` being viable).
+- **`SearchView` losing the AI banner is a visible behavior change for any user who navigates to Search expecting to see latest reports.** Accepted — the AI surface is moving to a more prominent place (Landing), not disappearing.
+- **`ThisWeekMatchupsCard` is the only Landing component that fetches over the network on appear.** Cold-start cost is one HTTP call (`/league/<id>/matchups/<week>`) — already exercised by `HistoryStore.fetchRawMatchups`. The card uses `.task(id:)` so it re-fires only on leagueId/week/refreshToken change; no polling.
+- **Tray entry count rises by 1.** Acceptable — still under the 19-entry threshold flagged in the epic risks. F4 will add one more (`.archive`), which is still within tolerance.
+- **`HistoryStore.pairMatchupsStatic` is accessed by a feature view directly** rather than through a store method. This is mildly anti-architectural (views talking to "Static" helpers), but the alternative (introducing a new store or extending `HistoryStore` to own current-week state) is heavier for v1. Accepted; can refactor if a second consumer appears.
+- **`AIReviewHomeCard` becomes orphaned (used only from `SearchView`, then no longer)**. Per Resolved Q10 we keep it — flagged with a `retained for future search-AI integration` comment so a future cleanup pass knows the intent.
+- **Critical-tag styling on announcements could clash visually with championGold-tinted hero card above it.** Mitigation: red accent is a 3pt left bar only, not a full background — should read as urgent without competing with the hero.
+
+---
+
+## Open Questions
+
+None blocking. All design questions resolved above. Potential v2 follow-ups (not gating this PR):
+
+- [ ] Should expired announcements still render dimmed for a few days post-expiry, or hard-cut at `expiresAt`? (v1: hard-cut.)
+- [ ] Should the standings scroll bar show a small playoff-cutoff visual (a vertical bar between 6th and 7th)? (v1: no — flat list.)
+- [ ] Should the matchups card highlight the current user's matchup? (v1: no — uniform scoreboard styling.)
+
+---
+
+## Skills / Agents to Use
+
+- **ios-specialist**: invoke directly via `/execute f2-landing` once status flips to Ready. This is the primary executor — file count (~6 new + 5 modified) is large enough to warrant a single dedicated agent rather than ad-hoc edits.
+- **swiftui-reviewer** (if available): post-`/execute` review pass since this touches real view composition + theme adherence on a brand-new top-level surface.
+- **No researcher**: data sources and patterns already mapped in this plan; nothing to discover.
+- **No backend-specialist**: zero backend changes.
+
+---
+
+## Notes for the Executor
+
+- Stick to the dependency order in Implementation Steps — Step 3 (default flip) intentionally precedes Step 6 (switch case) for chronological clarity, but the build will not be green between them. Land them in the same commit if you prefer, but do not commit Step 3 alone.
+- Every new view file must include a `#Preview` block with stub stores in a `NavigationStack`, matching the existing convention (see `MatchupsView.swift:330-340`).
+- All new views must respect the dark-only theme — no `.preferredColorScheme(.light)` in previews, no hardcoded white/black colors. Use `XomperColors` exclusively.
+- Spacing must use `XomperTheme.Spacing.*` constants — no raw `.padding(16)` literals.
+- All async work on `@MainActor` (default for `View`s and `@Observable` stores).
+- After adding new Swift files: `xcodegen generate` then commit the `project.pbxproj` diff in the same commit as the source files.

--- a/docs/features/season-refocus/f3-draft-tab/PLAN.md
+++ b/docs/features/season-refocus/f3-draft-tab/PLAN.md
@@ -1,0 +1,27 @@
+# Plan: Season Refocus — F3 Draft Tab Restructure
+
+**Epic**: season-refocus
+**Phase**: 3 of 4
+**Status**: Draft
+**Created**: 2026-05-21
+**Depends on**: F1, F2 (Landing card from F2 deep-links into this surface)
+**Repos touched**: xomper-ios
+
+---
+
+## Summary
+
+Restructure the Draft surface around per-year sub-tabs driven by the existing `HeaderBar` season chip + `SeasonStore`. When viewing 2026 (current season): show three sub-tabs — **Live order**, **Mocks**, **Recap** (Recap loads AIReport `type=postDraft` for that year). When viewing past year (2024, 2025): show two sub-tabs — **Picks**, **Recap**. Port `DraftOrderView`'s `.live` and `.mocks` content into the new sub-tabs. After this refactor, `DraftOrderView` only renders the reverse-HPP Proposal (single view, no internal tabs).
+
+---
+
+## Open questions to resolve in `/plan`
+
+- Year switcher in Draft — confirm HeaderBar chip is the right call vs. local control. Sanity-check cross-view side effects (chip is global; changing it in Draft drifts other season-aware views).
+- Exact sub-tab labels — confirm wording: "Live order" vs. "Live", "Picks" vs. "Board", "Mocks", "Recap".
+- Per-year season list — match `SeasonStore.availableSeasons` exactly, or filter to years with completed drafts + current year?
+- Empty-state copy for past-year Recap tab when AI report backfill hasn't landed yet.
+
+---
+
+<!-- /plan f3-draft-tab to fill in scope, architecture, file-by-file steps, test plan -->

--- a/docs/features/season-refocus/f4-standings-archive/PLAN.md
+++ b/docs/features/season-refocus/f4-standings-archive/PLAN.md
@@ -1,0 +1,27 @@
+# Plan: Season Refocus — F4 Standings Wipe + Archive
+
+**Epic**: season-refocus
+**Phase**: 4 of 4
+**Status**: Draft
+**Created**: 2026-05-21
+**Depends on**: F1, F2, F3 (safe to land last because by then Standings is no longer the cold-open default)
+**Repos touched**: xomper-ios
+
+---
+
+## Summary
+
+`StandingsView` becomes live-only — shows current-season standings during regular season; otherwise renders an **offseason countdown** empty state with hardcoded dates: **July 6 6:30pm ET (draft)** and **Sept 8 (Week 1)**. Add a new `TrayDestination.archive` at the bottom of the tray housing sub-sections: past standings (per year), past matchup history (link to existing `.matchupHistory`), past drafts (link into per-year Draft tab from F3). Use `nflStateStore` to detect "is there live data yet" for the offseason switch.
+
+---
+
+## Open questions to resolve in `/plan`
+
+- Whether Archive section needs its own brand of empty state per sub-page — lock at `/plan` time.
+- Archive entry shape — single `.archive` hub view OR multi-entry section in the tray ("Past Standings", "Past Drafts", "All AI Reports")?
+- Exact offseason copy for `StandingsView` empty state — countdown component design, hardcoded date strings.
+- Tray real estate audit — adding `.archive` brings total entries past 19; confirm nothing else folds.
+
+---
+
+<!-- /plan f4-standings-archive to fill in scope, architecture, file-by-file steps, test plan -->


### PR DESCRIPTION
## Summary

Phase 2 of the season-refocus epic. Adds a new `.landing` `TrayDestination` and `LandingView` that becomes the app's new default home screen, composing four cards in a static order. Flips `NavigationStore.currentDestination` default from `.standings` to `.landing` — first-load behavior change for all users on the next TestFlight build.

Plan: [`docs/features/season-refocus/f2-landing/PLAN.md`](docs/features/season-refocus/f2-landing/PLAN.md)
Epic: [`docs/features/season-refocus/EPIC_PLAN.md`](docs/features/season-refocus/EPIC_PLAN.md)
Brainstorm: [`docs/features/season-refocus/BRAINSTORM.md`](docs/features/season-refocus/BRAINSTORM.md)

## What changed

**New files (6 Swift sources + 1 test):**
- `Xomper/Features/Landing/LandingView.swift` — root view, `.refreshable` parallel-refresh
- `Xomper/Features/Landing/HeadlineAIReportCard.swift` — hero variant of the AI report card, championGold border + 3-line preview, cold-start placeholder when no report
- `Xomper/Features/Landing/LeagueAnnouncement.swift` — `LeagueAnnouncement` struct + `LeagueAnnouncements.current` hardcoded list (2026 draft date, Rule Proposals reminder, Sept 8 season start)
- `Xomper/Features/Landing/AnnouncementsCard.swift` — filtered + critical-first sorted list; expired entries hard-cut, zero-height when empty
- `Xomper/Features/Landing/StandingsScrollBar.swift` — horizontal chip scroller (avatar + team name + W-L), offseason empty state
- `Xomper/Features/Landing/ThisWeekMatchupsCard.swift` — self-loading scoreboard with `ThisWeekMatchupsController` shim so outer pull-to-refresh can await it; offseason short-circuits the fetch
- `XomperTests/LandingViewTests.swift` — announcement filter/sort tests + LandingView smoke construct test

**Modified files (5 + project regen):**
- `Xomper/Features/Shell/TrayDestination.swift` — added `case landing`, title `"Home"`, glyph `house.fill`
- `Xomper/Features/Shell/NavigationStore.swift` — default `currentDestination` flipped to `.landing`
- `Xomper/Features/Shell/DrawerView.swift` — new "HOME" section pinned above "COMPETE" (single entry)
- `Xomper/Features/Shell/MainShell.swift` — `.landing` switch arm wiring the four stores Landing needs
- `Xomper/Features/Home/SearchView.swift` — removed `AIReviewHomeCard` injection and the three-way prime task; `aiReviewStore` parameter retained with a `// retained for future search-AI integration` comment
- `Xomper.xcodeproj/project.pbxproj` — regenerated via `xcodegen generate`

## Notable behavior changes

- **Default destination flip**: cold open now lands on `.landing` instead of `.standings`. Drawer manual selection of Standings still works; `StandingsView` itself is unchanged.
- **Search**: AI banner is gone from `SearchView`. The search field is now the topmost item.
- **`AIReviewHomeCard.swift` is kept** as a reusable component but is no longer rendered anywhere; flagged with a retained-for-future comment.

## Card order (locked for v1)

1. Headline AI Review (hero, championGold border)
2. Announcements
3. Standings scroll bar
4. This-Week Matchups

Time-aware reordering is explicitly deferred per the epic out-of-scope.

## Test plan

- [ ] Cold launch lands on the new Home screen (not Standings)
- [ ] Drawer shows "HOME" section above "COMPETE"; tapping "Home" routes back to Landing from any other destination
- [ ] Headline AI card shows the cold-start placeholder when no report exists; otherwise shows the most recent (postDraft / Preseason / Weekly) with chip; tap navigates to AI Review + detail
- [ ] Announcements show 3 entries today (Draft / Rule Proposals / Season start); critical entry has the red left accent bar; entries past `expiresAt` disappear automatically
- [ ] Standings scroll bar shows offseason copy today (`!nflStateStore.isRegularSeason`); in-season it shows all 12 teams as chips and a chip tap pushes team detail
- [ ] This-week matchups card shows offseason copy today; in-season it renders the 6 paired matchups with point totals when present
- [ ] Pull-to-refresh on Landing fans out to all four data sources in parallel
- [ ] Search screen has no AI banner; field is at the top of the body
- [ ] No regressions on Matchups, Playoffs, AI Review, Team Analyzer, Admin, Settings

## Build / tests

- `xcodebuild` for iPhone 17 Pro simulator: `** BUILD SUCCEEDED **`, no warnings
- `XomperTests`: 40 tests pass (36 existing + 4 new)