### PR TITLE
feat(season-refocus F4): Standings live-only + new Archive tray destination

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		189F79187B5D4D5686909B2F /* AIReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A95FE8DD123C85CA39DAE13 /* AIReport.swift */; };
 		194BED1749B3F623C8D732DE /* XomperColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82B0FEAAB9BC80BA0801E98 /* XomperColors.swift */; };
 		1A9D12F3D247BD472801D26D /* XomperApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8BD31456E25771C8D7D39C9 /* XomperApp.swift */; };
+		1AB96323B0D6E48838903DF6 /* PastStandingsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2B7884F65B1BD0E9B82AA9 /* PastStandingsListView.swift */; };
+		1AFF6ACF05FD9FC1D186C5A8 /* StandingsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34E8D4C4B1A29FC412EBA41 /* StandingsListView.swift */; };
 		1C4049A62CC4A443AC38E464 /* Draft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */; };
 		1D279CC4379E6F068F2615DE /* RuleProposalFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B6C68E1131F2BBBE625DEAF /* RuleProposalFormView.swift */; };
 		1D74425C19EE5C00589214C3 /* TaxiSquadPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2DA1B65780757E6CC78CD61 /* TaxiSquadPlayer.swift */; };
@@ -44,6 +46,7 @@
 		427F23653F78A52108C55692 /* XomperLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3B178733D5AF9EB7DA7189 /* XomperLoader.swift */; };
 		42BF3DEE63074148F1DF0BD1 /* AIReviewDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967DCE922FE090CE4F067587 /* AIReviewDetailView.swift */; };
 		42E7DDAD3454512247E1AFA6 /* ProposedTrade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4690614F644FE74115D0DAB6 /* ProposedTrade.swift */; };
+		42F9C81AF6338A720FE0BC12 /* ArchiveNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E65C159F2C84E48B61A9A8 /* ArchiveNavigationTests.swift */; };
 		440A44095AD70A8D3D273EEE /* StandingsScrollBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1A7B1219575171DA3ABAB7 /* StandingsScrollBar.swift */; };
 		4A321187068EEBA8C4E75EFE /* PayoutProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E3BE36BCEA1A7722157C37 /* PayoutProjection.swift */; };
 		4B629DB100C96EB68A6A9A41 /* SearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323F422F2D0E1C2BA5D46C0A /* SearchResults.swift */; };
@@ -56,6 +59,7 @@
 		578172B9CCF7AD92CB66821E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D61F12E32D7C81FCA8F8CE /* ContentView.swift */; };
 		57C17293587E8DBED9A14970 /* TradedPick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F49969EE42BDE6462664021 /* TradedPick.swift */; };
 		58FD67DB9B137F1A8BE50521 /* TeamAnalyzerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8098F78566BB324ACC70FB94 /* TeamAnalyzerView.swift */; };
+		5BAA65DF5DF710DCBAAC2BF8 /* StandingsOffseasonCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6C6489A04EC9CA00FFBD0F /* StandingsOffseasonCard.swift */; };
 		5C041F847E3239901238FD5F /* LandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7048EDD875E2582C792BE47 /* LandingView.swift */; };
 		6010F16122E110BA50642611 /* CareerStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD43D54AB620DABD559F8A40 /* CareerStats.swift */; };
 		602B6E0F6BCF1DA7E3D75F07 /* AuthStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */; };
@@ -94,6 +98,7 @@
 		95DE1C46E20BF6910D4E5447 /* TrayItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E4EC7FDB93C47A9EE601BA3 /* TrayItem.swift */; };
 		98D5EE595D14742780A47B81 /* ThisWeekMatchupsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C921F3EC29B03A85D9F2A42C /* ThisWeekMatchupsCard.swift */; };
 		98F895FBCECB23325658339C /* StandingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A47FD1CF3BE7AE0B940DEC /* StandingsView.swift */; };
+		9B5472B757330119136683F1 /* PastDraftPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806CFC3CC188242F06D8639C /* PastDraftPickerView.swift */; };
 		9D9E8D2C4A8A0C623AC1EF0D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E767CD5492176E84C2092B0F /* AppDelegate.swift */; };
 		9E5C71DAB504EDCDF2084DF3 /* MyProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558164667DF7D89C4DF2F32E /* MyProfileView.swift */; };
 		A0F4E9BCA7E5D757DE8BE5B3 /* AIReviewStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08BD215787E2BFC1C57E7E7E /* AIReviewStoreTests.swift */; };
@@ -123,8 +128,10 @@
 		D09FC43EBE71A0DFF28B83D2 /* MatchupDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F2C7D74B3584D53CE601054 /* MatchupDetailView.swift */; };
 		D106F60A597D780F32FFA5E8 /* Matchup.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83EF3C6C93199CF3FCBAE42 /* Matchup.swift */; };
 		D107A9FEAF17BE9FCEA44958 /* LiveDraftView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04B5251715A37E924DF7CEF /* LiveDraftView.swift */; };
+		D1F778B07CC0F05640F72142 /* ArchiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AA9304E883FF9B1D42EB60 /* ArchiveView.swift */; };
 		D78D5302B3D17DE9BE7D557C /* AuthGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5E661424C55F695BF96281 /* AuthGateView.swift */; };
 		D7A95C32621E03E2AAB37327 /* TaxiStealConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66A2C896FE4C62CF9719D7A /* TaxiStealConfirmView.swift */; };
+		D9737CEB4C36AEFB5EC727D0 /* PastStandingsArchiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC1E989411B5FACF30C4B3A /* PastStandingsArchiveTests.swift */; };
 		E0951007574761D3F51B21B9 /* DraftSubTabSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7456E9AFD3FA47DA3DA0F7 /* DraftSubTabSelectionTests.swift */; };
 		E1D933F9B0C3E87F9C1C907A /* XomperAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89FC018282A1F1D8B2FD1B60 /* XomperAPIClient.swift */; };
 		E2E0551B857C17254E9B789B /* AdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E257076F7FE641947D1DC978 /* AdminView.swift */; };
@@ -133,6 +140,7 @@
 		F201A3A40D624F6AAA0C0CC1 /* PlayoffBracket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */; };
 		F57132F0D80EAB60AC0E07F3 /* WhitelistedLeague.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747C6FC769C117588F8A93E /* WhitelistedLeague.swift */; };
 		F5AD059EF52A068C469AFB6E /* URL+Sleeper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2452A5AEC270BE14CC085E1 /* URL+Sleeper.swift */; };
+		F5FB358418D7528D863DEA8E /* HistoricalStandingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46DB1025586B733C289B45A3 /* HistoricalStandingsView.swift */; };
 		F66FCFE7466291137B314370 /* HighestPossibleLineup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 765C03E7E4268373F28754DC /* HighestPossibleLineup.swift */; };
 		F7E0A8B9AECD0291527E0D0E /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F46A0AAE61A4E963BB15B0 /* SearchView.swift */; };
 		F9A37723FE37F4C30D46D6E1 /* PressableCardButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FB63BCA4BDD437FFE6D3A8 /* PressableCardButtonStyle.swift */; };
@@ -154,9 +162,11 @@
 		01A3969B9E9E60F0C59D83C9 /* MatchupHistoryBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupHistoryBrowserView.swift; sourceTree = "<group>"; };
 		08BD215787E2BFC1C57E7E7E /* AIReviewStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewStoreTests.swift; sourceTree = "<group>"; };
 		09DF8F2FE857C55AFB1C1205 /* NFLTeamColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFLTeamColors.swift; sourceTree = "<group>"; };
+		0BC1E989411B5FACF30C4B3A /* PastStandingsArchiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastStandingsArchiveTests.swift; sourceTree = "<group>"; };
 		10CD226D313FDD91E4037D8E /* SupabaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseManager.swift; sourceTree = "<group>"; };
 		18383A0375F5728A9E3FE065 /* Championship.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Championship.swift; sourceTree = "<group>"; };
 		1AD376EFB7AD4A192FAB3E8F /* RecordBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordBadge.swift; sourceTree = "<group>"; };
+		1D6C6489A04EC9CA00FFBD0F /* StandingsOffseasonCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsOffseasonCard.swift; sourceTree = "<group>"; };
 		1FBB5433786555EDDBC896C7 /* XomperTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperTheme.swift; sourceTree = "<group>"; };
 		22A99CAA9B57C1A0144DCA22 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 		22D61F12E32D7C81FCA8F8CE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -168,6 +178,7 @@
 		36A01820FD0F6643BBF8511D /* TeamStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamStore.swift; sourceTree = "<group>"; };
 		3728C5F6BEF61FE509A3EA32 /* ClinchCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClinchCalculator.swift; sourceTree = "<group>"; };
 		3747C6FC769C117588F8A93E /* WhitelistedLeague.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhitelistedLeague.swift; sourceTree = "<group>"; };
+		37E65C159F2C84E48B61A9A8 /* ArchiveNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveNavigationTests.swift; sourceTree = "<group>"; };
 		3A51BC6B9389405FE754DCEB /* AIReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewView.swift; sourceTree = "<group>"; };
 		3E4EC7FDB93C47A9EE601BA3 /* TrayItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayItem.swift; sourceTree = "<group>"; };
 		42C8A3FA617E9FEB48852C45 /* Profile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
@@ -179,6 +190,7 @@
 		45B52D5FD69B62417928B713 /* MatchupHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupHistory.swift; sourceTree = "<group>"; };
 		460030AF84E8D0E83D8F5896 /* Xomper.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Xomper.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4690614F644FE74115D0DAB6 /* ProposedTrade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProposedTrade.swift; sourceTree = "<group>"; };
+		46DB1025586B733C289B45A3 /* HistoricalStandingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoricalStandingsView.swift; sourceTree = "<group>"; };
 		501B8FD2B915B3BD6568F42C /* HexagonChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HexagonChartView.swift; sourceTree = "<group>"; };
 		50D86A1E276C98E0A3D5070F /* MocksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MocksView.swift; sourceTree = "<group>"; };
 		536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthStore.swift; sourceTree = "<group>"; };
@@ -188,6 +200,7 @@
 		581D4F6F3EB8FC0547F49927 /* PlayoffBracketView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayoffBracketView.swift; sourceTree = "<group>"; };
 		58ED7387DCA3E1DC5CDD7AFF /* AdminStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStoreTests.swift; sourceTree = "<group>"; };
 		5CE99E9B095120FB6636FC8A /* PlayerValuesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerValuesStore.swift; sourceTree = "<group>"; };
+		5E2B7884F65B1BD0E9B82AA9 /* PastStandingsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastStandingsListView.swift; sourceTree = "<group>"; };
 		5EABD25CAB8BF973C4709720 /* AppRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRouter.swift; sourceTree = "<group>"; };
 		5FDC8A9B02A2BFD83398D04F /* RulesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesStore.swift; sourceTree = "<group>"; };
 		62948D0A455E7CE99B15CB75 /* UserStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStore.swift; sourceTree = "<group>"; };
@@ -206,6 +219,7 @@
 		765C03E7E4268373F28754DC /* HighestPossibleLineup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighestPossibleLineup.swift; sourceTree = "<group>"; };
 		7839DD9CF0968986F91A58DB /* AdminStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStore.swift; sourceTree = "<group>"; };
 		7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Draft.swift; sourceTree = "<group>"; };
+		806CFC3CC188242F06D8639C /* PastDraftPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastDraftPickerView.swift; sourceTree = "<group>"; };
 		8098F78566BB324ACC70FB94 /* TeamAnalyzerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamAnalyzerView.swift; sourceTree = "<group>"; };
 		831DFA7D391F8415451D6479 /* DraftSubTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftSubTabBar.swift; sourceTree = "<group>"; };
 		840D50097382434B0D123ACB /* NavigationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStore.swift; sourceTree = "<group>"; };
@@ -222,6 +236,7 @@
 		9B7C85CB880ABD7D373E49A6 /* RuleProposal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleProposal.swift; sourceTree = "<group>"; };
 		9E94170F987E8EFE5C566B9B /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		9F49969EE42BDE6462664021 /* TradedPick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradedPick.swift; sourceTree = "<group>"; };
+		A2AA9304E883FF9B1D42EB60 /* ArchiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveView.swift; sourceTree = "<group>"; };
 		A2DA1B65780757E6CC78CD61 /* TaxiSquadPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiSquadPlayer.swift; sourceTree = "<group>"; };
 		A5DA384F46CEDA38C9898C14 /* DraftRecapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftRecapView.swift; sourceTree = "<group>"; };
 		A789B8D49FA4430886626289 /* DraftHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftHistory.swift; sourceTree = "<group>"; };
@@ -250,6 +265,7 @@
 		CC3F6B5022E8151683A45F4F /* PlayerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerStore.swift; sourceTree = "<group>"; };
 		CEAEC7A4917990425085AE71 /* PushNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationManager.swift; sourceTree = "<group>"; };
 		D12507ED13C57EFA8B240301 /* AIReviewHomeCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewHomeCard.swift; sourceTree = "<group>"; };
+		D34E8D4C4B1A29FC412EBA41 /* StandingsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsListView.swift; sourceTree = "<group>"; };
 		D36829F2AD0FD089788B9CE1 /* PlayerPointsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerPointsStore.swift; sourceTree = "<group>"; };
 		D7F3E6606D89CF3AEB320314 /* LandingViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingViewTests.swift; sourceTree = "<group>"; };
 		D7F3F1A18F4EEC5A3F81FD28 /* SeasonStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonStore.swift; sourceTree = "<group>"; };
@@ -358,6 +374,7 @@
 			children = (
 				DC10CB585B73997726A6710A /* Admin */,
 				B3EF58FFFA675A9DE32C8394 /* AIReview */,
+				3C29598BAFCE2A7B5540394F /* Archive */,
 				390D24DCB17100460C0E682A /* Auth */,
 				EB7304EC920FBEC53F6E4CEB /* DraftHistory */,
 				680358FA986CFA519A36A85D /* DraftOrder */,
@@ -409,12 +426,25 @@
 				58ED7387DCA3E1DC5CDD7AFF /* AdminStoreTests.swift */,
 				6CFEC46AB65E6E7A90E0A695 /* AdminStoreWeeklyTests.swift */,
 				08BD215787E2BFC1C57E7E7E /* AIReviewStoreTests.swift */,
+				37E65C159F2C84E48B61A9A8 /* ArchiveNavigationTests.swift */,
 				B3893B13276074EF6033CEA2 /* ClinchCalculatorTests.swift */,
 				2DB0B979B62A1CF6EB80417F /* DraftRecapResolverTests.swift */,
 				ED7456E9AFD3FA47DA3DA0F7 /* DraftSubTabSelectionTests.swift */,
 				D7F3E6606D89CF3AEB320314 /* LandingViewTests.swift */,
+				0BC1E989411B5FACF30C4B3A /* PastStandingsArchiveTests.swift */,
 			);
 			path = XomperTests;
+			sourceTree = "<group>";
+		};
+		3C29598BAFCE2A7B5540394F /* Archive */ = {
+			isa = PBXGroup;
+			children = (
+				A2AA9304E883FF9B1D42EB60 /* ArchiveView.swift */,
+				46DB1025586B733C289B45A3 /* HistoricalStandingsView.swift */,
+				806CFC3CC188242F06D8639C /* PastDraftPickerView.swift */,
+				5E2B7884F65B1BD0E9B82AA9 /* PastStandingsListView.swift */,
+			);
+			path = Archive;
 			sourceTree = "<group>";
 		};
 		3E62B7EC555EA6961ADE3151 /* Team */ = {
@@ -435,6 +465,8 @@
 				581D4F6F3EB8FC0547F49927 /* PlayoffBracketView.swift */,
 				2B6C68E1131F2BBBE625DEAF /* RuleProposalFormView.swift */,
 				C9382BCB18DFEB416A50A039 /* RulesView.swift */,
+				D34E8D4C4B1A29FC412EBA41 /* StandingsListView.swift */,
+				1D6C6489A04EC9CA00FFBD0F /* StandingsOffseasonCard.swift */,
 				E6A47FD1CF3BE7AE0B940DEC /* StandingsView.swift */,
 				44F83A5F997AF6E13C98660E /* WorldCupView.swift */,
 			);
@@ -798,10 +830,12 @@
 				A45E9B6A2A65059251FB3D76 /* AdminStorePreseasonTests.swift in Sources */,
 				37E600A31B5AA5DA5A766692 /* AdminStoreTests.swift in Sources */,
 				6D9C0E43C329D80ED8933AD2 /* AdminStoreWeeklyTests.swift in Sources */,
+				42F9C81AF6338A720FE0BC12 /* ArchiveNavigationTests.swift in Sources */,
 				02AC6FBAE68011749AA17644 /* ClinchCalculatorTests.swift in Sources */,
 				2BE0B9AB9BAEFD6AA714D2EF /* DraftRecapResolverTests.swift in Sources */,
 				E0951007574761D3F51B21B9 /* DraftSubTabSelectionTests.swift in Sources */,
 				007B11207486956897981421 /* LandingViewTests.swift in Sources */,
+				D9737CEB4C36AEFB5EC727D0 /* PastStandingsArchiveTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -819,6 +853,7 @@
 				0A87A5226863819FF3884F6C /* AnnouncementsCard.swift in Sources */,
 				9D9E8D2C4A8A0C623AC1EF0D /* AppDelegate.swift in Sources */,
 				8C67D3AAFE5A0A124BDE5F1A /* AppRouter.swift in Sources */,
+				D1F778B07CC0F05640F72142 /* ArchiveView.swift in Sources */,
 				D78D5302B3D17DE9BE7D557C /* AuthGateView.swift in Sources */,
 				602B6E0F6BCF1DA7E3D75F07 /* AuthStore.swift in Sources */,
 				C1D86EAE02F0D6EA70291876 /* AvatarView.swift in Sources */,
@@ -845,6 +880,7 @@
 				BFAF90EB6F36235274ECB2DC /* HeadlineAIReportCard.swift in Sources */,
 				C21992E2FA476C65D8D23BA8 /* HexagonChartView.swift in Sources */,
 				F66FCFE7466291137B314370 /* HighestPossibleLineup.swift in Sources */,
+				F5FB358418D7528D863DEA8E /* HistoricalStandingsView.swift in Sources */,
 				063FCD6AA342CA5D64ED79ED /* HistoryStore.swift in Sources */,
 				5C041F847E3239901238FD5F /* LandingView.swift in Sources */,
 				114998283E6705D075ED2CA7 /* League.swift in Sources */,
@@ -868,6 +904,8 @@
 				021A039E220940CD2E12304A /* NavigationStore.swift in Sources */,
 				7E34464209AAF9EC6801191A /* NflState.swift in Sources */,
 				CF4CEF4E2FE7A891950A2E17 /* NflStateStore.swift in Sources */,
+				9B5472B757330119136683F1 /* PastDraftPickerView.swift in Sources */,
+				1AB96323B0D6E48838903DF6 /* PastStandingsListView.swift in Sources */,
 				4A321187068EEBA8C4E75EFE /* PayoutProjection.swift in Sources */,
 				31CFADD9ECC5AC0D09B24BCF /* PayoutsView.swift in Sources */,
 				C9D656F4702A3483BB8E970C /* Player.swift in Sources */,
@@ -898,6 +936,8 @@
 				BB91E92DC29E6ECA5E1F0DEC /* SeasonStore.swift in Sources */,
 				77CFB7F9C5E4975E6350662B /* SettingsView.swift in Sources */,
 				65DC95B6907B22347616C3D7 /* SleeperAPIClient.swift in Sources */,
+				1AFF6ACF05FD9FC1D186C5A8 /* StandingsListView.swift in Sources */,
+				5BAA65DF5DF710DCBAAC2BF8 /* StandingsOffseasonCard.swift in Sources */,
 				440A44095AD70A8D3D273EEE /* StandingsScrollBar.swift in Sources */,
 				B48B9F6061A67CFC74A096CC /* StandingsStore.swift in Sources */,
 				7607DB7C775FCCC3B7C3377B /* StandingsTeam.swift in Sources */,

--- a/Xomper/Features/Archive/ArchiveView.swift
+++ b/Xomper/Features/Archive/ArchiveView.swift
@@ -1,0 +1,176 @@
+import SwiftUI
+
+/// Root of the Archive tray destination. A single scrolling page composed of
+/// three cards that hub the league's historical surfaces:
+///
+/// - **Past Standings** — pushes a per-year list; rows render historical
+///   standings reconstructed from `MatchupHistoryRecord`s.
+/// - **Past Matchup History** — switches the top-level destination to
+///   `.matchupHistory` (reuses the existing browser surface).
+/// - **Past Drafts** — pushes a year picker that sets the shared
+///   `SeasonStore.selectedSeason` then switches to `.draftHistory`, landing
+///   the Draft tab on the chosen prior year via F3's sub-tab UI.
+///
+/// Lazy-loads matchup + draft history on first appearance when the store is
+/// empty so the cards have something to drill into when the user navigates
+/// here cold.
+struct ArchiveView: View {
+    let navStore: NavigationStore
+    let router: AppRouter
+    let historyStore: HistoryStore
+    let leagueStore: LeagueStore
+    let authStore: AuthStore
+    let teamStore: TeamStore
+    let seasonStore: SeasonStore
+
+    var body: some View {
+        Group {
+            if isEmpty {
+                EmptyStateView(
+                    icon: "archivebox",
+                    title: "No archive yet",
+                    message: "Past seasons appear here once they're loaded."
+                )
+            } else {
+                cards
+            }
+        }
+        .background(XomperColors.bgDark)
+        .task {
+            await ensureLoaded()
+        }
+    }
+
+    // MARK: - Cards
+
+    private var cards: some View {
+        ScrollView {
+            VStack(spacing: XomperTheme.Spacing.md) {
+                ArchiveHubCard(
+                    icon: "list.number",
+                    title: "Past Standings",
+                    subtitle: "Final regular-season records by year",
+                    action: {
+                        router.navigate(to: .archivePastStandings)
+                    }
+                )
+
+                ArchiveHubCard(
+                    icon: "clock.arrow.circlepath",
+                    title: "Past Matchup History",
+                    subtitle: "Weekly results from prior seasons",
+                    action: {
+                        navStore.select(.matchupHistory, router: router)
+                    }
+                )
+
+                ArchiveHubCard(
+                    icon: "list.clipboard.fill",
+                    title: "Past Drafts",
+                    subtitle: "Pick boards from previous years",
+                    action: {
+                        router.navigate(to: .archivePastDraftPicker)
+                    }
+                )
+            }
+            .padding(.horizontal, XomperTheme.Spacing.md)
+            .padding(.vertical, XomperTheme.Spacing.sm)
+        }
+    }
+
+    // MARK: - Empty / load
+
+    /// Archive is "empty" when we have neither matchup nor draft history.
+    /// Drafts may exist without matchups (and vice versa) — either is enough
+    /// to surface meaningful cards.
+    private var isEmpty: Bool {
+        historyStore.matchupHistory.isEmpty && historyStore.draftHistory.isEmpty
+    }
+
+    /// Best-effort lazy fetch. Only fires when the underlying store is empty
+    /// so re-visits don't refetch. Both loads run in parallel and tolerate
+    /// failure — the empty-state view will simply persist.
+    private func ensureLoaded() async {
+        guard isEmpty else { return }
+        // Make sure we have a league chain before asking history to load.
+        if leagueStore.leagueChain.isEmpty,
+           let leagueId = leagueStore.myLeague?.leagueId {
+            await leagueStore.loadLeagueChain(startingFrom: leagueId)
+        }
+        let chain = leagueStore.leagueChain
+        guard !chain.isEmpty else { return }
+
+        async let matchups: () = historyStore.loadMatchupHistory(chain: chain)
+        async let drafts:   () = historyStore.loadDraftHistory(chain: chain)
+        _ = await (matchups, drafts)
+    }
+}
+
+// MARK: - Card chrome
+
+/// Single archive hub card. Matches the `pressableCard` button-style + rounded
+/// `bgCard` chrome used by other Landing/League cards so the page feels of-a-piece.
+private struct ArchiveHubCard: View {
+    let icon: String
+    let title: String
+    let subtitle: String
+    let action: () -> Void
+
+    var body: some View {
+        Button {
+            let generator = UIImpactFeedbackGenerator(style: .light)
+            generator.impactOccurred()
+            action()
+        } label: {
+            HStack(spacing: XomperTheme.Spacing.md) {
+                Image(systemName: icon)
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(XomperColors.championGold)
+                    .frame(width: 36, alignment: .center)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+                    Text(title)
+                        .font(.headline)
+                        .foregroundStyle(XomperColors.textPrimary)
+                        .multilineTextAlignment(.leading)
+
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(XomperColors.textSecondary)
+                        .multilineTextAlignment(.leading)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.bold))
+                    .foregroundStyle(XomperColors.textMuted)
+                    .accessibilityHidden(true)
+            }
+            .padding(XomperTheme.Spacing.md)
+            .frame(minHeight: XomperTheme.minTouchTarget)
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+            .xomperShadow(.sm)
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title). \(subtitle).")
+        .accessibilityHint("Double tap to open")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ArchiveView(
+            navStore: NavigationStore(),
+            router: AppRouter(),
+            historyStore: HistoryStore(),
+            leagueStore: LeagueStore(),
+            authStore: AuthStore(),
+            teamStore: TeamStore(),
+            seasonStore: SeasonStore()
+        )
+    }
+    .preferredColorScheme(.dark)
+}

--- a/Xomper/Features/Archive/HistoricalStandingsView.swift
+++ b/Xomper/Features/Archive/HistoricalStandingsView.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+/// Renders one prior season's standings by reconstructing it from cached
+/// `MatchupHistoryRecord`s via `StandingsBuilder.buildStandingsFromHistory`.
+/// Same renderer (`StandingsListView`) as the live league view, so the row
+/// layout / sort / accessibility all match.
+///
+/// v1 limits, all called out in the F4 plan:
+/// - **No division view**: past-year league metadata isn't cached alongside
+///   matchups, so divisions are suppressed (`hasDivisions = false`).
+/// - **No tappable rows**: historical roster ids don't resolve to the live
+///   `TeamStore`. Both row-tap and profile-context-menu closures are no-ops.
+/// - **No playoff cutoff line**: same metadata gap.
+struct HistoricalStandingsView: View {
+    let year: String
+    let historyStore: HistoryStore
+    let leagueStore: LeagueStore
+    let authStore: AuthStore
+    let teamStore: TeamStore
+    let router: AppRouter
+
+    @State private var standings: [StandingsTeam] = []
+
+    var body: some View {
+        Group {
+            if standings.isEmpty {
+                EmptyStateView(
+                    icon: "list.number",
+                    title: "No data for \(year)",
+                    message: "Pull to refresh from Matchup History to load this season."
+                )
+            } else {
+                StandingsListView(
+                    standings: standings,
+                    hasDivisions: false,
+                    divisionStandings: [:],
+                    playoffCutoff: nil,
+                    myUserId: authStore.sleeperUserId,
+                    onTeamTap: { _ in },
+                    onProfileTap: { _ in }
+                )
+            }
+        }
+        .background(XomperColors.bgDark)
+        .navigationTitle("\(year) Standings")
+        .navigationBarTitleDisplayMode(.large)
+        .task(id: year) {
+            rebuild()
+        }
+    }
+
+    // MARK: - Build
+
+    private func rebuild() {
+        let records = historyStore.matchups(forSeason: year)
+        standings = StandingsBuilder.buildStandingsFromHistory(records: records)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        HistoricalStandingsView(
+            year: "2024",
+            historyStore: HistoryStore(),
+            leagueStore: LeagueStore(),
+            authStore: AuthStore(),
+            teamStore: TeamStore(),
+            router: AppRouter()
+        )
+    }
+    .preferredColorScheme(.dark)
+}

--- a/Xomper/Features/Archive/PastDraftPickerView.swift
+++ b/Xomper/Features/Archive/PastDraftPickerView.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+/// Year picker pushed from `ArchiveView`'s "Past Drafts" card. Lists every
+/// past season we have draft history loaded for (excluding the current NFL
+/// season — that's already reachable directly from the Draft tab). Selecting
+/// a row sets the shared `SeasonStore.selectedSeason` and switches the
+/// top-level destination to `.draftHistory`, dropping the user on F3's
+/// per-year sub-tabs for that season.
+///
+/// Side effect note (also called out in the F4 plan): mutating
+/// `SeasonStore.selectedSeason` is global — Matchups / World Cup / etc. will
+/// also reflect the new year until the user changes it back via the header
+/// chip. Same caveat any other in-app season switch has.
+struct PastDraftPickerView: View {
+    let historyStore: HistoryStore
+    let seasonStore: SeasonStore
+    let navStore: NavigationStore
+    let router: AppRouter
+
+    /// Optional — used to filter the current NFL season out of the list. F3's
+    /// Draft tab handles the current season as its default view, so the
+    /// Archive picker stays focused on past years.
+    let currentSeason: String
+
+    var body: some View {
+        Group {
+            if years.isEmpty {
+                EmptyStateView(
+                    icon: "list.clipboard",
+                    title: "No past drafts loaded",
+                    message: "Open the Draft tab once to populate the archive."
+                )
+            } else {
+                ScrollView {
+                    VStack(spacing: XomperTheme.Spacing.sm) {
+                        ForEach(years, id: \.self) { year in
+                            yearRow(year)
+                        }
+                    }
+                    .padding(.horizontal, XomperTheme.Spacing.md)
+                    .padding(.vertical, XomperTheme.Spacing.sm)
+                }
+            }
+        }
+        .background(XomperColors.bgDark)
+        .navigationTitle("Past Drafts")
+        .navigationBarTitleDisplayMode(.large)
+    }
+
+    // MARK: - Rows
+
+    private func yearRow(_ year: String) -> some View {
+        Button {
+            let generator = UIImpactFeedbackGenerator(style: .light)
+            generator.impactOccurred()
+            seasonStore.select(year)
+            navStore.select(.draftHistory, router: router)
+        } label: {
+            HStack(spacing: XomperTheme.Spacing.md) {
+                Image(systemName: "list.clipboard.fill")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(XomperColors.championGold)
+                    .frame(width: 32, alignment: .center)
+                    .accessibilityHidden(true)
+
+                Text("\(year) Draft")
+                    .font(.headline)
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.bold))
+                    .foregroundStyle(XomperColors.textMuted)
+                    .accessibilityHidden(true)
+            }
+            .padding(XomperTheme.Spacing.md)
+            .frame(minHeight: XomperTheme.minTouchTarget)
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+            .xomperShadow(.sm)
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(year) draft")
+        .accessibilityHint("Double tap to open in Draft tab")
+    }
+
+    // MARK: - Data
+
+    private var years: [String] {
+        historyStore.availableDraftSeasons.filter { $0 != currentSeason }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        PastDraftPickerView(
+            historyStore: HistoryStore(),
+            seasonStore: SeasonStore(),
+            navStore: NavigationStore(),
+            router: AppRouter(),
+            currentSeason: "2026"
+        )
+    }
+    .preferredColorScheme(.dark)
+}

--- a/Xomper/Features/Archive/PastStandingsListView.swift
+++ b/Xomper/Features/Archive/PastStandingsListView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+/// Year list drilled into from `ArchiveView`'s "Past Standings" card. Each row
+/// is a tappable card representing one historical season; selection pushes
+/// `HistoricalStandingsView` for that year.
+///
+/// Years come from `HistoryStore.availableMatchupSeasons` — already used to
+/// drive the season picker, so no extra fetch path. Descending order (newest
+/// first). Empty state renders when the store has no matchup history loaded
+/// at all.
+struct PastStandingsListView: View {
+    let historyStore: HistoryStore
+    let leagueStore: LeagueStore
+    let authStore: AuthStore
+    let teamStore: TeamStore
+    let router: AppRouter
+
+    var body: some View {
+        Group {
+            if years.isEmpty {
+                EmptyStateView(
+                    icon: "list.number",
+                    title: "No past seasons loaded",
+                    message: "Open Matchup History first to load prior seasons."
+                )
+            } else {
+                ScrollView {
+                    VStack(spacing: XomperTheme.Spacing.sm) {
+                        ForEach(years, id: \.self) { year in
+                            yearRow(year)
+                        }
+                    }
+                    .padding(.horizontal, XomperTheme.Spacing.md)
+                    .padding(.vertical, XomperTheme.Spacing.sm)
+                }
+            }
+        }
+        .background(XomperColors.bgDark)
+        .navigationTitle("Past Standings")
+        .navigationBarTitleDisplayMode(.large)
+    }
+
+    // MARK: - Rows
+
+    private func yearRow(_ year: String) -> some View {
+        Button {
+            let generator = UIImpactFeedbackGenerator(style: .light)
+            generator.impactOccurred()
+            router.navigate(to: .archiveHistoricalStandings(year: year))
+        } label: {
+            HStack(spacing: XomperTheme.Spacing.md) {
+                Image(systemName: "calendar")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(XomperColors.championGold)
+                    .frame(width: 32, alignment: .center)
+                    .accessibilityHidden(true)
+
+                Text("\(year) Standings")
+                    .font(.headline)
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.bold))
+                    .foregroundStyle(XomperColors.textMuted)
+                    .accessibilityHidden(true)
+            }
+            .padding(XomperTheme.Spacing.md)
+            .frame(minHeight: XomperTheme.minTouchTarget)
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+            .xomperShadow(.sm)
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(year) standings")
+        .accessibilityHint("Double tap to view")
+    }
+
+    // MARK: - Data
+
+    private var years: [String] {
+        historyStore.availableMatchupSeasons
+    }
+}
+
+#Preview {
+    NavigationStack {
+        PastStandingsListView(
+            historyStore: HistoryStore(),
+            leagueStore: LeagueStore(),
+            authStore: AuthStore(),
+            teamStore: TeamStore(),
+            router: AppRouter()
+        )
+    }
+    .preferredColorScheme(.dark)
+}

--- a/Xomper/Features/League/StandingsListView.swift
+++ b/Xomper/Features/League/StandingsListView.swift
@@ -1,0 +1,329 @@
+import SwiftUI
+
+/// Pure renderer for a list of `StandingsTeam`s. Extracted from `StandingsView`
+/// during F4 so the same layout serves both the live league context and the
+/// per-year historical context surfaced via the new Archive destination.
+///
+/// Owns the league/division view-mode toggle and the row layout — no data
+/// fetching, no store dependencies beyond the data passed in. The caller is
+/// responsible for providing already-built `StandingsTeam`s plus the few
+/// presentation hints below.
+struct StandingsListView: View {
+    /// League-wide standings, pre-sorted (wins desc, then PF desc).
+    let standings: [StandingsTeam]
+
+    /// Whether the data has resolvable divisions. When false the toggle is
+    /// hidden and the view renders the league-wide layout only.
+    let hasDivisions: Bool
+
+    /// Per-division grouping, only consulted when `hasDivisions == true`.
+    let divisionStandings: [String: [StandingsTeam]]
+
+    /// League-wide playoff cutoff used to draw a separator under the last
+    /// playoff-bound row. Pass `nil` to suppress the divider (e.g. historical
+    /// view where league metadata isn't available).
+    let playoffCutoff: Int?
+
+    /// The signed-in user's Sleeper user id, used to highlight their row.
+    /// Pass `nil` to never highlight (historical view).
+    let myUserId: String?
+
+    /// Tap on a team row — typically pushes a team-detail view.
+    let onTeamTap: (StandingsTeam) -> Void
+
+    /// Long-press / context-menu "View Owner Profile". Pass an empty closure
+    /// when the source can't resolve to a profile (historical view v1).
+    let onProfileTap: (StandingsTeam) -> Void
+
+    @State private var viewMode: StandingsListViewMode = .league
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: XomperTheme.Spacing.md) {
+                if hasDivisions {
+                    viewModeToggle
+                }
+
+                switch viewMode {
+                case .league:
+                    leagueStandingsView
+                case .division:
+                    divisionStandingsView
+                }
+            }
+            .padding(.horizontal, XomperTheme.Spacing.md)
+            .padding(.vertical, XomperTheme.Spacing.sm)
+        }
+        .background(XomperColors.bgDark)
+    }
+
+    // MARK: - View Mode Toggle
+
+    private var viewModeToggle: some View {
+        HStack(spacing: XomperTheme.Spacing.sm) {
+            ForEach(StandingsListViewMode.allCases) { mode in
+                Button {
+                    let generator = UIImpactFeedbackGenerator(style: .light)
+                    generator.impactOccurred()
+                    withAnimation(XomperTheme.defaultAnimation) {
+                        viewMode = mode
+                    }
+                } label: {
+                    Text(mode.title)
+                        .font(.subheadline)
+                        .fontWeight(viewMode == mode ? .semibold : .regular)
+                        .foregroundStyle(viewMode == mode ? XomperColors.deepNavy : XomperColors.textSecondary)
+                        .padding(.horizontal, XomperTheme.Spacing.md)
+                        .padding(.vertical, XomperTheme.Spacing.sm)
+                        .frame(minHeight: XomperTheme.minTouchTarget)
+                        .background(viewMode == mode ? XomperColors.championGold : XomperColors.surfaceLight)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.pressableCard)
+                .accessibilityLabel("\(mode.title) view")
+                .accessibilityAddTraits(viewMode == mode ? .isSelected : [])
+            }
+            Spacer()
+        }
+    }
+
+    // MARK: - League Standings
+
+    private var leagueStandingsView: some View {
+        LazyVStack(spacing: XomperTheme.Spacing.md) {
+            standingsHeader
+            ForEach(standings) { team in
+                StandingsRowView(
+                    team: team,
+                    rank: team.leagueRank,
+                    isMyTeam: team.userId == myUserId,
+                    playoffCutoff: playoffCutoff
+                ) {
+                    onTeamTap(team)
+                } onProfileTap: {
+                    onProfileTap(team)
+                }
+            }
+        }
+    }
+
+    // MARK: - Division Standings
+
+    private var divisionStandingsView: some View {
+        LazyVStack(spacing: XomperTheme.Spacing.lg) {
+            let sortedKeys = divisionStandings.keys.sorted()
+            ForEach(sortedKeys, id: \.self) { divisionName in
+                if let teams = divisionStandings[divisionName] {
+                    divisionSection(name: divisionName, teams: teams)
+                }
+            }
+        }
+    }
+
+    private func divisionSection(name: String, teams: [StandingsTeam]) -> some View {
+        VStack(spacing: XomperTheme.Spacing.md) {
+            HStack(spacing: XomperTheme.Spacing.sm) {
+                if let avatarId = teams.first?.divisionAvatar {
+                    AvatarView(avatarID: avatarId, size: XomperTheme.AvatarSize.sm, isTeam: true)
+                }
+                Text(name)
+                    .font(.headline)
+                    .foregroundStyle(XomperColors.textPrimary)
+                Spacer()
+            }
+            .padding(.horizontal, XomperTheme.Spacing.md)
+
+            standingsHeader
+
+            ForEach(teams) { team in
+                StandingsRowView(
+                    team: team,
+                    rank: team.divisionRank,
+                    isMyTeam: team.userId == myUserId,
+                    playoffCutoff: nil
+                ) {
+                    onTeamTap(team)
+                } onProfileTap: {
+                    onProfileTap(team)
+                }
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var standingsHeader: some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            Text("#")
+                .frame(width: 28, alignment: .center)
+            Text("Team")
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text("W")
+                .frame(width: 28, alignment: .center)
+            Text("L")
+                .frame(width: 28, alignment: .center)
+            Text("Str")
+                .frame(width: 36, alignment: .center)
+            Text("PF")
+                .frame(width: 64, alignment: .trailing)
+        }
+        .font(.caption2)
+        .fontWeight(.semibold)
+        .foregroundStyle(XomperColors.textMuted)
+        .padding(.horizontal, XomperTheme.Spacing.md)
+        .padding(.vertical, XomperTheme.Spacing.sm)
+        .accessibilityHidden(true)
+    }
+}
+
+// MARK: - Standings Row
+
+private struct StandingsRowView: View {
+    let team: StandingsTeam
+    let rank: Int
+    let isMyTeam: Bool
+    let playoffCutoff: Int?
+    let onTap: () -> Void
+    var onProfileTap: (() -> Void)?
+
+    var body: some View {
+        Button {
+            let generator = UIImpactFeedbackGenerator(style: .light)
+            generator.impactOccurred()
+            onTap()
+        } label: {
+            HStack(spacing: 0) {
+                rankBadge
+                teamInfo
+                statsColumns
+            }
+            .padding(.horizontal, XomperTheme.Spacing.md)
+            .padding(.vertical, XomperTheme.Spacing.sm)
+            .frame(minHeight: XomperTheme.minTouchTarget)
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md)
+                    .stroke(
+                        isMyTeam ? XomperColors.championGold.opacity(0.4) : Color.clear,
+                        lineWidth: 1
+                    )
+            )
+            .xomperShadow(.sm)
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityDescription)
+        .accessibilityHint("Double tap to view team details")
+        .contextMenu {
+            if let onProfileTap {
+                Button {
+                    onProfileTap()
+                } label: {
+                    Label("View Owner Profile", systemImage: "person.circle")
+                }
+            }
+        }
+    }
+
+    private var rankBadge: some View {
+        Text("\(rank)")
+            .font(.caption)
+            .fontWeight(.bold)
+            .foregroundStyle(rankColor)
+            .frame(width: 28, alignment: .center)
+    }
+
+    private var teamInfo: some View {
+        HStack(spacing: XomperTheme.Spacing.sm) {
+            AvatarView(avatarID: team.avatarId, size: XomperTheme.AvatarSize.sm)
+
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+                Text(team.teamName)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .lineLimit(1)
+
+                Text(team.displayName)
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.textSecondary)
+                    .lineLimit(1)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var statsColumns: some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            Text("\(team.wins)")
+                .frame(width: 28, alignment: .center)
+                .foregroundStyle(XomperColors.textPrimary)
+
+            Text("\(team.losses)")
+                .frame(width: 28, alignment: .center)
+                .foregroundStyle(XomperColors.textSecondary)
+
+            Text(team.streak.displayString)
+                .frame(width: 36, alignment: .center)
+                .foregroundStyle(streakColor)
+
+            Text(team.fpts.formattedPoints)
+                .frame(width: 64, alignment: .trailing)
+                .foregroundStyle(XomperColors.textPrimary)
+        }
+        .font(.caption)
+        .fontWeight(.medium)
+    }
+
+    // MARK: - Helpers
+
+    private var rankColor: Color {
+        switch rank {
+        case 1: XomperColors.championGold
+        case 2: Color(hex: 0xC0C0C0)
+        case 3: Color(hex: 0xCD7F32)
+        default: XomperColors.textMuted
+        }
+    }
+
+    private var streakColor: Color {
+        switch team.streak.type {
+        case .win: XomperColors.successGreen
+        case .loss: XomperColors.accentRed
+        case .none: XomperColors.textMuted
+        }
+    }
+
+    private var accessibilityDescription: String {
+        var parts = [
+            "Rank \(rank)",
+            team.teamName,
+            team.displayName,
+            "\(team.wins) wins, \(team.losses) losses",
+            "\(team.fpts.formattedPoints) points for"
+        ]
+        if isMyTeam {
+            parts.insert("Your team", at: 0)
+        }
+        return parts.joined(separator: ", ")
+    }
+}
+
+// MARK: - View Mode Enum
+
+/// Local toggle state for `StandingsListView`. Named to avoid collision with
+/// any future shared enum and to keep the extraction self-contained.
+private enum StandingsListViewMode: String, CaseIterable, Identifiable {
+    case league
+    case division
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .league: "League"
+        case .division: "Divisions"
+        }
+    }
+}

--- a/Xomper/Features/League/StandingsOffseasonCard.swift
+++ b/Xomper/Features/League/StandingsOffseasonCard.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+// MARK: - Hardcoded dates
+//
+// F4 ships with the 2026 offseason dates pinned in code. When the draft date
+// slips or we roll into 2027 the strings below are a 1-line edit each. There
+// is intentionally no `Date` math here — the card is a static informational
+// surface and should never mis-render due to time zone confusion.
+
+private let draftDateLine = "Mon, Jul 6 · 6:30pm ET"
+private let draftLabel    = "2026 Rookie Draft"
+private let week1DateLine = "Mon, Sep 8"
+private let week1Label    = "Week 1 Kickoff"
+
+/// Empty-state card for `StandingsView` when the NFL season is not in a
+/// regular-season window (offseason, preseason, playoffs — anything where
+/// `NflStateStore.isRegularSeason == false`).
+///
+/// Communicates "standings unlock when Week 1 starts" without lying about
+/// 0-0-0 records or rendering stale data. Hardcoded date strings — see top
+/// of file for the pin sites.
+struct StandingsOffseasonCard: View {
+    var body: some View {
+        VStack(spacing: XomperTheme.Spacing.md) {
+            Image(systemName: "moon.zzz.fill")
+                .font(.system(size: XomperTheme.IconSize.xl))
+                .foregroundStyle(XomperColors.championGold)
+                .accessibilityHidden(true)
+
+            VStack(spacing: XomperTheme.Spacing.xs) {
+                Text("Standings unlock Week 1")
+                    .font(.headline)
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .multilineTextAlignment(.center)
+
+                Text("Until then, the league is in the offseason.")
+                    .font(.subheadline)
+                    .foregroundStyle(XomperColors.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            VStack(spacing: XomperTheme.Spacing.sm) {
+                dateRow(date: draftDateLine, label: draftLabel)
+                dateRow(date: week1DateLine, label: week1Label)
+            }
+            .padding(.top, XomperTheme.Spacing.sm)
+        }
+        .padding(XomperTheme.Spacing.lg)
+        .frame(maxWidth: .infinity)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .xomperShadow(.sm)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "Standings unlock Week 1. Until then, the league is in the offseason. " +
+            "\(draftDateLine), \(draftLabel). \(week1DateLine), \(week1Label)."
+        )
+    }
+
+    private func dateRow(date: String, label: String) -> some View {
+        HStack(spacing: XomperTheme.Spacing.md) {
+            Text(date)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(XomperColors.textPrimary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(XomperColors.textSecondary)
+        }
+        .padding(.horizontal, XomperTheme.Spacing.md)
+        .padding(.vertical, XomperTheme.Spacing.sm)
+        .background(XomperColors.surfaceLight)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+    }
+}
+
+#Preview {
+    ScrollView {
+        StandingsOffseasonCard()
+            .padding()
+    }
+    .background(XomperColors.bgDark)
+    .preferredColorScheme(.dark)
+}

--- a/Xomper/Features/League/StandingsView.swift
+++ b/Xomper/Features/League/StandingsView.swift
@@ -1,43 +1,31 @@
 import SwiftUI
 
+/// Top-level Standings destination. Thin wrapper around `StandingsListView`
+/// that:
+///
+/// - builds the live `[StandingsTeam]` from `LeagueStore`
+/// - gates on `NflStateStore.isRegularSeason` and renders
+///   `StandingsOffseasonCard` whenever the league isn't actively playing
+///
+/// All actual row + division rendering lives in `StandingsListView` so the
+/// same layout can be reused by the Archive's `HistoricalStandingsView`.
 struct StandingsView: View {
     var leagueStore: LeagueStore
     var teamStore: TeamStore
     var authStore: AuthStore
+    var nflStateStore: NflStateStore
     var router: AppRouter
 
-    @State private var viewMode: StandingsViewMode = .league
     @State private var standings: [StandingsTeam] = []
     @State private var divisionStandings: [String: [StandingsTeam]] = [:]
     @State private var hasDivisions = false
 
     var body: some View {
         Group {
-            if standings.isEmpty && (leagueStore.isLoading || leagueStore.myLeagueRosters.isEmpty) {
-                LoadingView(message: "Loading standings...")
-            } else if standings.isEmpty {
-                EmptyStateView(
-                    icon: "list.number",
-                    title: "Standings Not Loaded",
-                    message: "Pull to refresh to load the latest standings."
-                )
+            if nflStateStore.isRegularSeason {
+                liveStandings
             } else {
-                ScrollView {
-                    VStack(spacing: XomperTheme.Spacing.md) {
-                        if hasDivisions {
-                            viewModeToggle
-                        }
-
-                        switch viewMode {
-                        case .league:
-                            leagueStandingsView
-                        case .division:
-                            divisionStandingsView
-                        }
-                    }
-                    .padding(.horizontal, XomperTheme.Spacing.md)
-                    .padding(.vertical, XomperTheme.Spacing.sm)
-                }
+                offseason
             }
         }
         .background(XomperColors.bgDark)
@@ -58,122 +46,39 @@ struct StandingsView: View {
         }
     }
 
-    // MARK: - View Mode Toggle
+    // MARK: - Live standings (regular season)
 
-    private var viewModeToggle: some View {
-        HStack(spacing: XomperTheme.Spacing.sm) {
-            ForEach(StandingsViewMode.allCases) { mode in
-                Button {
-                    let generator = UIImpactFeedbackGenerator(style: .light)
-                    generator.impactOccurred()
-                    withAnimation(XomperTheme.defaultAnimation) {
-                        viewMode = mode
-                    }
-                } label: {
-                    Text(mode.title)
-                        .font(.subheadline)
-                        .fontWeight(viewMode == mode ? .semibold : .regular)
-                        .foregroundStyle(viewMode == mode ? XomperColors.deepNavy : XomperColors.textSecondary)
-                        .padding(.horizontal, XomperTheme.Spacing.md)
-                        .padding(.vertical, XomperTheme.Spacing.sm)
-                        .frame(minHeight: XomperTheme.minTouchTarget)
-                        .background(viewMode == mode ? XomperColors.championGold : XomperColors.surfaceLight)
-                        .clipShape(Capsule())
-                }
-                .buttonStyle(.pressableCard)
-                .accessibilityLabel("\(mode.title) view")
-                .accessibilityAddTraits(viewMode == mode ? .isSelected : [])
-            }
-            Spacer()
+    @ViewBuilder
+    private var liveStandings: some View {
+        if standings.isEmpty && (leagueStore.isLoading || leagueStore.myLeagueRosters.isEmpty) {
+            LoadingView(message: "Loading standings...")
+        } else if standings.isEmpty {
+            EmptyStateView(
+                icon: "list.number",
+                title: "Standings Not Loaded",
+                message: "Pull to refresh to load the latest standings."
+            )
+        } else {
+            StandingsListView(
+                standings: standings,
+                hasDivisions: hasDivisions,
+                divisionStandings: divisionStandings,
+                playoffCutoff: leagueStore.myLeague?.settings?.playoffTeams,
+                myUserId: authStore.sleeperUserId,
+                onTeamTap: selectTeam,
+                onProfileTap: navigateToProfile
+            )
         }
     }
 
-    // MARK: - League Standings
+    // MARK: - Offseason empty state
 
-    private var leagueStandingsView: some View {
-        LazyVStack(spacing: XomperTheme.Spacing.md) {
-            standingsHeader
-            ForEach(standings) { team in
-                StandingsRowView(
-                    team: team,
-                    rank: team.leagueRank,
-                    isMyTeam: team.userId == authStore.sleeperUserId,
-                    playoffCutoff: leagueStore.myLeague?.settings?.playoffTeams
-                ) {
-                    selectTeam(team)
-                } onProfileTap: {
-                    navigateToProfile(team)
-                }
-            }
+    private var offseason: some View {
+        ScrollView {
+            StandingsOffseasonCard()
+                .padding(.horizontal, XomperTheme.Spacing.md)
+                .padding(.vertical, XomperTheme.Spacing.sm)
         }
-    }
-
-    // MARK: - Division Standings
-
-    private var divisionStandingsView: some View {
-        LazyVStack(spacing: XomperTheme.Spacing.lg) {
-            let sortedKeys = divisionStandings.keys.sorted()
-            ForEach(sortedKeys, id: \.self) { divisionName in
-                if let teams = divisionStandings[divisionName] {
-                    divisionSection(name: divisionName, teams: teams)
-                }
-            }
-        }
-    }
-
-    private func divisionSection(name: String, teams: [StandingsTeam]) -> some View {
-        VStack(spacing: XomperTheme.Spacing.md) {
-            HStack(spacing: XomperTheme.Spacing.sm) {
-                if let avatarId = teams.first?.divisionAvatar {
-                    AvatarView(avatarID: avatarId, size: XomperTheme.AvatarSize.sm, isTeam: true)
-                }
-                Text(name)
-                    .font(.headline)
-                    .foregroundStyle(XomperColors.textPrimary)
-                Spacer()
-            }
-            .padding(.horizontal, XomperTheme.Spacing.md)
-
-            standingsHeader
-
-            ForEach(teams) { team in
-                StandingsRowView(
-                    team: team,
-                    rank: team.divisionRank,
-                    isMyTeam: team.userId == authStore.sleeperUserId,
-                    playoffCutoff: nil
-                ) {
-                    selectTeam(team)
-                } onProfileTap: {
-                    navigateToProfile(team)
-                }
-            }
-        }
-    }
-
-    // MARK: - Header
-
-    private var standingsHeader: some View {
-        HStack(spacing: XomperTheme.Spacing.xs) {
-            Text("#")
-                .frame(width: 28, alignment: .center)
-            Text("Team")
-                .frame(maxWidth: .infinity, alignment: .leading)
-            Text("W")
-                .frame(width: 28, alignment: .center)
-            Text("L")
-                .frame(width: 28, alignment: .center)
-            Text("Str")
-                .frame(width: 36, alignment: .center)
-            Text("PF")
-                .frame(width: 64, alignment: .trailing)
-        }
-        .font(.caption2)
-        .fontWeight(.semibold)
-        .foregroundStyle(XomperColors.textMuted)
-        .padding(.horizontal, XomperTheme.Spacing.md)
-        .padding(.vertical, XomperTheme.Spacing.sm)
-        .accessibilityHidden(true)
     }
 
     // MARK: - Actions
@@ -216,162 +121,13 @@ struct StandingsView: View {
     }
 }
 
-// MARK: - Standings Row
-
-private struct StandingsRowView: View {
-    let team: StandingsTeam
-    let rank: Int
-    let isMyTeam: Bool
-    let playoffCutoff: Int?
-    let onTap: () -> Void
-    var onProfileTap: (() -> Void)?
-
-    var body: some View {
-        Button {
-            let generator = UIImpactFeedbackGenerator(style: .light)
-            generator.impactOccurred()
-            onTap()
-        } label: {
-            HStack(spacing: 0) {
-                rankBadge
-                teamInfo
-                statsColumns
-            }
-            .padding(.horizontal, XomperTheme.Spacing.md)
-            .padding(.vertical, XomperTheme.Spacing.sm)
-            .frame(minHeight: XomperTheme.minTouchTarget)
-            .background(XomperColors.bgCard)
-            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
-            .overlay(
-                RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md)
-                    .stroke(
-                        isMyTeam ? XomperColors.championGold.opacity(0.4) : Color.clear,
-                        lineWidth: 1
-                    )
-            )
-            .xomperShadow(.sm)
-        }
-        .buttonStyle(.pressableCard)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityDescription)
-        .accessibilityHint("Double tap to view team details")
-        .contextMenu {
-            if let onProfileTap {
-                Button {
-                    onProfileTap()
-                } label: {
-                    Label("View Owner Profile", systemImage: "person.circle")
-                }
-            }
-        }
-    }
-
-    private var rankBadge: some View {
-        Text("\(rank)")
-            .font(.caption)
-            .fontWeight(.bold)
-            .foregroundStyle(rankColor)
-            .frame(width: 28, alignment: .center)
-    }
-
-    private var teamInfo: some View {
-        HStack(spacing: XomperTheme.Spacing.sm) {
-            AvatarView(avatarID: team.avatarId, size: XomperTheme.AvatarSize.sm)
-
-            VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
-                Text(team.teamName)
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-                    .foregroundStyle(XomperColors.textPrimary)
-                    .lineLimit(1)
-
-                Text(team.displayName)
-                    .font(.caption2)
-                    .foregroundStyle(XomperColors.textSecondary)
-                    .lineLimit(1)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private var statsColumns: some View {
-        HStack(spacing: XomperTheme.Spacing.xs) {
-            Text("\(team.wins)")
-                .frame(width: 28, alignment: .center)
-                .foregroundStyle(XomperColors.textPrimary)
-
-            Text("\(team.losses)")
-                .frame(width: 28, alignment: .center)
-                .foregroundStyle(XomperColors.textSecondary)
-
-            Text(team.streak.displayString)
-                .frame(width: 36, alignment: .center)
-                .foregroundStyle(streakColor)
-
-            Text(team.fpts.formattedPoints)
-                .frame(width: 64, alignment: .trailing)
-                .foregroundStyle(XomperColors.textPrimary)
-        }
-        .font(.caption)
-        .fontWeight(.medium)
-    }
-
-    // MARK: - Helpers
-
-    private var rankColor: Color {
-        switch rank {
-        case 1: XomperColors.championGold
-        case 2: Color(hex: 0xC0C0C0)
-        case 3: Color(hex: 0xCD7F32)
-        default: XomperColors.textMuted
-        }
-    }
-
-    private var streakColor: Color {
-        switch team.streak.type {
-        case .win: XomperColors.successGreen
-        case .loss: XomperColors.accentRed
-        case .none: XomperColors.textMuted
-        }
-    }
-
-    private var accessibilityDescription: String {
-        var parts = [
-            "Rank \(rank)",
-            team.teamName,
-            team.displayName,
-            "\(team.wins) wins, \(team.losses) losses",
-            "\(team.fpts.formattedPoints) points for"
-        ]
-        if isMyTeam {
-            parts.insert("Your team", at: 0)
-        }
-        return parts.joined(separator: ", ")
-    }
-}
-
-// MARK: - View Mode Enum
-
-private enum StandingsViewMode: String, CaseIterable, Identifiable {
-    case league
-    case division
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .league: "League"
-        case .division: "Divisions"
-        }
-    }
-}
-
 #Preview {
     NavigationStack {
         StandingsView(
             leagueStore: LeagueStore(),
             teamStore: TeamStore(),
             authStore: AuthStore(),
+            nflStateStore: NflStateStore(),
             router: AppRouter()
         )
     }

--- a/Xomper/Features/Shell/DrawerView.swift
+++ b/Xomper/Features/Shell/DrawerView.swift
@@ -46,6 +46,10 @@ struct DrawerView: View {
                 title: "League",
                 entries: [.payouts, .aiReview, .rulebook, .scoring, .leagueSettings, .ruleProposals, .draftOrder]
             ),
+            TraySection(
+                title: "Archive",
+                entries: [.archive]
+            ),
         ]
         if isAdmin {
             out.append(TraySection(title: "Admin", entries: [.admin]))

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -140,6 +140,7 @@ struct MainShell: View {
                     leagueStore: leagueStore,
                     teamStore: teamStore,
                     authStore: authStore,
+                    nflStateStore: nflStateStore,
                     router: router
                 )
 
@@ -225,6 +226,17 @@ struct MainShell: View {
                 AIReviewView(
                     store: aiReviewStore,
                     router: router
+                )
+
+            case .archive:
+                ArchiveView(
+                    navStore: navStore,
+                    router: router,
+                    historyStore: historyStore,
+                    leagueStore: leagueStore,
+                    authStore: authStore,
+                    teamStore: teamStore,
+                    seasonStore: seasonStore
                 )
 
             case .admin:
@@ -346,6 +358,7 @@ struct MainShell: View {
                 leagueStore: leagueStore,
                 teamStore: teamStore,
                 authStore: authStore,
+                nflStateStore: nflStateStore,
                 router: router
             )
 
@@ -449,6 +462,34 @@ struct MainShell: View {
                     message: "We couldn't load this report — pull to refresh the archive."
                 )
             }
+
+        case .archivePastStandings:
+            PastStandingsListView(
+                historyStore: historyStore,
+                leagueStore: leagueStore,
+                authStore: authStore,
+                teamStore: teamStore,
+                router: router
+            )
+
+        case .archiveHistoricalStandings(let year):
+            HistoricalStandingsView(
+                year: year,
+                historyStore: historyStore,
+                leagueStore: leagueStore,
+                authStore: authStore,
+                teamStore: teamStore,
+                router: router
+            )
+
+        case .archivePastDraftPicker:
+            PastDraftPickerView(
+                historyStore: historyStore,
+                seasonStore: seasonStore,
+                navStore: navStore,
+                router: router,
+                currentSeason: nflStateStore.currentSeason
+            )
         }
     }
 

--- a/Xomper/Features/Shell/TrayDestination.swift
+++ b/Xomper/Features/Shell/TrayDestination.swift
@@ -9,6 +9,7 @@ import Foundation
 /// - History:  draftHistory, matchupHistory, worldCup
 /// - Roster:   myTeam, taxiSquad
 /// - Rules:    rulebook, scoring, leagueSettings, ruleProposals
+/// - Archive:  archive (hubs past standings + past matchups + past drafts)
 /// - Profile/Settings are surfaced via the profile card and pinned footer.
 enum TrayDestination: Hashable {
     case landing
@@ -33,6 +34,7 @@ enum TrayDestination: Hashable {
     case payouts
     case draftOrder
     case aiReview
+    case archive
     case admin
     case profile
     case settings
@@ -58,6 +60,7 @@ enum TrayDestination: Hashable {
         case .payouts:        "Payouts"
         case .draftOrder:     "Draft Order Proposal"
         case .aiReview:       "AI Review"
+        case .archive:        "Archive"
         case .admin:          "Admin"
         case .profile:        "Profile"
         case .settings:       "Settings"
@@ -84,6 +87,7 @@ enum TrayDestination: Hashable {
         case .payouts:        "dollarsign.circle.fill"
         case .draftOrder:     "list.bullet.rectangle"
         case .aiReview:       "sparkles"
+        case .archive:        "archivebox.fill"
         case .admin:          "wrench.and.screwdriver.fill"
         case .profile:        "person.crop.circle.fill"
         case .settings:       "gearshape.fill"

--- a/Xomper/Navigation/AppRouter.swift
+++ b/Xomper/Navigation/AppRouter.swift
@@ -23,6 +23,23 @@ enum AppRoute: Hashable {
     /// matches `AIReport.id` (computed from `pk|sk`) and the detail
     /// view resolves the struct from `AIReviewStore`.
     case aiReportDetail(reportId: String)
+
+    // MARK: - Archive (F4)
+
+    /// Pushed from `ArchiveView`'s "Past Standings" card. Lists every
+    /// available historical season as a row → drills into
+    /// `archiveHistoricalStandings(year:)`.
+    case archivePastStandings
+
+    /// Pushed from `archivePastStandings`. Renders that year's standings
+    /// reconstructed from `MatchupHistoryRecord`s via
+    /// `StandingsBuilder.buildStandingsFromHistory`.
+    case archiveHistoricalStandings(year: String)
+
+    /// Pushed from `ArchiveView`'s "Past Drafts" card. Lists past-season
+    /// drafts; on selection sets `SeasonStore.selectedSeason` and switches
+    /// the top-level destination to `.draftHistory`.
+    case archivePastDraftPicker
 }
 
 /// Owns the inner `NavigationStack` path inside `MainShell`. The drawer

--- a/XomperTests/ArchiveNavigationTests.swift
+++ b/XomperTests/ArchiveNavigationTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import Xomper
+
+/// Coverage for the side effects the Archive's `PastDraftPickerView` row tap
+/// performs:
+///
+///   1. `SeasonStore.select(year)` — sets the shared `selectedSeason` if it's
+///      in the `availableSeasons` set.
+///   2. `NavigationStore.select(.draftHistory, router:)` — flips the
+///      top-level destination and closes the drawer.
+///
+/// The view itself isn't constructed; we drive the same store calls the
+/// button action wires up so the contract is locked even if the view
+/// rebody-changes.
+@MainActor
+final class ArchiveNavigationTests: XCTestCase {
+
+    /// Selecting a past year should land both stores in the expected
+    /// post-tap state: `selectedSeason` updated and `currentDestination`
+    /// flipped to `.draftHistory`.
+    func testPastDraftRowTap_setsSeasonAndDestination() {
+        // Arrange — seed the season store as it would be in production:
+        // current season 2026, plus past years 2024 + 2025 available.
+        let seasonStore = SeasonStore()
+        seasonStore.refreshAvailable(
+            matchupSeasons: ["2024", "2025"],
+            draftSeasons: ["2024", "2025", "2026"],
+            chainSeasons: ["2024", "2025", "2026"],
+            currentSeason: "2026"
+        )
+        // Default selection after bootstrap is the current season.
+        XCTAssertEqual(seasonStore.selectedSeason, "2026")
+
+        let navStore = NavigationStore()
+        XCTAssertEqual(navStore.currentDestination, .landing)
+
+        // Act — same side effects PastDraftPickerView fires on row tap.
+        seasonStore.select("2024")
+        navStore.select(.draftHistory, router: nil)
+
+        // Assert — both stores now reflect the past-draft selection.
+        XCTAssertEqual(seasonStore.selectedSeason, "2024")
+        XCTAssertEqual(navStore.currentDestination, .draftHistory)
+        XCTAssertFalse(navStore.isDrawerOpen)
+    }
+
+    /// `SeasonStore.select(_:)` is defensive — selecting a year that isn't
+    /// in `availableSeasons` should be a no-op so a stale tap can't strand
+    /// the user on a non-existent season chip.
+    func testPastDraftRowTap_unknownYearIsNoop() {
+        let seasonStore = SeasonStore()
+        seasonStore.refreshAvailable(
+            matchupSeasons: ["2024"],
+            draftSeasons: ["2024"],
+            chainSeasons: ["2024"],
+            currentSeason: "2024"
+        )
+        XCTAssertEqual(seasonStore.selectedSeason, "2024")
+
+        seasonStore.select("1999")
+
+        XCTAssertEqual(
+            seasonStore.selectedSeason,
+            "2024",
+            "selecting an unavailable season should not mutate the store"
+        )
+    }
+}

--- a/XomperTests/PastStandingsArchiveTests.swift
+++ b/XomperTests/PastStandingsArchiveTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+@testable import Xomper
+
+/// Coverage for the historical-standings path that powers F4's Archive →
+/// Past Standings drill-down. Reuses the existing
+/// `StandingsBuilder.buildStandingsFromHistory(records:)` (already covered
+/// upstream by `PayoutsView`) so failures here surface directly instead of
+/// only via the Payouts numbers.
+@MainActor
+final class PastStandingsArchiveTests: XCTestCase {
+
+    // MARK: - Fixture
+
+    /// Three regular-season records across three rosters:
+    ///   - Roster 1 wins both its games (vs 2, vs 3)  → 2-0, 230 PF
+    ///   - Roster 2 splits (loss to 1, win vs 3)      → 1-1, 200 PF
+    ///   - Roster 3 loses both                        → 0-2, 165 PF
+    private func makeRecords() -> [MatchupHistoryRecord] {
+        let leagueId = "league-2024"
+        let season = "2024"
+
+        func record(
+            week: Int,
+            matchupId: Int,
+            aRoster: Int, aUser: String, aPoints: Double,
+            bRoster: Int, bUser: String, bPoints: Double,
+            winner: Int?
+        ) -> MatchupHistoryRecord {
+            MatchupHistoryRecord(
+                leagueId: leagueId,
+                season: season,
+                week: week,
+                matchupId: matchupId,
+                teamARosterId: aRoster,
+                teamAUserId: aUser,
+                teamAUsername: aUser,
+                teamATeamName: "\(aUser)'s Team",
+                teamAPoints: aPoints,
+                teamBRosterId: bRoster,
+                teamBUserId: bUser,
+                teamBUsername: bUser,
+                teamBTeamName: "\(bUser)'s Team",
+                teamBPoints: bPoints,
+                winnerRosterId: winner,
+                isPlayoff: false,
+                isChampionship: false,
+                teamADivision: 0,
+                teamBDivision: 0,
+                playoffPlacement: nil
+            )
+        }
+
+        return [
+            // Week 1 — 1 beats 2 by 10
+            record(
+                week: 1, matchupId: 1,
+                aRoster: 1, aUser: "alice", aPoints: 120.0,
+                bRoster: 2, bUser: "bob",   bPoints: 110.0,
+                winner: 1
+            ),
+            // Week 1 — 3 vs (bye-equivalent) — skipped; only paired games count
+            // Week 2 — 1 beats 3 by big margin
+            record(
+                week: 2, matchupId: 2,
+                aRoster: 1, aUser: "alice", aPoints: 110.0,
+                bRoster: 3, bUser: "carl",  bPoints: 80.0,
+                winner: 1
+            ),
+            // Week 3 — 2 beats 3
+            record(
+                week: 3, matchupId: 3,
+                aRoster: 2, aUser: "bob",   aPoints: 90.0,
+                bRoster: 3, bUser: "carl",  bPoints: 85.0,
+                winner: 2
+            ),
+        ]
+    }
+
+    // MARK: - Tests
+
+    /// Wins/losses aggregate correctly across multiple weeks; sort is
+    /// wins-desc, then PF-desc — same contract Payouts depends on.
+    func testBuildStandingsFromHistory_aggregatesAndSorts() {
+        let records = makeRecords()
+        let standings = StandingsBuilder.buildStandingsFromHistory(records: records)
+
+        XCTAssertEqual(standings.count, 3, "expected one standings row per roster")
+
+        // Rank 1: roster 1 (alice) — 2-0
+        XCTAssertEqual(standings[0].rosterId, 1)
+        XCTAssertEqual(standings[0].wins, 2)
+        XCTAssertEqual(standings[0].losses, 0)
+        XCTAssertEqual(standings[0].leagueRank, 1)
+        XCTAssertEqual(standings[0].fpts, 230.0, accuracy: 0.001)
+
+        // Rank 2: roster 2 (bob) — 1-1
+        XCTAssertEqual(standings[1].rosterId, 2)
+        XCTAssertEqual(standings[1].wins, 1)
+        XCTAssertEqual(standings[1].losses, 1)
+        XCTAssertEqual(standings[1].leagueRank, 2)
+        XCTAssertEqual(standings[1].fpts, 200.0, accuracy: 0.001)
+
+        // Rank 3: roster 3 (carl) — 0-2
+        XCTAssertEqual(standings[2].rosterId, 3)
+        XCTAssertEqual(standings[2].wins, 0)
+        XCTAssertEqual(standings[2].losses, 2)
+        XCTAssertEqual(standings[2].leagueRank, 3)
+        XCTAssertEqual(standings[2].fpts, 165.0, accuracy: 0.001)
+    }
+
+    /// Playoff records (`isPlayoff == true`) must NOT count toward
+    /// regular-season standings — that's the contract Past Standings
+    /// communicates ("Final regular-season records by year").
+    func testBuildStandingsFromHistory_excludesPlayoffRecords() {
+        var records = makeRecords()
+        // Tack on a fake playoff blowout for roster 3. Should NOT lift
+        // them above roster 2 in the standings.
+        records.append(
+            MatchupHistoryRecord(
+                leagueId: "league-2024",
+                season: "2024",
+                week: 15,
+                matchupId: 99,
+                teamARosterId: 3,
+                teamAUserId: "carl",
+                teamAUsername: "carl",
+                teamATeamName: "carl's Team",
+                teamAPoints: 200.0,
+                teamBRosterId: 2,
+                teamBUserId: "bob",
+                teamBUsername: "bob",
+                teamBTeamName: "bob's Team",
+                teamBPoints: 50.0,
+                winnerRosterId: 3,
+                isPlayoff: true,
+                isChampionship: false,
+                teamADivision: 0,
+                teamBDivision: 0,
+                playoffPlacement: nil
+            )
+        )
+
+        let standings = StandingsBuilder.buildStandingsFromHistory(records: records)
+        // Roster 3 should remain last (0-2 in regular season).
+        XCTAssertEqual(standings.last?.rosterId, 3)
+        XCTAssertEqual(standings.last?.wins, 0)
+        // PF for roster 3 should still be 165 (no playoff PF added).
+        XCTAssertEqual(standings.last?.fpts ?? 0, 165.0, accuracy: 0.001)
+    }
+
+    /// Empty input must produce an empty result without crashing — the
+    /// `HistoricalStandingsView` empty-state path depends on this.
+    func testBuildStandingsFromHistory_emptyInput() {
+        let standings = StandingsBuilder.buildStandingsFromHistory(records: [])
+        XCTAssertTrue(standings.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Final phase of the Season Refocus epic. Two changes:

- **Standings live-only switch** — `StandingsView` becomes a thin wrapper that gates on `NflStateStore.isRegularSeason`. Live records render exactly as today during the regular season (via a new `StandingsListView` extracted from the existing body); outside the regular season the view renders a new `StandingsOffseasonCard` with hardcoded July 6 (draft) and Sept 8 (Week 1) dates instead of stale 0-0-0 records.
- **New `.archive` tray destination** — single page with three hub cards (Past Standings, Past Matchup History, Past Drafts) under a new ARCHIVE section in the drawer, pinned between League and Admin.

Plan: `docs/features/season-refocus/f4-standings-archive/PLAN.md`. Epic: `docs/features/season-refocus/` (this PR closes out F1-F4).

## What's in the box

### New files (5 product + 2 tests = 7)
- `Xomper/Features/League/StandingsListView.swift` — pure renderer extracted from `StandingsView` (toggle + rows + division layout). Reused by both live and historical standings.
- `Xomper/Features/League/StandingsOffseasonCard.swift` — offseason empty-state card with hardcoded dates.
- `Xomper/Features/Archive/ArchiveView.swift` — hub page with 3 cards + lazy load.
- `Xomper/Features/Archive/PastStandingsListView.swift` — year list → `HistoricalStandingsView`.
- `Xomper/Features/Archive/HistoricalStandingsView.swift` — per-year standings via `StandingsBuilder.buildStandingsFromHistory`.
- `Xomper/Features/Archive/PastDraftPickerView.swift` — year picker → sets `SeasonStore` + switches to `.draftHistory`.
- `XomperTests/PastStandingsArchiveTests.swift` + `XomperTests/ArchiveNavigationTests.swift`.

### Modified files (4)
- `Xomper/Features/League/StandingsView.swift` — gate on `nflStateStore.isRegularSeason`, delegate live render to `StandingsListView`. No regression in regular-season behavior.
- `Xomper/Features/Shell/TrayDestination.swift` — add `.archive` case (icon `archivebox.fill`).
- `Xomper/Features/Shell/DrawerView.swift` — add Archive section between League and Admin.
- `Xomper/Features/Shell/MainShell.swift` — add `.archive` destination arm + 3 new pushed routes (`archivePastStandings`, `archiveHistoricalStandings(year:)`, `archivePastDraftPicker`). Inject `nflStateStore` into both `.standings` constructor sites.
- `Xomper/Navigation/AppRouter.swift` — 3 new `AppRoute` cases.

## Behavior notes

- **Offseason gate catches `seasonType == "post"`** (playoffs). The plan explicitly accepts this for v1 — the "Standings unlock Week 1" copy is still informative during the playoff window, and the playoff bracket has its own destination. A future "playoffs underway" variant is a known follow-up.
- **Hardcoded 2026 dates** — `"Mon, Jul 6 · 6:30pm ET"` and `"Mon, Sep 8"`. 1-line edits when the draft slips or we roll into 2027 (pin sites documented at the top of `StandingsOffseasonCard.swift`).
- **`HistoricalStandingsView` v1 limits** — no division view, no tappable rows. The historical league metadata isn't cached and historical roster ids don't resolve to the live `TeamStore`. Tracked as v2 follow-up.
- **`PastDraftPickerView` side effect** — selecting a past year mutates the shared `SeasonStore.selectedSeason`. Same caveat the existing HeaderBar season chip has (called out in the F3 brainstorm). Not a regression.

## Test plan

- [ ] Cold open in May 2026 (offseason). Drawer → Standings. Renders offseason card with the two pinned dates. No "Loading…" flash.
- [ ] Drawer → Archive. New entry visible at the bottom of the tray, between League and (Admin or) Settings.
- [ ] Archive → Past Standings → 2024. List of years renders; tapping a year pushes a 12-team historical standings sorted W-L desc then PF desc.
- [ ] Archive → Past Matchup History. Top-level destination switches to `.matchupHistory` (drawer closes, title becomes "Matchup History").
- [ ] Archive → Past Drafts → 2024. `SeasonStore.selectedSeason` becomes "2024"; destination switches to `.draftHistory`; F3 sub-tabs land on the chosen year.
- [ ] Regression check: nothing in the regular-season Standings path changes — division toggle, team-detail push, profile context menu, pull-to-refresh all still work (verify with a debug override of `seasonType`, or wait for Week 1).
- [ ] Pull-to-refresh on the offseason card is a no-op and doesn't crash.
- [ ] All `XomperTests` green (59 tests including 5 new).
- [ ] `xcodebuild -scheme Xomper build` succeeds with no warnings.