### PR TITLE
feat(season-refocus F3): Draft tab restructure — per-year sub-tabs, strip Live+Mocks from DraftOrderView

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		1D74425C19EE5C00589214C3 /* TaxiSquadPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2DA1B65780757E6CC78CD61 /* TaxiSquadPlayer.swift */; };
 		2378DF41F2BB3933117897A7 /* MatchupHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B52D5FD69B62417928B713 /* MatchupHistory.swift */; };
 		284F17C4CD26363D19756E03 /* TrayProfileCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3FE7B1A468AA2569D95B20 /* TrayProfileCard.swift */; };
+		2BE0B9AB9BAEFD6AA714D2EF /* DraftRecapResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB0B979B62A1CF6EB80417F /* DraftRecapResolverTests.swift */; };
 		2F09FBAE23D8109C931D63A9 /* XomperTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBB5433786555EDDBC896C7 /* XomperTheme.swift */; };
 		2F50FD9BC26550139DAD2E96 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F510E2F428E107F1AD75CD /* Config.swift */; };
 		2F60B09D13BABD5E49B3DCBF /* MainShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A254D17EF062523E09C9D4 /* MainShell.swift */; };
@@ -65,6 +66,7 @@
 		68EE3E2F11A28AD898ABB03C /* AIReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A51BC6B9389405FE754DCEB /* AIReviewView.swift */; };
 		6BC002C5DD7EF547F82CA860 /* DraftOrderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9ED150F995299D37368EDC3 /* DraftOrderView.swift */; };
 		6C89029D05AEE66FB2315616 /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C8A3FA617E9FEB48852C45 /* Profile.swift */; };
+		6D833D6D3E53E0913363925C /* DraftSubTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831DFA7D391F8415451D6479 /* DraftSubTabBar.swift */; };
 		6D9C0E43C329D80ED8933AD2 /* AdminStoreWeeklyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFEC46AB65E6E7A90E0A695 /* AdminStoreWeeklyTests.swift */; };
 		724482308D102AFA35AB4017 /* LeagueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56BB91320E3D5EBE1F777838 /* LeagueStore.swift */; };
 		72FF7B4516B2DCDAE4683B9D /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83A8FEFFD8FA91F498D03A0 /* EmptyStateView.swift */; };
@@ -83,6 +85,7 @@
 		83E71E429B2F8B4B7AEBAB96 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD0F6820960B354EAB3E89D /* LoadingView.swift */; };
 		86412A35609319AF08D413D3 /* TaxiSquadStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6387E34B6FA70159F3F9D80A /* TaxiSquadStore.swift */; };
 		8C2ABA833D6AB1C5A3017BDA /* LeaguePayouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AC494E7D11CB94A2FD56EA /* LeaguePayouts.swift */; };
+		8C58AAB4103D2F8A473DAA4E /* MocksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D86A1E276C98E0A3D5070F /* MocksView.swift */; };
 		8C67D3AAFE5A0A124BDE5F1A /* AppRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EABD25CAB8BF973C4709720 /* AppRouter.swift */; };
 		8E8B3EC17A43676ACA176FC3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6F2D6E80C100927C4C20FAD7 /* Assets.xcassets */; };
 		901F54CB41785D269CC63160 /* WorldCupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E1C6D5A18697DE79586C1B /* WorldCupStore.swift */; };
@@ -98,6 +101,7 @@
 		A379F9D71FE84EC4F3A2499C /* SearchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C5F37100E6EBB467EBFE1C /* SearchStore.swift */; };
 		A45E9B6A2A65059251FB3D76 /* AdminStorePreseasonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD03A165767A043D34A9499 /* AdminStorePreseasonTests.swift */; };
 		A4D93DF4C02A8DE6C695CE4D /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E94170F987E8EFE5C566B9B /* LoginView.swift */; };
+		AFE044848CB195AC6BC3CA62 /* DraftRecapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5DA384F46CEDA38C9898C14 /* DraftRecapView.swift */; };
 		B24D5DBDDF4C163FCAB52689 /* TeamAnalysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC09DFF48D9AAFEF0A286BAD /* TeamAnalysis.swift */; };
 		B309CAE3F00F954918C09554 /* PlayerValuesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE99E9B095120FB6636FC8A /* PlayerValuesStore.swift */; };
 		B48B9F6061A67CFC74A096CC /* StandingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957EE31D25CFE325633622D4 /* StandingsStore.swift */; };
@@ -118,8 +122,10 @@
 		CFE915FD4020FDEB923157C2 /* RuleProposal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7C85CB880ABD7D373E49A6 /* RuleProposal.swift */; };
 		D09FC43EBE71A0DFF28B83D2 /* MatchupDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F2C7D74B3584D53CE601054 /* MatchupDetailView.swift */; };
 		D106F60A597D780F32FFA5E8 /* Matchup.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83EF3C6C93199CF3FCBAE42 /* Matchup.swift */; };
+		D107A9FEAF17BE9FCEA44958 /* LiveDraftView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04B5251715A37E924DF7CEF /* LiveDraftView.swift */; };
 		D78D5302B3D17DE9BE7D557C /* AuthGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5E661424C55F695BF96281 /* AuthGateView.swift */; };
 		D7A95C32621E03E2AAB37327 /* TaxiStealConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66A2C896FE4C62CF9719D7A /* TaxiStealConfirmView.swift */; };
+		E0951007574761D3F51B21B9 /* DraftSubTabSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7456E9AFD3FA47DA3DA0F7 /* DraftSubTabSelectionTests.swift */; };
 		E1D933F9B0C3E87F9C1C907A /* XomperAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89FC018282A1F1D8B2FD1B60 /* XomperAPIClient.swift */; };
 		E2E0551B857C17254E9B789B /* AdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E257076F7FE641947D1DC978 /* AdminView.swift */; };
 		E2EC532916CAA2FBB779DB35 /* UserStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62948D0A455E7CE99B15CB75 /* UserStore.swift */; };
@@ -156,6 +162,7 @@
 		22D61F12E32D7C81FCA8F8CE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		2B670A3A0762D22FB3202E1E /* DivisionBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DivisionBadge.swift; sourceTree = "<group>"; };
 		2B6C68E1131F2BBBE625DEAF /* RuleProposalFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleProposalFormView.swift; sourceTree = "<group>"; };
+		2DB0B979B62A1CF6EB80417F /* DraftRecapResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftRecapResolverTests.swift; sourceTree = "<group>"; };
 		2DCF4387BA57375E04A8940B /* AnnouncementsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsCard.swift; sourceTree = "<group>"; };
 		323F422F2D0E1C2BA5D46C0A /* SearchResults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResults.swift; sourceTree = "<group>"; };
 		36A01820FD0F6643BBF8511D /* TeamStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamStore.swift; sourceTree = "<group>"; };
@@ -173,6 +180,7 @@
 		460030AF84E8D0E83D8F5896 /* Xomper.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Xomper.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4690614F644FE74115D0DAB6 /* ProposedTrade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProposedTrade.swift; sourceTree = "<group>"; };
 		501B8FD2B915B3BD6568F42C /* HexagonChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HexagonChartView.swift; sourceTree = "<group>"; };
+		50D86A1E276C98E0A3D5070F /* MocksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MocksView.swift; sourceTree = "<group>"; };
 		536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthStore.swift; sourceTree = "<group>"; };
 		558164667DF7D89C4DF2F32E /* MyProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyProfileView.swift; sourceTree = "<group>"; };
 		56BB91320E3D5EBE1F777838 /* LeagueStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeagueStore.swift; sourceTree = "<group>"; };
@@ -199,6 +207,7 @@
 		7839DD9CF0968986F91A58DB /* AdminStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStore.swift; sourceTree = "<group>"; };
 		7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Draft.swift; sourceTree = "<group>"; };
 		8098F78566BB324ACC70FB94 /* TeamAnalyzerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamAnalyzerView.swift; sourceTree = "<group>"; };
+		831DFA7D391F8415451D6479 /* DraftSubTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftSubTabBar.swift; sourceTree = "<group>"; };
 		840D50097382434B0D123ACB /* NavigationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStore.swift; sourceTree = "<group>"; };
 		8521885A7FF4C6910DFBF549 /* MatchupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupsView.swift; sourceTree = "<group>"; };
 		89FC018282A1F1D8B2FD1B60 /* XomperAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperAPIClient.swift; sourceTree = "<group>"; };
@@ -214,6 +223,7 @@
 		9E94170F987E8EFE5C566B9B /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		9F49969EE42BDE6462664021 /* TradedPick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradedPick.swift; sourceTree = "<group>"; };
 		A2DA1B65780757E6CC78CD61 /* TaxiSquadPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiSquadPlayer.swift; sourceTree = "<group>"; };
+		A5DA384F46CEDA38C9898C14 /* DraftRecapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftRecapView.swift; sourceTree = "<group>"; };
 		A789B8D49FA4430886626289 /* DraftHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftHistory.swift; sourceTree = "<group>"; };
 		A83A8FEFFD8FA91F498D03A0 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		A84518A312FF0F96719AF1E8 /* LeagueOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeagueOverviewView.swift; sourceTree = "<group>"; };
@@ -221,6 +231,7 @@
 		ACCFF9888476668EBE7AA0CC /* XomperTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = XomperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD43D54AB620DABD559F8A40 /* CareerStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareerStats.swift; sourceTree = "<group>"; };
 		AE543CB2E49335ADD02E8000 /* Roster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Roster.swift; sourceTree = "<group>"; };
+		B04B5251715A37E924DF7CEF /* LiveDraftView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveDraftView.swift; sourceTree = "<group>"; };
 		B29D510D87CD290AE7F76FBF /* StandingsTeam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsTeam.swift; sourceTree = "<group>"; };
 		B3893B13276074EF6033CEA2 /* ClinchCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClinchCalculatorTests.swift; sourceTree = "<group>"; };
 		B6060C3A4F2B355757F1E3A2 /* DraftHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftHistoryView.swift; sourceTree = "<group>"; };
@@ -261,6 +272,7 @@
 		E9ED150F995299D37368EDC3 /* DraftOrderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftOrderView.swift; sourceTree = "<group>"; };
 		ECC70812B3E7E07BA6658A54 /* AvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
 		ED3E9ADC138A5F405E59389C /* DrawerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerView.swift; sourceTree = "<group>"; };
+		ED7456E9AFD3FA47DA3DA0F7 /* DraftSubTabSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftSubTabSelectionTests.swift; sourceTree = "<group>"; };
 		F013CD37874EFB0FA1CB4261 /* HistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryStore.swift; sourceTree = "<group>"; };
 		F1E7D0FD804723AC6A3E4298 /* HeaderBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderBar.swift; sourceTree = "<group>"; };
 		F2452A5AEC270BE14CC085E1 /* URL+Sleeper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Sleeper.swift"; sourceTree = "<group>"; };
@@ -398,6 +410,8 @@
 				6CFEC46AB65E6E7A90E0A695 /* AdminStoreWeeklyTests.swift */,
 				08BD215787E2BFC1C57E7E7E /* AIReviewStoreTests.swift */,
 				B3893B13276074EF6033CEA2 /* ClinchCalculatorTests.swift */,
+				2DB0B979B62A1CF6EB80417F /* DraftRecapResolverTests.swift */,
+				ED7456E9AFD3FA47DA3DA0F7 /* DraftSubTabSelectionTests.swift */,
 				D7F3E6606D89CF3AEB320314 /* LandingViewTests.swift */,
 			);
 			path = XomperTests;
@@ -468,6 +482,17 @@
 				E7F510E2F428E107F1AD75CD /* Config.swift */,
 			);
 			path = Config;
+			sourceTree = "<group>";
+		};
+		7D491FDD816B6270D6975B2A /* Draft */ = {
+			isa = PBXGroup;
+			children = (
+				A5DA384F46CEDA38C9898C14 /* DraftRecapView.swift */,
+				831DFA7D391F8415451D6479 /* DraftSubTabBar.swift */,
+				B04B5251715A37E924DF7CEF /* LiveDraftView.swift */,
+				50D86A1E276C98E0A3D5070F /* MocksView.swift */,
+			);
+			path = Draft;
 			sourceTree = "<group>";
 		};
 		7DEC053904198785F4461D4A /* Home */ = {
@@ -639,6 +664,7 @@
 			isa = PBXGroup;
 			children = (
 				B6060C3A4F2B355757F1E3A2 /* DraftHistoryView.swift */,
+				7D491FDD816B6270D6975B2A /* Draft */,
 			);
 			path = DraftHistory;
 			sourceTree = "<group>";
@@ -773,6 +799,8 @@
 				37E600A31B5AA5DA5A766692 /* AdminStoreTests.swift in Sources */,
 				6D9C0E43C329D80ED8933AD2 /* AdminStoreWeeklyTests.swift in Sources */,
 				02AC6FBAE68011749AA17644 /* ClinchCalculatorTests.swift in Sources */,
+				2BE0B9AB9BAEFD6AA714D2EF /* DraftRecapResolverTests.swift in Sources */,
+				E0951007574761D3F51B21B9 /* DraftSubTabSelectionTests.swift in Sources */,
 				007B11207486956897981421 /* LandingViewTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -806,6 +834,8 @@
 				4E0CAC9964BF3F2B59EDD844 /* DraftHistory.swift in Sources */,
 				3B67875F822BE9AA9BD052EF /* DraftHistoryView.swift in Sources */,
 				6BC002C5DD7EF547F82CA860 /* DraftOrderView.swift in Sources */,
+				AFE044848CB195AC6BC3CA62 /* DraftRecapView.swift in Sources */,
+				6D833D6D3E53E0913363925C /* DraftSubTabBar.swift in Sources */,
 				3B1DDBCA7B19B8703FAF717E /* DrawerScrim.swift in Sources */,
 				817EEBDA82021E74A830E1B3 /* DrawerView.swift in Sources */,
 				72FF7B4516B2DCDAE4683B9D /* EmptyStateView.swift in Sources */,
@@ -822,6 +852,7 @@
 				CEC2B1D5D34F80BFB3444C6F /* LeagueOverviewView.swift in Sources */,
 				8C2ABA833D6AB1C5A3017BDA /* LeaguePayouts.swift in Sources */,
 				724482308D102AFA35AB4017 /* LeagueStore.swift in Sources */,
+				D107A9FEAF17BE9FCEA44958 /* LiveDraftView.swift in Sources */,
 				83E71E429B2F8B4B7AEBAB96 /* LoadingView.swift in Sources */,
 				A4D93DF4C02A8DE6C695CE4D /* LoginView.swift in Sources */,
 				2F60B09D13BABD5E49B3DCBF /* MainShell.swift in Sources */,
@@ -831,6 +862,7 @@
 				368D96609CAF02430F340657 /* MatchupHistoryBrowserView.swift in Sources */,
 				7EA8F8FCEFFE3C165655208C /* MatchupHistoryView.swift in Sources */,
 				16F47DD114B2470F88D007A5 /* MatchupsView.swift in Sources */,
+				8C58AAB4103D2F8A473DAA4E /* MocksView.swift in Sources */,
 				9E5C71DAB504EDCDF2084DF3 /* MyProfileView.swift in Sources */,
 				FAE7847413A293EF8CE9090C /* NFLTeamColors.swift in Sources */,
 				021A039E220940CD2E12304A /* NavigationStore.swift in Sources */,

--- a/Xomper/Features/DraftHistory/Draft/DraftRecapView.swift
+++ b/Xomper/Features/DraftHistory/Draft/DraftRecapView.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+
+/// Inline render of the most recent `postDraft` AI report for a given
+/// year. Lives as the third sub-tab on the Draft surface (current
+/// season) and the second sub-tab on past seasons. No navigation
+/// push — markdown body renders directly, matching the body card on
+/// `AIReviewDetailView`.
+///
+/// Data flow:
+/// 1. On appear / year change, lazy-load the archive if it hasn't
+///    been pulled yet.
+/// 2. Filter `aiReviewStore.archive` for `reportType == .postDraft`
+///    AND `period.contains(year)`. The archive is newest-first so
+///    `first(where:)` returns the most recent match.
+/// 3. Render header (period + createdAt) and body
+///    (`AttributedString(markdown:)`).
+///
+/// Pull-to-refresh forces an archive reload via `force: true`.
+struct DraftRecapView: View {
+    var aiReviewStore: AIReviewStore
+    let year: String
+
+    var body: some View {
+        Group {
+            if let report = matchingReport {
+                reportContent(report)
+            } else if aiReviewStore.isLoading {
+                LoadingView(message: "Loading \(year) draft recap…")
+            } else {
+                EmptyStateView(
+                    icon: "sparkles",
+                    title: "No Recap Yet",
+                    message: "We haven't generated a post-draft report for \(year). Check back after the report runs."
+                )
+            }
+        }
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .task(id: year) {
+            await ensureArchiveLoaded()
+        }
+        .refreshable {
+            await aiReviewStore.loadArchive(force: true)
+        }
+    }
+
+    // MARK: - Resolved report
+
+    /// Resolves the matching report from the store's archive. Static
+    /// peer (`Self.matchingReport`) holds the actual logic so tests
+    /// can drive it directly.
+    private var matchingReport: AIReport? {
+        Self.matchingReport(in: aiReviewStore.archive, year: year)
+    }
+
+    /// Pure filter: take the first `postDraft` report whose `period`
+    /// string contains `year`. Period strings carry the year per the
+    /// F0 wire format (`"2026"`, `"2026-POSTDRAFT"`, etc.) — combined
+    /// with the type filter, the substring match is safe.
+    ///
+    /// Archive is newest-first sorted upstream, so `first` returns
+    /// the most recent matching report.
+    static func matchingReport(in archive: [AIReport], year: String) -> AIReport? {
+        guard !year.isEmpty else { return nil }
+        return archive.first { report in
+            report.reportType == .postDraft && report.period.contains(year)
+        }
+    }
+
+    // MARK: - Loading
+
+    private func ensureArchiveLoaded() async {
+        // Lazy-load only when the archive is empty. The 12-hour
+        // freshness guard inside `loadArchive` short-circuits any
+        // subsequent calls, so we don't need to gate on
+        // `lastLoadedAt` here.
+        if aiReviewStore.archive.isEmpty {
+            await aiReviewStore.loadArchive()
+        }
+    }
+
+    // MARK: - Report content
+
+    private func reportContent(_ report: AIReport) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
+                headerCard(report)
+                bodyCard(report)
+            }
+            .padding(.horizontal, XomperTheme.Spacing.md)
+            .padding(.vertical, XomperTheme.Spacing.sm)
+        }
+    }
+
+    private func headerCard(_ report: AIReport) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                Text("RECAP")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(XomperColors.bgDark)
+                    .padding(.horizontal, XomperTheme.Spacing.xs)
+                    .padding(.vertical, 2)
+                    .background(XomperColors.championGold)
+                    .clipShape(Capsule())
+                Text(report.period)
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+                Spacer()
+                Text(formattedDate(report.createdAt))
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(XomperColors.textMuted)
+                    .monospacedDigit()
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    private func bodyCard(_ report: AIReport) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            renderedMarkdown(report)
+                .font(.body)
+                .foregroundStyle(XomperColors.textPrimary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+    }
+
+    /// iOS 17 `AttributedString(markdown:)` with full interpreted
+    /// syntax (headings, lists, bold). Falls back to plain text if
+    /// the markdown is malformed.
+    @ViewBuilder
+    private func renderedMarkdown(_ report: AIReport) -> some View {
+        if let attributed = try? AttributedString(
+            markdown: report.bodyMarkdown,
+            options: AttributedString.MarkdownParsingOptions(
+                interpretedSyntax: .full
+            )
+        ) {
+            Text(attributed)
+        } else {
+            Text(report.bodyMarkdown)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, yyyy"
+        return formatter.string(from: date)
+    }
+}

--- a/Xomper/Features/DraftHistory/Draft/DraftSubTabBar.swift
+++ b/Xomper/Features/DraftHistory/Draft/DraftSubTabBar.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+/// Sub-tabs for the Draft surface (legacy `Features/DraftHistory/`
+/// directory). Per the F3 Season Refocus plan, the current-season
+/// view exposes [.live, .mocks, .recap]; past seasons collapse to
+/// [.picks, .recap]. The view that hosts these is `DraftHistoryView`,
+/// which is the orchestrator after F3.
+///
+/// `DraftSubTabBar` mirrors the pill-segmented styling that lived in
+/// `DraftOrderView.viewModeBar` before F3 — championGold fill for
+/// the selected pill, dim text otherwise.
+enum DraftSubTab: String, CaseIterable, Identifiable, Sendable, Hashable {
+    case live
+    case mocks
+    case recap
+    case picks
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .live:  "Live"
+        case .mocks: "Mocks"
+        case .recap: "Recap"
+        case .picks: "Picks"
+        }
+    }
+}
+
+/// Pill-segmented control for the Draft sub-tabs. Renders one button
+/// per entry in `tabs`, championGold fill on the selected pill,
+/// muted text otherwise. Layout + styling mirrors the pre-F3
+/// `DraftOrderView.viewModeBar` so the visual language matches across
+/// the app.
+struct DraftSubTabBar: View {
+    let tabs: [DraftSubTab]
+    @Binding var selection: DraftSubTab
+
+    var body: some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            ForEach(tabs) { tab in
+                tabButton(tab)
+            }
+        }
+        .padding(2)
+        .background(XomperColors.surfaceLight.opacity(0.4))
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md + 2))
+        .padding(.horizontal, XomperTheme.Spacing.md)
+        .padding(.vertical, XomperTheme.Spacing.sm)
+    }
+
+    private func tabButton(_ tab: DraftSubTab) -> some View {
+        let isSelected = selection == tab
+        return Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            withAnimation(XomperTheme.defaultAnimation) {
+                selection = tab
+            }
+        } label: {
+            Text(tab.label)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(isSelected ? XomperColors.bgDark : XomperColors.textSecondary)
+                .padding(.horizontal, XomperTheme.Spacing.sm)
+                .padding(.vertical, 6)
+                .frame(maxWidth: .infinity)
+                .background(isSelected ? XomperColors.championGold : Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityLabel(tab.label)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+// MARK: - Sub-tab list helpers
+
+/// Pure helpers for the sub-tab list. Lifted to a namespace so tests
+/// can drive them without view materialization.
+enum DraftSubTabSelection {
+
+    /// Sub-tabs the Draft surface shows for a given season. Current
+    /// season → Live / Mocks / Recap. Past season → Picks / Recap.
+    static func availableSubTabs(isCurrentSeason: Bool) -> [DraftSubTab] {
+        isCurrentSeason ? [.live, .mocks, .recap] : [.picks, .recap]
+    }
+
+    /// Default selection for a given mode. Current → `.live`, past
+    /// → `.picks`. Used on first render and on season-change reset.
+    static func defaultSubTab(isCurrentSeason: Bool) -> DraftSubTab {
+        availableSubTabs(isCurrentSeason: isCurrentSeason).first ?? .recap
+    }
+}

--- a/Xomper/Features/DraftHistory/Draft/LiveDraftView.swift
+++ b/Xomper/Features/DraftHistory/Draft/LiveDraftView.swift
@@ -1,0 +1,250 @@
+import SwiftUI
+
+/// Live draft view — the commissioner-set order pulled from Sleeper
+/// (`historyStore.upcomingDraft`). Answers "who's picking when in
+/// this year's draft?" with the start time + 1-day-per-pick pace
+/// estimate.
+///
+/// Extracted verbatim from the pre-F3 `DraftOrderView.liveContent`
+/// path. Renders the round-1 slot order with the YOU badge on the
+/// signed-in user's slot. Sub-tab bar lives one level up in
+/// `DraftHistoryView` — this view is one of three current-season
+/// children (Live / Mocks / Recap).
+struct LiveDraftView: View {
+    var leagueStore: LeagueStore
+    var historyStore: HistoryStore
+    var userStore: UserStore
+    var nflStateStore: NflStateStore
+
+    var body: some View {
+        Group {
+            if historyStore.isLoadingUpcoming && historyStore.upcomingDraft == nil {
+                LoadingView(message: "Loading \(nextDraftSeason) draft…")
+            } else if let error = historyStore.upcomingError, historyStore.upcomingDraft == nil {
+                ErrorView(message: error.localizedDescription) {
+                    Task { await ensureLiveLoaded() }
+                }
+            } else if let draft = historyStore.upcomingDraft {
+                liveDraftBody(draft: draft)
+            } else {
+                EmptyStateView(
+                    icon: "calendar.badge.exclamationmark",
+                    title: "\(nextDraftSeason) Draft Not Scheduled",
+                    message: "The commissioner hasn't created next season's draft yet. Pull to refresh once it's set up."
+                )
+            }
+        }
+        .task(id: leagueStore.myLeague?.leagueId) {
+            await ensureLiveLoaded()
+        }
+        .refreshable {
+            await ensureLiveLoaded()
+        }
+    }
+
+    // MARK: - Body
+
+    private func liveDraftBody(draft: Draft) -> some View {
+        let teamsBySlot = liveTeamsBySlot(draft: draft)
+        let slots = liveSlots(draft: draft, teamsBySlot: teamsBySlot)
+        let rounds = max(draft.settings?.rounds ?? 5, 1)
+        let totalPicks = slots.count * rounds
+        let firstPick = liveStartDate(draft: draft)
+        let myUserId = userStore.myUser?.userId
+
+        return ScrollView {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
+                liveHeaderCard(draft: draft, totalPicks: totalPicks, firstPick: firstPick)
+
+                sectionHeader("Round 1 order (\(slots.count) slots)")
+                ForEach(slots, id: \.self) { slot in
+                    let team = teamsBySlot[slot]
+                    let isMine = team?.userId != nil && team?.userId == myUserId
+                    liveRow(
+                        slot: slot,
+                        team: team,
+                        isMine: isMine,
+                        pickDate: pickDate(firstPick: firstPick, pickNo: slot)
+                    )
+                }
+            }
+            .padding(.horizontal, XomperTheme.Spacing.md)
+            .padding(.vertical, XomperTheme.Spacing.sm)
+        }
+    }
+
+    private func liveHeaderCard(draft: Draft, totalPicks: Int, firstPick: Date?) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                Text("LIVE")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(XomperColors.bgDark)
+                    .padding(.horizontal, XomperTheme.Spacing.xs)
+                    .padding(.vertical, 2)
+                    .background(XomperColors.championGold)
+                    .clipShape(Capsule())
+                Text("\(draft.season) rookie draft")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+            }
+
+            if let firstPick {
+                Text("Starts \(formatted(firstPick))")
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textSecondary)
+            } else {
+                Text("Slot order is locked. No start time set in Sleeper yet.")
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textSecondary)
+            }
+
+            if let firstPick, totalPicks > 0,
+               let end = Calendar.current.date(byAdding: .day, value: totalPicks - 1, to: firstPick) {
+                Text("Pace: ~1 day per pick → final pick around \(formattedShort(end))")
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.textMuted)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    private func liveRow(slot: Int, team: UpcomingDraftTeam?, isMine: Bool, pickDate: Date?) -> some View {
+        HStack(spacing: XomperTheme.Spacing.md) {
+            Text("\(slot)")
+                .font(.title3.weight(.bold))
+                .foregroundStyle(isMine ? XomperColors.championGold : XomperColors.textSecondary)
+                .frame(width: 36, alignment: .leading)
+                .monospacedDigit()
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(team?.teamName ?? "Slot \(slot)")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .lineLimit(1)
+                if let pickDate {
+                    Text("Pick #\(slot) · ~\(formattedShort(pickDate))")
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .monospacedDigit()
+                } else {
+                    Text("Pick #\(slot)")
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .monospacedDigit()
+                }
+            }
+
+            Spacer()
+
+            if isMine {
+                Text("YOU")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(XomperColors.bgDark)
+                    .padding(.horizontal, XomperTheme.Spacing.xs)
+                    .background(XomperColors.championGold)
+                    .clipShape(Capsule())
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(
+                    isMine ? XomperColors.championGold.opacity(0.4) : Color.clear,
+                    lineWidth: 1
+                )
+        )
+    }
+
+    // MARK: - Section header
+
+    private func sectionHeader(_ text: String) -> some View {
+        Text(text)
+            .font(.caption.weight(.bold))
+            .textCase(.uppercase)
+            .tracking(0.5)
+            .foregroundStyle(XomperColors.textMuted)
+            .padding(.top, XomperTheme.Spacing.sm)
+    }
+
+    // MARK: - Helpers
+
+    private func liveTeamsBySlot(draft: Draft) -> [Int: UpcomingDraftTeam] {
+        var byUser: [String: UpcomingDraftTeam] = [:]
+        for user in historyStore.upcomingUsers {
+            guard let userId = user.userId else { continue }
+            byUser[userId] = UpcomingDraftTeam(
+                userId: userId,
+                teamName: user.teamName ?? user.resolvedDisplayName,
+                avatarId: user.avatar
+            )
+        }
+        var bySlot: [Int: UpcomingDraftTeam] = [:]
+        if let order = draft.draftOrder {
+            for (userId, slot) in order {
+                if let team = byUser[userId] {
+                    bySlot[slot] = team
+                }
+            }
+        }
+        return bySlot
+    }
+
+    private func liveSlots(draft: Draft, teamsBySlot: [Int: UpcomingDraftTeam]) -> [Int] {
+        let count = draft.settings?.teams
+            ?? max(teamsBySlot.keys.max() ?? 0, historyStore.upcomingRosters.count)
+        return Array(1...max(count, 1))
+    }
+
+    private func liveStartDate(draft: Draft) -> Date? {
+        guard let epochMillis = draft.startTime, epochMillis > 0 else { return nil }
+        return Date(timeIntervalSince1970: TimeInterval(epochMillis) / 1000.0)
+    }
+
+    /// Each pick gets one calendar day. Pick #N is on `start + (N - 1)
+    /// days`. Picks past slot count belong to round 2+ and aren't shown
+    /// in this list, so we only use this for round-1 slot rows.
+    private func pickDate(firstPick: Date?, pickNo: Int) -> Date? {
+        guard let firstPick else { return nil }
+        return Calendar.current.date(byAdding: .day, value: pickNo - 1, to: firstPick)
+    }
+
+    private func formatted(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "EEE, MMM d 'at' h:mm a zzz"
+        return f.string(from: date)
+    }
+
+    private func formattedShort(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f.string(from: date)
+    }
+
+    private var nextDraftSeason: String {
+        nflStateStore.currentSeason.isEmpty
+            ? (leagueStore.myLeague?.season ?? "next")
+            : nflStateStore.currentSeason
+    }
+
+    // MARK: - Data loading
+
+    private func ensureLiveLoaded() async {
+        guard let userId = userStore.myUser?.userId else { return }
+        let homeName = leagueStore.resolvedHomeLeagueName
+        let season = nextDraftSeason
+        await historyStore.loadUpcomingDraft(
+            season: season,
+            homeLeagueName: homeName,
+            userId: userId
+        )
+    }
+}

--- a/Xomper/Features/DraftHistory/Draft/MocksView.swift
+++ b/Xomper/Features/DraftHistory/Draft/MocksView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+/// Placeholder for the rookie-mock-draft engine. Copy + icon mirror
+/// the pre-F3 `DraftOrderView.mocksPlaceholder` verbatim. Replaced
+/// with the real engine in the separate Mock Drafts epic.
+struct MocksView: View {
+    var body: some View {
+        EmptyStateView(
+            icon: "wand.and.stars",
+            title: "Mock Drafts Coming Soon",
+            message: "A 5-round rookie mock driven by team-need scoring + multiple draft personalities. Lands in the next update."
+        )
+    }
+}
+
+#Preview {
+    MocksView()
+        .preferredColorScheme(.dark)
+}

--- a/Xomper/Features/DraftHistory/DraftHistoryView.swift
+++ b/Xomper/Features/DraftHistory/DraftHistoryView.swift
@@ -1,5 +1,22 @@
 import SwiftUI
 
+/// The "Draft" tray destination. The directory name (`DraftHistory/`)
+/// and tray case (`.draftHistory`) are legacy from the pre-F3
+/// single-purpose draft-picks view — preserved across the F3 refactor
+/// to avoid churn. Post-F3 this view is the orchestrator of the per-
+/// year sub-tab structure described in
+/// `docs/features/season-refocus/f3-draft-tab/PLAN.md`:
+///
+/// - Current season → Live / Mocks / Recap (Live + Mocks live in
+///   `Draft/` subfolder; the original Live code was extracted out of
+///   `DraftOrderView` during F3).
+/// - Past seasons → Picks / Recap (Picks is the legacy rounds + board
+///   rendering that lived here pre-F3).
+///
+/// The HeaderBar season chip drives `SeasonStore.selectedSeason`; this
+/// view reads it via `@Environment(\.selectedSeason)`. On a season
+/// change, the sub-tab selection resets to the mode's default
+/// (`.live` for current, `.picks` for past).
 struct DraftHistoryView: View {
     var leagueStore: LeagueStore
     var historyStore: HistoryStore
@@ -7,58 +24,125 @@ struct DraftHistoryView: View {
     var playerPointsStore: PlayerPointsStore
     var userStore: UserStore
     var nflStateStore: NflStateStore
+    var aiReviewStore: AIReviewStore
 
     @Environment(\.selectedSeason) private var seasonStore: SeasonStore?
 
     @State private var filterMode: PickFilter = .all
     @State private var viewMode: DraftViewMode = .rounds
     @State private var selectedPlayer: Player?
+    @State private var selectedSubTab: DraftSubTab = .live
 
     private var currentSeason: String {
         seasonStore?.selectedSeason ?? ""
     }
 
-    /// True when the selected chip is the in-progress NFL season AND
-    /// no completed draft has been ingested for it yet. Triggers the
-    /// upcoming-draft view, which fetches the league + draft from
-    /// Sleeper and renders the actual commissioner-set draft order
-    /// (slots-by-team) in both list and board modes.
-    private var isUpcomingDraft: Bool {
+    /// True when the selected chip equals the in-progress NFL season.
+    /// Broader than the legacy `isUpcomingDraft` check — once the
+    /// current-year draft completes and picks are ingested, the
+    /// current-season sub-tabs (Live / Mocks / Recap) still render.
+    /// The Picks sub-tab is intentionally absent on current years —
+    /// view picks via the Live sub-tab's slot list while the draft
+    /// is in progress.
+    private var isCurrentSeason: Bool {
         !currentSeason.isEmpty
             && currentSeason == nflStateStore.currentSeason
+    }
+
+    /// True when the user has the current season selected AND no
+    /// completed draft has been ingested yet. Drives the "upcoming
+    /// draft" fallback that fetches the commissioner-set order from
+    /// Sleeper for the Picks sub-tab on the current year.
+    private var isUpcomingDraft: Bool {
+        isCurrentSeason
             && historyStore.draftPicksByRound(forSeason: currentSeason).isEmpty
     }
 
+    private var availableSubTabs: [DraftSubTab] {
+        DraftSubTabSelection.availableSubTabs(isCurrentSeason: isCurrentSeason)
+    }
+
     var body: some View {
-        Group {
-            if historyStore.isLoadingDrafts && !historyStore.hasDrafts {
-                LoadingView(message: "Loading draft history...")
-            } else if let error = historyStore.draftError, !historyStore.hasDrafts {
-                ErrorView(message: error.localizedDescription) {
-                    Task { await loadDraftHistory() }
+        VStack(spacing: 0) {
+            DraftSubTabBar(tabs: availableSubTabs, selection: $selectedSubTab)
+
+            Group {
+                switch selectedSubTab {
+                case .live:
+                    LiveDraftView(
+                        leagueStore: leagueStore,
+                        historyStore: historyStore,
+                        userStore: userStore,
+                        nflStateStore: nflStateStore
+                    )
+                case .mocks:
+                    MocksView()
+                case .recap:
+                    DraftRecapView(
+                        aiReviewStore: aiReviewStore,
+                        year: currentSeason
+                    )
+                case .picks:
+                    picksContent
                 }
-            } else if isUpcomingDraft {
-                upcomingDraftContent
-            } else if historyStore.hasDrafts {
-                draftContent
-            } else {
-                EmptyStateView(
-                    icon: "list.clipboard",
-                    title: "No Draft Picks Yet",
-                    message: "Draft picks will appear here once a draft is complete."
-                )
             }
         }
+        .background(XomperColors.bgDark.ignoresSafeArea())
         .task(id: leagueStore.myLeague?.leagueId) {
             await loadDraftHistory()
         }
         .task(id: isUpcomingDraft) {
+            // Only the Picks sub-tab consumes upcoming-draft data;
+            // the Live sub-tab loads it independently. We still
+            // pre-fetch so the manual Picks → current-year path
+            // shows the list without an extra round-trip.
             if isUpcomingDraft {
                 await loadUpcomingDraft()
             }
         }
+        .onChange(of: isCurrentSeason) { _, newValue in
+            // Season chip switched between current and past. Reset
+            // to the new mode's default sub-tab so users don't land
+            // on an unavailable tab.
+            selectedSubTab = DraftSubTabSelection.defaultSubTab(isCurrentSeason: newValue)
+        }
+        .onAppear {
+            // Initial selection: defer to the resolved season's mode.
+            // Without this the `@State` default of `.live` would be
+            // wrong if the user lands on a past year first.
+            if !availableSubTabs.contains(selectedSubTab) {
+                selectedSubTab = DraftSubTabSelection.defaultSubTab(isCurrentSeason: isCurrentSeason)
+            }
+        }
         .sheet(item: $selectedPlayer) { player in
             PlayerDetailView(player: player, playerStore: playerStore)
+        }
+    }
+
+    // MARK: - Picks content
+
+    /// Legacy draft-picks rendering (rounds list + draft-board grid).
+    /// Default sub-tab on past seasons; manually-selectable on the
+    /// current season (falls back to the upcoming-draft slot order
+    /// when picks haven't been ingested yet).
+    @ViewBuilder
+    private var picksContent: some View {
+        if historyStore.isLoadingDrafts && !historyStore.hasDrafts {
+            LoadingView(message: "Loading draft history...")
+        } else if let error = historyStore.draftError, !historyStore.hasDrafts {
+            ErrorView(message: error.localizedDescription) {
+                Task { await loadDraftHistory() }
+            }
+        } else if isUpcomingDraft {
+            upcomingDraftContent
+        } else if historyStore.hasDrafts {
+            draftContent
+        } else {
+            EmptyStateView(
+                icon: "list.clipboard",
+                title: "No Draft Picks Yet",
+                message: "Draft picks will appear here once a draft is complete."
+            )
         }
     }
 
@@ -949,7 +1033,8 @@ enum DraftViewMode: String, CaseIterable, Identifiable {
             playerStore: PlayerStore(),
             playerPointsStore: PlayerPointsStore(),
             userStore: UserStore(),
-            nflStateStore: NflStateStore()
+            nflStateStore: NflStateStore(),
+            aiReviewStore: AIReviewStore()
         )
     }
     .preferredColorScheme(.dark)

--- a/Xomper/Features/DraftOrder/DraftOrderView.swift
+++ b/Xomper/Features/DraftOrder/DraftOrderView.swift
@@ -1,288 +1,32 @@
 import SwiftUI
 
-/// Draft Order screen. Three modes:
-/// - `.live`: the actual commissioner-set order pulled from Sleeper
-///   (`historyStore.upcomingDraft`). Default — answers "who's picking
-///   when in this year's draft?" with the start time + 1-day-per-pick
-///   pace.
-/// - `.proposal`: the reverse-HPP rule proposal (non-playoff teams in
-///   ascending season HPP, playoff teams at the back ordered by actual
-///   playoff finish). What we'd switch to under the league rule
-///   discussion from #57.
-/// - `.mocks`: simulated rookie drafts driven by different personality
-///   weightings (BPA, team-fit, wildcard…). Placeholder for now —
-///   wired up once the mock engine lands.
+/// Draft Order Proposal screen. Renders the Reverse-HPP rule
+/// proposal (non-playoff teams in ascending season HPP, playoff
+/// teams at the back ordered by actual playoff finish). Proposal,
+/// not yet in effect — the live commissioner-set order lives on the
+/// Draft tab's Live sub-tab (post-F3 restructure; see
+/// `docs/features/season-refocus/f3-draft-tab/PLAN.md`).
+///
+/// Before F3 this view also hosted Live + Mocks under an internal
+/// segmented control. Those were extracted out into the new Draft
+/// tab; this view is now single-purpose — no internal tabs, no
+/// `viewMode` state.
 struct DraftOrderView: View {
     var leagueStore: LeagueStore
     var historyStore: HistoryStore
     var playerStore: PlayerStore
     var playerPointsStore: PlayerPointsStore
     var userStore: UserStore
-    var nflStateStore: NflStateStore
-
-    @State private var viewMode: DraftOrderViewMode = .live
 
     var body: some View {
-        VStack(spacing: 0) {
-            viewModeBar
-
-            Group {
-                switch viewMode {
-                case .live:    liveContent
-                case .proposal: proposalContent
-                case .mocks:   mocksPlaceholder
-                }
+        proposalContent
+            .background(XomperColors.bgDark.ignoresSafeArea())
+            .task(id: leagueStore.myLeague?.leagueId) {
+                await ensureProposalLoaded()
             }
-        }
-        .background(XomperColors.bgDark.ignoresSafeArea())
-        .task(id: leagueStore.myLeague?.leagueId) {
-            await ensureProposalLoaded()
-        }
-        .task(id: viewMode) {
-            if viewMode == .live { await ensureLiveLoaded() }
-            if viewMode == .proposal { await ensureProposalLoaded() }
-        }
-        .refreshable {
-            switch viewMode {
-            case .live:    await ensureLiveLoaded()
-            case .proposal: await ensureProposalLoaded()
-            case .mocks:   break
+            .refreshable {
+                await ensureProposalLoaded()
             }
-        }
-    }
-
-    // MARK: - View mode picker
-
-    private var viewModeBar: some View {
-        HStack(spacing: XomperTheme.Spacing.xs) {
-            ForEach(DraftOrderViewMode.allCases) { mode in
-                viewModeButton(mode)
-            }
-        }
-        .padding(2)
-        .background(XomperColors.surfaceLight.opacity(0.4))
-        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md + 2))
-        .padding(.horizontal, XomperTheme.Spacing.md)
-        .padding(.vertical, XomperTheme.Spacing.sm)
-    }
-
-    private func viewModeButton(_ mode: DraftOrderViewMode) -> some View {
-        let isSelected = viewMode == mode
-        return Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            withAnimation(XomperTheme.defaultAnimation) { viewMode = mode }
-        } label: {
-            Text(mode.label)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(isSelected ? XomperColors.bgDark : XomperColors.textSecondary)
-                .padding(.horizontal, XomperTheme.Spacing.sm)
-                .padding(.vertical, 6)
-                .frame(maxWidth: .infinity)
-                .background(isSelected ? XomperColors.championGold : Color.clear)
-                .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
-        }
-        .buttonStyle(.pressableCard)
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
-    }
-
-    // MARK: - Live content
-
-    private var liveContent: some View {
-        Group {
-            if historyStore.isLoadingUpcoming && historyStore.upcomingDraft == nil {
-                LoadingView(message: "Loading \(nextDraftSeason) draft…")
-            } else if let error = historyStore.upcomingError, historyStore.upcomingDraft == nil {
-                ErrorView(message: error.localizedDescription) {
-                    Task { await ensureLiveLoaded() }
-                }
-            } else if let draft = historyStore.upcomingDraft {
-                liveDraftBody(draft: draft)
-            } else {
-                EmptyStateView(
-                    icon: "calendar.badge.exclamationmark",
-                    title: "\(nextDraftSeason) Draft Not Scheduled",
-                    message: "The commissioner hasn't created next season's draft yet. Pull to refresh once it's set up."
-                )
-            }
-        }
-    }
-
-    private func liveDraftBody(draft: Draft) -> some View {
-        let teamsBySlot = liveTeamsBySlot(draft: draft)
-        let slots = liveSlots(draft: draft, teamsBySlot: teamsBySlot)
-        let rounds = max(draft.settings?.rounds ?? 5, 1)
-        let totalPicks = slots.count * rounds
-        let firstPick = liveStartDate(draft: draft)
-        let myUserId = userStore.myUser?.userId
-
-        return ScrollView {
-            VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
-                liveHeaderCard(draft: draft, totalPicks: totalPicks, firstPick: firstPick)
-
-                sectionHeader("Round 1 order (\(slots.count) slots)")
-                ForEach(slots, id: \.self) { slot in
-                    let team = teamsBySlot[slot]
-                    let isMine = team?.userId != nil && team?.userId == myUserId
-                    liveRow(
-                        slot: slot,
-                        team: team,
-                        isMine: isMine,
-                        pickDate: pickDate(firstPick: firstPick, pickNo: slot)
-                    )
-                }
-            }
-            .padding(.horizontal, XomperTheme.Spacing.md)
-            .padding(.vertical, XomperTheme.Spacing.sm)
-        }
-    }
-
-    private func liveHeaderCard(draft: Draft, totalPicks: Int, firstPick: Date?) -> some View {
-        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
-            HStack(spacing: XomperTheme.Spacing.xs) {
-                Text("LIVE")
-                    .font(.caption2.weight(.bold))
-                    .foregroundStyle(XomperColors.bgDark)
-                    .padding(.horizontal, XomperTheme.Spacing.xs)
-                    .padding(.vertical, 2)
-                    .background(XomperColors.championGold)
-                    .clipShape(Capsule())
-                Text("\(draft.season) rookie draft")
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(XomperColors.championGold)
-            }
-
-            if let firstPick {
-                Text("Starts \(formatted(firstPick))")
-                    .font(.caption)
-                    .foregroundStyle(XomperColors.textSecondary)
-            } else {
-                Text("Slot order is locked. No start time set in Sleeper yet.")
-                    .font(.caption)
-                    .foregroundStyle(XomperColors.textSecondary)
-            }
-
-            if let firstPick, totalPicks > 0,
-               let end = Calendar.current.date(byAdding: .day, value: totalPicks - 1, to: firstPick) {
-                Text("Pace: ~1 day per pick → final pick around \(formattedShort(end))")
-                    .font(.caption2)
-                    .foregroundStyle(XomperColors.textMuted)
-            }
-        }
-        .padding(XomperTheme.Spacing.md)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(XomperColors.bgCard)
-        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
-                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
-        )
-    }
-
-    private func liveRow(slot: Int, team: UpcomingDraftTeam?, isMine: Bool, pickDate: Date?) -> some View {
-        HStack(spacing: XomperTheme.Spacing.md) {
-            Text("\(slot)")
-                .font(.title3.weight(.bold))
-                .foregroundStyle(isMine ? XomperColors.championGold : XomperColors.textSecondary)
-                .frame(width: 36, alignment: .leading)
-                .monospacedDigit()
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(team?.teamName ?? "Slot \(slot)")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(XomperColors.textPrimary)
-                    .lineLimit(1)
-                if let pickDate {
-                    Text("Pick #\(slot) · ~\(formattedShort(pickDate))")
-                        .font(.caption2)
-                        .foregroundStyle(XomperColors.textMuted)
-                        .monospacedDigit()
-                } else {
-                    Text("Pick #\(slot)")
-                        .font(.caption2)
-                        .foregroundStyle(XomperColors.textMuted)
-                        .monospacedDigit()
-                }
-            }
-
-            Spacer()
-
-            if isMine {
-                Text("YOU")
-                    .font(.caption2.weight(.bold))
-                    .foregroundStyle(XomperColors.bgDark)
-                    .padding(.horizontal, XomperTheme.Spacing.xs)
-                    .background(XomperColors.championGold)
-                    .clipShape(Capsule())
-            }
-        }
-        .padding(XomperTheme.Spacing.md)
-        .background(XomperColors.bgCard)
-        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
-                .strokeBorder(
-                    isMine ? XomperColors.championGold.opacity(0.4) : Color.clear,
-                    lineWidth: 1
-                )
-        )
-    }
-
-    private func liveTeamsBySlot(draft: Draft) -> [Int: UpcomingDraftTeam] {
-        var byUser: [String: UpcomingDraftTeam] = [:]
-        for user in historyStore.upcomingUsers {
-            guard let userId = user.userId else { continue }
-            byUser[userId] = UpcomingDraftTeam(
-                userId: userId,
-                teamName: user.teamName ?? user.resolvedDisplayName,
-                avatarId: user.avatar
-            )
-        }
-        var bySlot: [Int: UpcomingDraftTeam] = [:]
-        if let order = draft.draftOrder {
-            for (userId, slot) in order {
-                if let team = byUser[userId] {
-                    bySlot[slot] = team
-                }
-            }
-        }
-        return bySlot
-    }
-
-    private func liveSlots(draft: Draft, teamsBySlot: [Int: UpcomingDraftTeam]) -> [Int] {
-        let count = draft.settings?.teams
-            ?? max(teamsBySlot.keys.max() ?? 0, historyStore.upcomingRosters.count)
-        return Array(1...max(count, 1))
-    }
-
-    private func liveStartDate(draft: Draft) -> Date? {
-        guard let epochMillis = draft.startTime, epochMillis > 0 else { return nil }
-        return Date(timeIntervalSince1970: TimeInterval(epochMillis) / 1000.0)
-    }
-
-    /// Each pick gets one calendar day. Pick #N is on `start + (N - 1)
-    /// days`. Picks past slot count belong to round 2+ and aren't shown
-    /// in this list, so we only use this for round-1 slot rows.
-    private func pickDate(firstPick: Date?, pickNo: Int) -> Date? {
-        guard let firstPick else { return nil }
-        return Calendar.current.date(byAdding: .day, value: pickNo - 1, to: firstPick)
-    }
-
-    private func formatted(_ date: Date) -> String {
-        let f = DateFormatter()
-        f.dateFormat = "EEE, MMM d 'at' h:mm a zzz"
-        return f.string(from: date)
-    }
-
-    private func formattedShort(_ date: Date) -> String {
-        let f = DateFormatter()
-        f.dateFormat = "MMM d"
-        return f.string(from: date)
-    }
-
-    private var nextDraftSeason: String {
-        nflStateStore.currentSeason.isEmpty
-            ? (leagueStore.myLeague?.season ?? "next")
-            : nflStateStore.currentSeason
     }
 
     // MARK: - Proposal content
@@ -356,7 +100,7 @@ struct DraftOrderView: View {
                     .foregroundStyle(XomperColors.championGold)
             }
 
-            Text("This is a *proposed* rule, not in effect yet. The actual order set by the commissioner lives on the Live tab.")
+            Text("This is a *proposed* rule, not in effect yet. The actual commissioner-set order lives on the Draft tab's Live sub-tab.")
                 .font(.caption)
                 .foregroundStyle(XomperColors.textSecondary)
 
@@ -466,16 +210,6 @@ struct DraftOrderView: View {
         }
     }
 
-    // MARK: - Mocks placeholder
-
-    private var mocksPlaceholder: some View {
-        EmptyStateView(
-            icon: "wand.and.stars",
-            title: "Mock Drafts Coming Soon",
-            message: "A 5-round rookie mock driven by team-need scoring + multiple draft personalities. Lands in the next update."
-        )
-    }
-
     // MARK: - Compute (proposal)
 
     private func compute() -> DraftOrderProjection {
@@ -500,17 +234,6 @@ struct DraftOrderView: View {
         }
     }
 
-    private func ensureLiveLoaded() async {
-        guard let userId = userStore.myUser?.userId else { return }
-        let homeName = leagueStore.resolvedHomeLeagueName
-        let season = nextDraftSeason
-        await historyStore.loadUpcomingDraft(
-            season: season,
-            homeLeagueName: homeName,
-            userId: userId
-        )
-    }
-
     private var regularSeasonLastWeek: Int {
         guard let value = leagueStore.myLeague?.settings?.additionalSettings?["playoff_week_start"] else {
             return 14
@@ -518,22 +241,6 @@ struct DraftOrderView: View {
         if let i = value.intValue { return max(i - 1, 1) }
         if let d = value.doubleValue { return max(Int(d) - 1, 1) }
         return 14
-    }
-}
-
-// MARK: - View mode
-
-enum DraftOrderViewMode: String, CaseIterable, Identifiable {
-    case live, proposal, mocks
-
-    var id: String { rawValue }
-
-    var label: String {
-        switch self {
-        case .live:     return "Live"
-        case .proposal: return "Proposal"
-        case .mocks:    return "Mocks"
-        }
     }
 }
 

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -165,7 +165,8 @@ struct MainShell: View {
                     playerStore: playerStore,
                     playerPointsStore: playerPointsStore,
                     userStore: userStore,
-                    nflStateStore: nflStateStore
+                    nflStateStore: nflStateStore,
+                    aiReviewStore: aiReviewStore
                 )
 
             case .matchupHistory:
@@ -217,8 +218,7 @@ struct MainShell: View {
                     historyStore: historyStore,
                     playerStore: playerStore,
                     playerPointsStore: playerPointsStore,
-                    userStore: userStore,
-                    nflStateStore: nflStateStore
+                    userStore: userStore
                 )
 
             case .aiReview:
@@ -387,7 +387,8 @@ struct MainShell: View {
                 playerStore: playerStore,
                 playerPointsStore: playerPointsStore,
                 userStore: userStore,
-                nflStateStore: nflStateStore
+                nflStateStore: nflStateStore,
+                aiReviewStore: aiReviewStore
             )
 
         case .matchupHistory:

--- a/Xomper/Features/Shell/TrayDestination.swift
+++ b/Xomper/Features/Shell/TrayDestination.swift
@@ -15,6 +15,11 @@ enum TrayDestination: Hashable {
     case standings
     case matchups
     case playoffs
+    // Legacy name — the user-facing label is "Draft" and the
+    // renderer is the post-F3 sub-tabbed `DraftHistoryView` (Live /
+    // Mocks / Recap on the current season; Picks / Recap on past
+    // seasons). The case + the `Features/DraftHistory/` directory
+    // are kept stable to avoid cross-file churn across migrations.
     case draftHistory
     case matchupHistory
     case worldCup

--- a/XomperTests/DraftRecapResolverTests.swift
+++ b/XomperTests/DraftRecapResolverTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+@testable import Xomper
+
+/// Tests for the postDraft recap filter that lives on `DraftRecapView`
+/// (Season Refocus F3 — Draft tab restructure). The filter is lifted
+/// to a static helper (`DraftRecapView.matchingReport(in:year:)`) so
+/// tests can drive it without view materialization.
+@MainActor
+final class DraftRecapResolverTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeReport(
+        id: String,
+        type: AIReportType,
+        period: String,
+        createdAt: Date = Date()
+    ) -> AIReport {
+        AIReport(
+            id: id,
+            leagueId: "L1",
+            reportType: type,
+            period: period,
+            bodyMarkdown: "## Recap\nBody.",
+            metadata: [:],
+            createdAt: createdAt,
+            model: "claude-haiku-4-5",
+            promptVersion: "f0-2026-05-21"
+        )
+    }
+
+    // MARK: - Test 1: matches a single postDraft report for the year
+
+    func testMatchingReport_singlePostDraft_returnsIt() {
+        let report = makeReport(
+            id: "L1|REPORT#postDraft#2026",
+            type: .postDraft,
+            period: "2026"
+        )
+
+        let match = DraftRecapView.matchingReport(in: [report], year: "2026")
+
+        XCTAssertNotNil(match)
+        XCTAssertEqual(match?.id, report.id)
+    }
+
+    // MARK: - Test 2: picks the right year when multiple postDraft reports exist
+
+    func testMatchingReport_multipleYears_filtersToSelected() {
+        let r2024 = makeReport(
+            id: "L1|REPORT#postDraft#2024",
+            type: .postDraft,
+            period: "2024"
+        )
+        let r2025 = makeReport(
+            id: "L1|REPORT#postDraft#2025",
+            type: .postDraft,
+            period: "2025"
+        )
+        let r2026 = makeReport(
+            id: "L1|REPORT#postDraft#2026",
+            type: .postDraft,
+            period: "2026"
+        )
+        // Archive is newest-first per the store contract.
+        let archive = [r2026, r2025, r2024]
+
+        let match = DraftRecapView.matchingReport(in: archive, year: "2025")
+
+        XCTAssertEqual(match?.id, r2025.id)
+    }
+
+    // MARK: - Test 3: returns nil when no postDraft reports exist
+
+    func testMatchingReport_onlyWeeklyReports_returnsNil() {
+        let weekly = makeReport(
+            id: "L1|REPORT#weekly#2026W04",
+            type: .weekly,
+            period: "2026W04"
+        )
+
+        let match = DraftRecapView.matchingReport(in: [weekly], year: "2026")
+
+        XCTAssertNil(match)
+    }
+
+    // MARK: - Test 4: returns the first (newest) when duplicates exist
+
+    func testMatchingReport_duplicatePostDraftSameYear_returnsFirst() {
+        let newer = makeReport(
+            id: "L1|REPORT#postDraft#2026-v2",
+            type: .postDraft,
+            period: "2026",
+            createdAt: Date()
+        )
+        let older = makeReport(
+            id: "L1|REPORT#postDraft#2026-v1",
+            type: .postDraft,
+            period: "2026",
+            createdAt: Date(timeIntervalSinceNow: -86400)
+        )
+        // Archive is newest-first sorted upstream.
+        let archive = [newer, older]
+
+        let match = DraftRecapView.matchingReport(in: archive, year: "2026")
+
+        XCTAssertEqual(match?.id, newer.id)
+    }
+
+    // MARK: - Test 5: substring match works for period strings like "2026-POSTDRAFT"
+
+    func testMatchingReport_periodWithSuffix_stillMatches() {
+        let report = makeReport(
+            id: "L1|REPORT#postDraft#2026-POSTDRAFT",
+            type: .postDraft,
+            period: "2026-POSTDRAFT"
+        )
+
+        let match = DraftRecapView.matchingReport(in: [report], year: "2026")
+
+        XCTAssertEqual(match?.id, report.id)
+    }
+
+    // MARK: - Test 6: empty year returns nil (defensive)
+
+    func testMatchingReport_emptyYear_returnsNil() {
+        let report = makeReport(
+            id: "L1|REPORT#postDraft#2026",
+            type: .postDraft,
+            period: "2026"
+        )
+
+        let match = DraftRecapView.matchingReport(in: [report], year: "")
+
+        XCTAssertNil(match)
+    }
+
+    // MARK: - Test 7: empty archive returns nil
+
+    func testMatchingReport_emptyArchive_returnsNil() {
+        let match = DraftRecapView.matchingReport(in: [], year: "2026")
+        XCTAssertNil(match)
+    }
+}

--- a/XomperTests/DraftSubTabSelectionTests.swift
+++ b/XomperTests/DraftSubTabSelectionTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import Xomper
+
+/// Tests for the per-season sub-tab list logic on the Draft surface
+/// (Season Refocus F3). The helper lives in `DraftSubTabSelection` so
+/// tests can drive it without materializing the view.
+final class DraftSubTabSelectionTests: XCTestCase {
+
+    // MARK: - Current season → Live / Mocks / Recap
+
+    func testAvailableSubTabs_currentSeason_returnsLiveMocksRecap() {
+        let tabs = DraftSubTabSelection.availableSubTabs(isCurrentSeason: true)
+        XCTAssertEqual(tabs, [.live, .mocks, .recap])
+    }
+
+    // MARK: - Past season → Picks / Recap
+
+    func testAvailableSubTabs_pastSeason_returnsPicksRecap() {
+        let tabs = DraftSubTabSelection.availableSubTabs(isCurrentSeason: false)
+        XCTAssertEqual(tabs, [.picks, .recap])
+    }
+
+    // MARK: - Default sub-tab
+
+    func testDefaultSubTab_currentSeason_isLive() {
+        XCTAssertEqual(
+            DraftSubTabSelection.defaultSubTab(isCurrentSeason: true),
+            .live
+        )
+    }
+
+    func testDefaultSubTab_pastSeason_isPicks() {
+        XCTAssertEqual(
+            DraftSubTabSelection.defaultSubTab(isCurrentSeason: false),
+            .picks
+        )
+    }
+
+    // MARK: - Default sub-tab is always in the available list
+
+    func testDefaultSubTab_isInAvailableList_currentSeason() {
+        let tabs = DraftSubTabSelection.availableSubTabs(isCurrentSeason: true)
+        let def = DraftSubTabSelection.defaultSubTab(isCurrentSeason: true)
+        XCTAssertTrue(tabs.contains(def))
+    }
+
+    func testDefaultSubTab_isInAvailableList_pastSeason() {
+        let tabs = DraftSubTabSelection.availableSubTabs(isCurrentSeason: false)
+        let def = DraftSubTabSelection.defaultSubTab(isCurrentSeason: false)
+        XCTAssertTrue(tabs.contains(def))
+    }
+
+    // MARK: - Sub-tab labels (sanity)
+
+    func testSubTabLabels_areHumanReadable() {
+        XCTAssertEqual(DraftSubTab.live.label, "Live")
+        XCTAssertEqual(DraftSubTab.mocks.label, "Mocks")
+        XCTAssertEqual(DraftSubTab.recap.label, "Recap")
+        XCTAssertEqual(DraftSubTab.picks.label, "Picks")
+    }
+}


### PR DESCRIPTION
## Summary

Restructures the Draft tab (legacy `.draftHistory` tray case) around per-year sub-tabs driven by the existing `HeaderBar` season chip + `SeasonStore`:

- **Current season** → Live / Mocks / Recap
- **Past seasons** → Picks / Recap

Live + Mocks were extracted out of `DraftOrderView`. That view is now single-purpose — it only renders the **Reverse-HPP Proposal**. No internal segmented control. `DraftOrderViewMode` enum deleted.

Recap is a new sub-tab that lazy-loads `aiReviewStore.archive` and renders the most recent `postDraft` AI report for the selected year as inline markdown (matches `AIReviewDetailView.bodyCard`). Empty state with year-specific copy when no matching report exists.

Sub-tab selection resets to the mode's default (`.live` / `.picks`) when the season chip swaps current ↔ past, so users never land on an unavailable tab.

Legacy names preserved with explanatory comments:
- `TrayDestination.draftHistory` enum case
- `Features/DraftHistory/` directory

Part of the [Season Refocus epic](docs/features/season-refocus/EPIC_PLAN.md). Follows F1 (tray label) and F2 (Landing card deep-link).

Plan: `docs/features/season-refocus/f3-draft-tab/PLAN.md`

## Files

**New (6):**
- `Xomper/Features/DraftHistory/Draft/DraftSubTabBar.swift` — pill segmented control + `DraftSubTab` enum + `DraftSubTabSelection` helpers
- `Xomper/Features/DraftHistory/Draft/LiveDraftView.swift` — extracted verbatim from pre-F3 `DraftOrderView.liveContent`
- `Xomper/Features/DraftHistory/Draft/MocksView.swift` — extracted placeholder
- `Xomper/Features/DraftHistory/Draft/DraftRecapView.swift` — inline markdown render of postDraft AI report
- `XomperTests/DraftRecapResolverTests.swift` — 7 tests on the period filter helper
- `XomperTests/DraftSubTabSelectionTests.swift` — 7 tests on the sub-tab list helper

**Modified (4):**
- `Xomper/Features/DraftHistory/DraftHistoryView.swift` — orchestrator: routes between Live / Mocks / Recap / Picks based on `isCurrentSeason`
- `Xomper/Features/DraftOrder/DraftOrderView.swift` — stripped to proposal-only; removed `viewMode`, `viewModeBar`, all live/mocks helpers, `DraftOrderViewMode` enum, and the `nflStateStore` parameter (no longer needed)
- `Xomper/Features/Shell/MainShell.swift` — passes `aiReviewStore` into both `.draftHistory` call sites; drops `nflStateStore` from `DraftOrderView` constructor
- `Xomper/Features/Shell/TrayDestination.swift` — legacy-name comment on `.draftHistory`

## Test plan

- [x] `xcodegen generate` succeeds
- [x] Build for iPhone 17 Pro simulator — clean, no warnings
- [x] `XomperTests` all green (54 tests, +14 new)
- [ ] Manual QA: 2026 → see Live / Mocks / Recap sub-tabs
- [ ] Manual QA: switch to 2025 → sub-tabs collapse to Picks / Recap
- [ ] Manual QA: switch to 2024 → same as 2025
- [ ] Manual QA: Live sub-tab renders upcoming-draft slot order with start time + 1-day-per-pick pace
- [ ] Manual QA: Mocks sub-tab renders the "Mock Drafts Coming Soon" placeholder
- [ ] Manual QA: Recap sub-tab renders empty state on 2026 (no report yet) and the markdown body if 2025 backfill lands
- [ ] Manual QA: Pull-to-refresh on Recap reloads the AI archive
- [ ] Manual QA: Draft Order Proposal tray entry shows only the Reverse-HPP proposal — no segmented control at top
- [ ] Manual QA: Season chip change while on a sub-tab resets to the new mode's default
- [ ] Manual QA: No regressions in Matchups, Matchup History, Payouts (all share the season chip)