### PR TITLE
feat(ai-review): iOS mocks tab + per-matchup blurbs on MatchupsView

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		2F50FD9BC26550139DAD2E96 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F510E2F428E107F1AD75CD /* Config.swift */; };
 		2F60B09D13BABD5E49B3DCBF /* MainShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A254D17EF062523E09C9D4 /* MainShell.swift */; };
 		31CFADD9ECC5AC0D09B24BCF /* PayoutsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3443191E5EED3E2888F8757 /* PayoutsView.swift */; };
+		3403B87830513963A9D86F8F /* MockDraftMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7877A392F88F41B8D4979F23 /* MockDraftMetadataTests.swift */; };
 		366C0075FA9F4ABA1C88C1A9 /* Championship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18383A0375F5728A9E3FE065 /* Championship.swift */; };
 		368D96609CAF02430F340657 /* MatchupHistoryBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A3969B9E9E60F0C59D83C9 /* MatchupHistoryBrowserView.swift */; };
 		37E600A31B5AA5DA5A766692 /* AdminStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ED7387DCA3E1DC5CDD7AFF /* AdminStoreTests.swift */; };
@@ -75,6 +76,8 @@
 		724482308D102AFA35AB4017 /* LeagueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56BB91320E3D5EBE1F777838 /* LeagueStore.swift */; };
 		72FF7B4516B2DCDAE4683B9D /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83A8FEFFD8FA91F498D03A0 /* EmptyStateView.swift */; };
 		73E3AB3D048A23D710376D09 /* AIReviewStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E6A6BADE3F51FA922A078F4 /* AIReviewStore.swift */; };
+		75837F1ECFAFDA457B558FBC /* MockDraftModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = F26DB16948AD7EE81EF91B47 /* MockDraftModels.swift */; };
+		75AB19702AADCC870510A1FC /* WeeklyRecapMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2549566AC9312F44BA381BB6 /* WeeklyRecapMetadata.swift */; };
 		7607DB7C775FCCC3B7C3377B /* StandingsTeam.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29D510D87CD290AE7F76FBF /* StandingsTeam.swift */; };
 		76260F26A40213A62E5F22FB /* RecordBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AD376EFB7AD4A192FAB3E8F /* RecordBadge.swift */; };
 		775985FFAD33E6481C34174A /* TrophyCaseCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2908776CDAC0CACB28B4B1 /* TrophyCaseCard.swift */; };
@@ -170,6 +173,7 @@
 		1FBB5433786555EDDBC896C7 /* XomperTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperTheme.swift; sourceTree = "<group>"; };
 		22A99CAA9B57C1A0144DCA22 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 		22D61F12E32D7C81FCA8F8CE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		2549566AC9312F44BA381BB6 /* WeeklyRecapMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapMetadata.swift; sourceTree = "<group>"; };
 		2B670A3A0762D22FB3202E1E /* DivisionBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DivisionBadge.swift; sourceTree = "<group>"; };
 		2B6C68E1131F2BBBE625DEAF /* RuleProposalFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleProposalFormView.swift; sourceTree = "<group>"; };
 		2DB0B979B62A1CF6EB80417F /* DraftRecapResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftRecapResolverTests.swift; sourceTree = "<group>"; };
@@ -218,6 +222,7 @@
 		72CFD764A2BA7FF93B318A7F /* CareerStatsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareerStatsSection.swift; sourceTree = "<group>"; };
 		765C03E7E4268373F28754DC /* HighestPossibleLineup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighestPossibleLineup.swift; sourceTree = "<group>"; };
 		7839DD9CF0968986F91A58DB /* AdminStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStore.swift; sourceTree = "<group>"; };
+		7877A392F88F41B8D4979F23 /* MockDraftMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftMetadataTests.swift; sourceTree = "<group>"; };
 		7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Draft.swift; sourceTree = "<group>"; };
 		806CFC3CC188242F06D8639C /* PastDraftPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastDraftPickerView.swift; sourceTree = "<group>"; };
 		8098F78566BB324ACC70FB94 /* TeamAnalyzerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamAnalyzerView.swift; sourceTree = "<group>"; };
@@ -292,6 +297,7 @@
 		F013CD37874EFB0FA1CB4261 /* HistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryStore.swift; sourceTree = "<group>"; };
 		F1E7D0FD804723AC6A3E4298 /* HeaderBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderBar.swift; sourceTree = "<group>"; };
 		F2452A5AEC270BE14CC085E1 /* URL+Sleeper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Sleeper.swift"; sourceTree = "<group>"; };
+		F26DB16948AD7EE81EF91B47 /* MockDraftModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftModels.swift; sourceTree = "<group>"; };
 		F3443191E5EED3E2888F8757 /* PayoutsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayoutsView.swift; sourceTree = "<group>"; };
 		F4A254D17EF062523E09C9D4 /* MainShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainShell.swift; sourceTree = "<group>"; };
 		F51CC9357B13AB7ADD9C8586 /* TeamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamView.swift; sourceTree = "<group>"; };
@@ -431,6 +437,7 @@
 				2DB0B979B62A1CF6EB80417F /* DraftRecapResolverTests.swift */,
 				ED7456E9AFD3FA47DA3DA0F7 /* DraftSubTabSelectionTests.swift */,
 				D7F3E6606D89CF3AEB320314 /* LandingViewTests.swift */,
+				7877A392F88F41B8D4979F23 /* MockDraftMetadataTests.swift */,
 				0BC1E989411B5FACF30C4B3A /* PastStandingsArchiveTests.swift */,
 			);
 			path = XomperTests;
@@ -569,6 +576,7 @@
 				43AC494E7D11CB94A2FD56EA /* LeaguePayouts.swift */,
 				C83EF3C6C93199CF3FCBAE42 /* Matchup.swift */,
 				45B52D5FD69B62417928B713 /* MatchupHistory.swift */,
+				F26DB16948AD7EE81EF91B47 /* MockDraftModels.swift */,
 				E1E5A60EE78F668F02CF63C0 /* NflState.swift */,
 				E7E3BE36BCEA1A7722157C37 /* PayoutProjection.swift */,
 				22A99CAA9B57C1A0144DCA22 /* Player.swift */,
@@ -583,6 +591,7 @@
 				A2DA1B65780757E6CC78CD61 /* TaxiSquadPlayer.swift */,
 				FC09DFF48D9AAFEF0A286BAD /* TeamAnalysis.swift */,
 				9F49969EE42BDE6462664021 /* TradedPick.swift */,
+				2549566AC9312F44BA381BB6 /* WeeklyRecapMetadata.swift */,
 				3747C6FC769C117588F8A93E /* WhitelistedLeague.swift */,
 				E969C4A894017F9D0072CCFA /* WorldCup.swift */,
 			);
@@ -835,6 +844,7 @@
 				2BE0B9AB9BAEFD6AA714D2EF /* DraftRecapResolverTests.swift in Sources */,
 				E0951007574761D3F51B21B9 /* DraftSubTabSelectionTests.swift in Sources */,
 				007B11207486956897981421 /* LandingViewTests.swift in Sources */,
+				3403B87830513963A9D86F8F /* MockDraftMetadataTests.swift in Sources */,
 				D9737CEB4C36AEFB5EC727D0 /* PastStandingsArchiveTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -898,6 +908,7 @@
 				368D96609CAF02430F340657 /* MatchupHistoryBrowserView.swift in Sources */,
 				7EA8F8FCEFFE3C165655208C /* MatchupHistoryView.swift in Sources */,
 				16F47DD114B2470F88D007A5 /* MatchupsView.swift in Sources */,
+				75837F1ECFAFDA457B558FBC /* MockDraftModels.swift in Sources */,
 				8C58AAB4103D2F8A473DAA4E /* MocksView.swift in Sources */,
 				9E5C71DAB504EDCDF2084DF3 /* MyProfileView.swift in Sources */,
 				FAE7847413A293EF8CE9090C /* NFLTeamColors.swift in Sources */,
@@ -961,6 +972,7 @@
 				65444EF8D83F3582CE2FC023 /* TrophyCaseSection.swift in Sources */,
 				F5AD059EF52A068C469AFB6E /* URL+Sleeper.swift in Sources */,
 				E2EC532916CAA2FBB779DB35 /* UserStore.swift in Sources */,
+				75AB19702AADCC870510A1FC /* WeeklyRecapMetadata.swift in Sources */,
 				F57132F0D80EAB60AC0E07F3 /* WhitelistedLeague.swift in Sources */,
 				61EBC3AC052763EAAC807AC9 /* WorldCup.swift in Sources */,
 				901F54CB41785D269CC63160 /* WorldCupStore.swift in Sources */,

--- a/Xomper/Core/Models/AIReport.swift
+++ b/Xomper/Core/Models/AIReport.swift
@@ -31,6 +31,12 @@ struct AIReport: Decodable, Identifiable, Sendable, Hashable {
     let period: String
     let bodyMarkdown: String
     let metadata: [String: String]
+    /// Raw JSON bytes of the `metadata` Dynamo Map, captured at decode
+    /// time. Used by typed extractors (`decodeMetadata(_:)`) that need
+    /// nested structures the flat `metadata: [String: String]` map
+    /// can't express — e.g. the `picks[]` array on mock-draft reports
+    /// and `matchups[]` on weekly reports.
+    let metadataRawJSON: Data?
     let createdAt: Date
     let model: String?
     let promptVersion: String?
@@ -58,14 +64,28 @@ struct AIReport: Decodable, Identifiable, Sendable, Hashable {
         self.period = (try? c.decode(String.self, forKey: .period)) ?? ""
         self.bodyMarkdown = (try? c.decode(String.self, forKey: .bodyMarkdown)) ?? ""
 
-        // Metadata is a Dynamo Map of mixed scalars. Decode leniently as
-        // string→string so iOS doesn't need a full Any-codable layer.
+        // Metadata is a Dynamo Map of mixed scalars + nested
+        // structures. Decode leniently as string→string so iOS doesn't
+        // need a full Any-codable layer for the common case (token
+        // counts, dry-run flags, etc.). Nested structures (arrays,
+        // sub-objects) are stripped — typed callers can recover them
+        // via `decodeMetadata(_:)` which reads `metadataRawJSON`.
         if let raw = try? c.decode([String: AnyScalar].self, forKey: .metadata) {
             var out: [String: String] = [:]
             for (k, v) in raw { out[k] = v.stringValue }
             self.metadata = out
         } else {
             self.metadata = [:]
+        }
+
+        // Capture the raw bytes of the metadata map for typed decode
+        // later. `JSONValue` accepts the full JSON grammar (including
+        // nested arrays + objects); re-encoding gives us a portable
+        // blob structured decoders can consume.
+        if let rawValue = try? c.decode(JSONValue.self, forKey: .metadata) {
+            self.metadataRawJSON = try? JSONEncoder().encode(rawValue)
+        } else {
+            self.metadataRawJSON = nil
         }
 
         // ISO 8601 with optional fractional seconds.
@@ -84,6 +104,7 @@ struct AIReport: Decodable, Identifiable, Sendable, Hashable {
         period: String,
         bodyMarkdown: String,
         metadata: [String: String] = [:],
+        metadataRawJSON: Data? = nil,
         createdAt: Date,
         model: String? = nil,
         promptVersion: String? = nil
@@ -94,9 +115,21 @@ struct AIReport: Decodable, Identifiable, Sendable, Hashable {
         self.period = period
         self.bodyMarkdown = bodyMarkdown
         self.metadata = metadata
+        self.metadataRawJSON = metadataRawJSON
         self.createdAt = createdAt
         self.model = model
         self.promptVersion = promptVersion
+    }
+
+    /// Decode the structured metadata blob into a strongly-typed
+    /// Swift model — used by mock drafts (`MockDraftMetadata`) and
+    /// weekly recaps (`WeeklyRecapMetadata`) that need the nested
+    /// `picks[]` / `matchups[]` arrays the flat string map throws
+    /// away. Returns `nil` when the raw JSON is missing or the shape
+    /// doesn't match — callers fall back to an empty state.
+    func decodeMetadata<T: Decodable>(_ type: T.Type) -> T? {
+        guard let data = metadataRawJSON else { return nil }
+        return try? JSONDecoder().decode(T.self, from: data)
     }
 
     /// Human-friendly title for cards and detail headers.
@@ -139,14 +172,15 @@ struct AIReport: Decodable, Identifiable, Sendable, Hashable {
 /// values mirror what `report_type` carries in DynamoDB / the API.
 ///
 /// Backend enforces camelCase via `REPORT_TYPES = ("postDraft",
-/// "preseason", "weekly")` in `lambdas/common/ai_reports_store.py`.
-/// `preseason` and `weekly` already default to their case names, but
-/// `postDraft` must be pinned to the camelCase wire value (was
-/// `"post-draft"` in F0, which would fail to decode).
+/// "preseason", "weekly", "mock")` in `lambdas/common/ai_reports_store.py`.
+/// `preseason`, `weekly`, and `mock` already default to their case
+/// names, but `postDraft` must be pinned to the camelCase wire value
+/// (was `"post-draft"` in F0, which would fail to decode).
 enum AIReportType: String, Codable, Sendable, CaseIterable, Hashable {
     case postDraft = "postDraft"
     case preseason = "preseason"
     case weekly = "weekly"
+    case mock = "mock"
 
     /// Display name used in chips and titles.
     var displayName: String {
@@ -154,6 +188,7 @@ enum AIReportType: String, Codable, Sendable, CaseIterable, Hashable {
         case .postDraft: "Post-Draft"
         case .preseason: "Preseason"
         case .weekly:    "Weekly"
+        case .mock:      "Mock Draft"
         }
     }
 
@@ -163,6 +198,7 @@ enum AIReportType: String, Codable, Sendable, CaseIterable, Hashable {
         case .postDraft: "list.clipboard.fill"
         case .preseason: "calendar"
         case .weekly:    "sparkles"
+        case .mock:      "wand.and.stars"
         }
     }
 
@@ -174,6 +210,7 @@ enum AIReportType: String, Codable, Sendable, CaseIterable, Hashable {
         case .postDraft: XomperColors.championGold
         case .preseason: XomperColors.successGreen
         case .weekly:    XomperColors.championGold
+        case .mock:      XomperColors.championGold
         }
     }
 }
@@ -262,6 +299,53 @@ private enum AnyScalar: Decodable, Sendable {
         case .double(let d): String(d)
         case .bool(let b):   String(b)
         case .null:          ""
+        }
+    }
+}
+
+/// Full JSON-grammar value used when round-tripping the `metadata`
+/// blob through `JSONEncoder` so a typed decoder can later re-extract
+/// nested arrays + objects (mock-draft `picks[]`, weekly
+/// `matchups[]`). The flat string→string `metadata` map on
+/// `AIReport` is preserved for back-compat with the simpler call
+/// sites (e.g. `metadata["dry_run"]` checks in AdminView).
+enum JSONValue: Codable, Sendable, Hashable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+    case null
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if c.decodeNil() { self = .null; return }
+        if let v = try? c.decode(Bool.self)    { self = .bool(v); return }
+        if let v = try? c.decode(Int.self)     { self = .int(v); return }
+        if let v = try? c.decode(Double.self)  { self = .double(v); return }
+        if let v = try? c.decode(String.self)  { self = .string(v); return }
+        if let v = try? c.decode([JSONValue].self) { self = .array(v); return }
+        if let v = try? c.decode([String: JSONValue].self) {
+            self = .object(v)
+            return
+        }
+        throw DecodingError.dataCorruptedError(
+            in: c,
+            debugDescription: "Unsupported JSON value"
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .string(let v): try c.encode(v)
+        case .int(let v):    try c.encode(v)
+        case .double(let v): try c.encode(v)
+        case .bool(let v):   try c.encode(v)
+        case .null:          try c.encodeNil()
+        case .array(let v):  try c.encode(v)
+        case .object(let v): try c.encode(v)
         }
     }
 }

--- a/Xomper/Core/Models/MockDraftModels.swift
+++ b/Xomper/Core/Models/MockDraftModels.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+// MARK: - Mock Draft Metadata
+
+/// Typed view of the `metadata` blob on a `mock` AI report. Decoded
+/// from `AIReport.metadataRawJSON` via `AIReport.decodeMetadata(_:)`.
+///
+/// Wire shape (snake_case):
+/// ```json
+/// {
+///   "personality": "bpa" | "team-fit" | "wildcard",
+///   "draft_year":  "2026",
+///   "mode":        "pure",
+///   "picks_count": "60" | 60,
+///   "picks":       [ { ...MockedPick... }, ... ]
+/// }
+/// ```
+///
+/// Defensive against boto3/Dynamo quirks: numeric fields
+/// (`picks_count` and `MockedPick.value` etc.) may arrive as either
+/// `Int` or `String`. The custom inits handle both.
+struct MockDraftMetadata: Decodable, Sendable, Hashable {
+    let personality: String
+    let draftYear: String
+    let mode: String
+    let picksCount: Int
+    let picks: [MockedPick]
+
+    enum CodingKeys: String, CodingKey {
+        case personality
+        case draftYear = "draft_year"
+        case mode
+        case picksCount = "picks_count"
+        case picks
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.personality = (try? c.decode(String.self, forKey: .personality)) ?? ""
+        self.draftYear = (try? c.decode(String.self, forKey: .draftYear)) ?? ""
+        self.mode = (try? c.decode(String.self, forKey: .mode)) ?? "pure"
+        self.picksCount = MockDraftDecoding.intOrString(c, key: .picksCount) ?? 0
+        self.picks = (try? c.decode([MockedPick].self, forKey: .picks)) ?? []
+    }
+
+    init(
+        personality: String,
+        draftYear: String,
+        mode: String = "pure",
+        picksCount: Int,
+        picks: [MockedPick]
+    ) {
+        self.personality = personality
+        self.draftYear = draftYear
+        self.mode = mode
+        self.picksCount = picksCount
+        self.picks = picks
+    }
+}
+
+/// A single pick from a mock draft. Built server-side by the
+/// mock-draft engine — the iOS layer renders it as-is.
+struct MockedPick: Decodable, Sendable, Hashable, Identifiable {
+    let pickNo: Int
+    let round: Int
+    let slot: Int
+    let userId: String
+    let team: String
+    let handle: String
+    let playerId: String
+    let playerName: String
+    let position: String
+    let nflTeam: String
+    /// Mock-engine internal value score. Wire shape is `String` (boto3
+    /// avoids float precision quirks by serializing as a string), but
+    /// older snapshots may emit `Double` — both are accepted.
+    let value: Double
+
+    var id: Int { pickNo }
+
+    enum CodingKeys: String, CodingKey {
+        case pickNo = "pick_no"
+        case round, slot
+        case userId = "user_id"
+        case team
+        case handle
+        case playerId = "player_id"
+        case playerName = "player_name"
+        case position
+        case nflTeam = "nfl_team"
+        case value
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.pickNo   = MockDraftDecoding.intOrString(c, key: .pickNo) ?? 0
+        self.round    = MockDraftDecoding.intOrString(c, key: .round) ?? 0
+        self.slot     = MockDraftDecoding.intOrString(c, key: .slot) ?? 0
+        self.userId     = (try? c.decode(String.self, forKey: .userId)) ?? ""
+        self.team       = (try? c.decode(String.self, forKey: .team)) ?? ""
+        self.handle     = (try? c.decode(String.self, forKey: .handle)) ?? ""
+        self.playerId   = (try? c.decode(String.self, forKey: .playerId)) ?? ""
+        self.playerName = (try? c.decode(String.self, forKey: .playerName)) ?? ""
+        self.position   = (try? c.decode(String.self, forKey: .position)) ?? ""
+        self.nflTeam    = (try? c.decode(String.self, forKey: .nflTeam)) ?? ""
+        self.value      = MockDraftDecoding.doubleOrString(c, key: .value) ?? 0
+    }
+
+    init(
+        pickNo: Int,
+        round: Int,
+        slot: Int,
+        userId: String,
+        team: String,
+        handle: String,
+        playerId: String,
+        playerName: String,
+        position: String,
+        nflTeam: String,
+        value: Double
+    ) {
+        self.pickNo = pickNo
+        self.round = round
+        self.slot = slot
+        self.userId = userId
+        self.team = team
+        self.handle = handle
+        self.playerId = playerId
+        self.playerName = playerName
+        self.position = position
+        self.nflTeam = nflTeam
+        self.value = value
+    }
+}
+
+// MARK: - Personality Presentation
+
+/// Static metadata used by `MocksView` to render a personality card
+/// (display name, blurb, ordering). Keyed by the lowercase identifier
+/// the backend stores in `metadata.personality`.
+enum MockDraftPersonality: String, CaseIterable, Sendable {
+    case bpa = "bpa"
+    case teamFit = "team-fit"
+    case wildcard = "wildcard"
+
+    /// Stable display order — BPA first because it's the most
+    /// conventional, wildcard last because it's the chaos take.
+    static var displayOrder: [MockDraftPersonality] {
+        [.bpa, .teamFit, .wildcard]
+    }
+
+    var displayName: String {
+        switch self {
+        case .bpa:      "Best Player Available"
+        case .teamFit:  "Team Fit"
+        case .wildcard: "Wildcard"
+        }
+    }
+
+    var blurb: String {
+        switch self {
+        case .bpa:
+            "Picks the highest-rated player on the board regardless of roster construction."
+        case .teamFit:
+            "Weights each team's positional needs against player value — closer to how real GMs draft."
+        case .wildcard:
+            "Random selection within the top 8 available — surfaces the chaotic alternate timelines."
+        }
+    }
+
+    /// Match the personality identifier from a report's metadata. The
+    /// backend emits the canonical lowercase form; this is a hook in
+    /// case future runs add variants.
+    static func from(_ raw: String) -> MockDraftPersonality? {
+        MockDraftPersonality(rawValue: raw.lowercased())
+    }
+}
+
+// MARK: - Decoding Helpers
+
+/// Defensive numeric-field decoder shared between `MockDraftMetadata`,
+/// `MockedPick`, and `WeeklyRecapMetadata`. Tries the native numeric
+/// type first, then falls back to a string the backend may have
+/// emitted via boto3's `Decimal`-as-string serialization quirk.
+enum MockDraftDecoding {
+    static func intOrString<K: CodingKey>(
+        _ container: KeyedDecodingContainer<K>,
+        key: K
+    ) -> Int? {
+        if let v = try? container.decode(Int.self, forKey: key) { return v }
+        if let s = try? container.decode(String.self, forKey: key),
+           let v = Int(s) {
+            return v
+        }
+        if let d = try? container.decode(Double.self, forKey: key) {
+            return Int(d)
+        }
+        return nil
+    }
+
+    static func doubleOrString<K: CodingKey>(
+        _ container: KeyedDecodingContainer<K>,
+        key: K
+    ) -> Double? {
+        if let v = try? container.decode(Double.self, forKey: key) { return v }
+        if let v = try? container.decode(Int.self, forKey: key) {
+            return Double(v)
+        }
+        if let s = try? container.decode(String.self, forKey: key),
+           let v = Double(s) {
+            return v
+        }
+        return nil
+    }
+}

--- a/Xomper/Core/Models/WeeklyRecapMetadata.swift
+++ b/Xomper/Core/Models/WeeklyRecapMetadata.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+// MARK: - Weekly Recap Metadata
+
+/// Typed view of the `metadata` blob on a `weekly` AI report. Decoded
+/// from `AIReport.metadataRawJSON` via `AIReport.decodeMetadata(_:)`.
+///
+/// The backend writes the full week recap to `body_markdown` AND a
+/// per-matchup blurb array to `metadata.matchups[]` so the iOS layer
+/// can render individual blurbs inline under each `MatchupCardView`.
+///
+/// Wire shape (snake_case):
+/// ```json
+/// {
+///   "matchups": [
+///     {
+///       "matchup_id": 1,
+///       "team_a": "Brock Party",
+///       "team_b": "Gangsters of Love",
+///       "handle_a": "domgiordano",
+///       "handle_b": "ozz",
+///       "user_id_a": "...", "user_id_b": "...",
+///       "score_a": "198.6" | 198.6,
+///       "score_b": "92.1"  | 92.1,
+///       "margin":  "106.5" | 106.5,
+///       "winner":  "a" | "b" | "tie",
+///       "blurb":   "**Brock Party obliterated …**"
+///     },
+///     ...
+///   ]
+/// }
+/// ```
+struct WeeklyRecapMetadata: Decodable, Sendable, Hashable {
+    let matchups: [WeeklyMatchupBlurb]
+
+    enum CodingKeys: String, CodingKey {
+        case matchups
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.matchups = (try? c.decode([WeeklyMatchupBlurb].self, forKey: .matchups)) ?? []
+    }
+
+    init(matchups: [WeeklyMatchupBlurb]) {
+        self.matchups = matchups
+    }
+}
+
+/// A single per-matchup blurb extracted from a weekly recap's
+/// metadata. Rendered as a small markdown card under each matchup row
+/// on `MatchupsView` when the user is viewing a past, scored week.
+struct WeeklyMatchupBlurb: Decodable, Sendable, Hashable, Identifiable {
+    let matchupId: Int
+    let teamA: String
+    let teamB: String
+    let handleA: String
+    let handleB: String
+    let userIdA: String
+    let userIdB: String
+    /// Scores + margin land as `String` from boto3 to avoid the
+    /// `Decimal`-as-`float` precision shuffle. Defensive: accept Int /
+    /// Double too in case the backend ever flips them.
+    let scoreA: Double
+    let scoreB: Double
+    let margin: Double
+    /// `"a"` / `"b"` / `"tie"` — preserved as-is so the renderer can
+    /// pick an accent color without round-tripping through an enum.
+    let winner: String
+    /// Markdown blurb (e.g. `"**Brock Party obliterated …**"`).
+    /// Rendered via `AttributedString(markdown:)`.
+    let blurb: String
+
+    var id: Int { matchupId }
+
+    enum CodingKeys: String, CodingKey {
+        case matchupId = "matchup_id"
+        case teamA = "team_a"
+        case teamB = "team_b"
+        case handleA = "handle_a"
+        case handleB = "handle_b"
+        case userIdA = "user_id_a"
+        case userIdB = "user_id_b"
+        case scoreA = "score_a"
+        case scoreB = "score_b"
+        case margin
+        case winner
+        case blurb
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.matchupId = MockDraftDecoding.intOrString(c, key: .matchupId) ?? 0
+        self.teamA = (try? c.decode(String.self, forKey: .teamA)) ?? ""
+        self.teamB = (try? c.decode(String.self, forKey: .teamB)) ?? ""
+        self.handleA = (try? c.decode(String.self, forKey: .handleA)) ?? ""
+        self.handleB = (try? c.decode(String.self, forKey: .handleB)) ?? ""
+        self.userIdA = (try? c.decode(String.self, forKey: .userIdA)) ?? ""
+        self.userIdB = (try? c.decode(String.self, forKey: .userIdB)) ?? ""
+        self.scoreA = MockDraftDecoding.doubleOrString(c, key: .scoreA) ?? 0
+        self.scoreB = MockDraftDecoding.doubleOrString(c, key: .scoreB) ?? 0
+        self.margin = MockDraftDecoding.doubleOrString(c, key: .margin) ?? 0
+        self.winner = (try? c.decode(String.self, forKey: .winner)) ?? "tie"
+        self.blurb = (try? c.decode(String.self, forKey: .blurb)) ?? ""
+    }
+
+    init(
+        matchupId: Int,
+        teamA: String,
+        teamB: String,
+        handleA: String = "",
+        handleB: String = "",
+        userIdA: String = "",
+        userIdB: String = "",
+        scoreA: Double,
+        scoreB: Double,
+        margin: Double,
+        winner: String,
+        blurb: String
+    ) {
+        self.matchupId = matchupId
+        self.teamA = teamA
+        self.teamB = teamB
+        self.handleA = handleA
+        self.handleB = handleB
+        self.userIdA = userIdA
+        self.userIdB = userIdB
+        self.scoreA = scoreA
+        self.scoreB = scoreB
+        self.margin = margin
+        self.winner = winner
+        self.blurb = blurb
+    }
+}

--- a/Xomper/Core/Networking/XomperAPIClient.swift
+++ b/Xomper/Core/Networking/XomperAPIClient.swift
@@ -17,6 +17,8 @@ protocol XomperAPIClientProtocol: Sendable {
     // AI Review
     func fetchLatestAIReport(type: AIReportType) async throws -> AIReport?
     func fetchAIReportsList(type: AIReportType?, limit: Int, cursor: String?) async throws -> AIReportsListResponse
+    func fetchAIReportByPeriod(type: AIReportType, period: String) async throws -> AIReport?
+    func fetchMockDrafts() async throws -> [AIReport]
     func triggerPostDraftAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse
     func triggerPreseasonAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse
     func triggerWeeklyAIReview(week: Int?, dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse
@@ -437,6 +439,63 @@ final class XomperAPIClient: XomperAPIClientProtocol {
             items.append(URLQueryItem(name: "cursor", value: cursor))
         }
         return try await get("/ai-reports/list", queryItems: items)
+    }
+
+    /// Look up a single AI report by its `(type, period)` pair. The
+    /// list endpoint doesn't yet accept a `period=` query param, so
+    /// this lists by type and client-side picks the row whose
+    /// `period` matches. Returns `nil` when no row matches — caller
+    /// can render an empty state. Walks the cursor if necessary so a
+    /// later-period report deep in the archive is still resolvable.
+    ///
+    /// Used by `MatchupsView` to fetch the weekly recap whose
+    /// `metadata.matchups[]` carries the per-matchup blurbs for a
+    /// past, scored week (e.g. `period = "2025W04"`).
+    func fetchAIReportByPeriod(
+        type: AIReportType,
+        period: String
+    ) async throws -> AIReport? {
+        var cursor: String? = nil
+        // Cap the walk so a misconfigured backend can't loop us.
+        // 5 pages × 20 rows = 100 reports of a single type, which is
+        // far more than the league produces in a season.
+        for _ in 0..<5 {
+            let response = try await fetchAIReportsList(
+                type: type,
+                limit: 20,
+                cursor: cursor
+            )
+            if let hit = response.rows.first(where: { $0.period == period }) {
+                return hit
+            }
+            guard let next = response.nextCursor, !next.isEmpty else {
+                return nil
+            }
+            cursor = next
+        }
+        return nil
+    }
+
+    /// Convenience wrapper over `fetchAIReportsList(type: .mock)` —
+    /// the mock-draft surface always wants every mock the backend has
+    /// produced for the active draft year, so we drain the cursor up
+    /// front instead of building cursor state into `MocksView`. The
+    /// per-personality count is small (3 today, ~handful at most), so
+    /// the all-pages walk is cheap.
+    func fetchMockDrafts() async throws -> [AIReport] {
+        var all: [AIReport] = []
+        var cursor: String? = nil
+        for _ in 0..<5 {
+            let response = try await fetchAIReportsList(
+                type: .mock,
+                limit: 20,
+                cursor: cursor
+            )
+            all.append(contentsOf: response.rows)
+            guard let next = response.nextCursor, !next.isEmpty else { break }
+            cursor = next
+        }
+        return all
     }
 
     /// Admin-only: fires the backend `notif_ai_review_postdraft`

--- a/Xomper/Core/Stores/AIReviewStore.swift
+++ b/Xomper/Core/Stores/AIReviewStore.swift
@@ -30,6 +30,23 @@ final class AIReviewStore {
     /// `nil` means no more pages.
     private(set) var archiveCursor: String?
 
+    /// Mock-draft reports — one per personality (`bpa`, `team-fit`,
+    /// `wildcard`). Populated by `loadMockDrafts()`. Held separately
+    /// from `archive` so `MocksView` can render them without scanning
+    /// the full archive on every render, and so the mock-draft surface
+    /// can refresh independently of the main archive list.
+    private(set) var mockDrafts: [AIReport] = []
+    private(set) var isLoadingMockDrafts = false
+    private(set) var mockDraftsError: Error?
+    private(set) var mockDraftsLoadedAt: Date?
+
+    /// Weekly recap reports indexed by `period` (e.g. `"2025W04"`).
+    /// Populated by `loadWeeklyReport(period:)` and consumed by
+    /// `MatchupsView` to render per-matchup blurbs under the matchup
+    /// cards. Cached so flipping between weeks doesn't re-fetch.
+    private(set) var weeklyReportsByPeriod: [String: AIReport] = [:]
+    private(set) var loadingWeeklyPeriods: Set<String> = []
+
     private(set) var isLoading = false
     private(set) var isLoadingMore = false
     private(set) var error: Error?
@@ -124,12 +141,83 @@ final class AIReviewStore {
         }
     }
 
+    /// Fetch every mock-draft report (one per personality) for the
+    /// active league. Replaces `mockDrafts` wholesale on success.
+    /// Skips re-fetch within 12 hours unless `force` is set.
+    ///
+    /// Loaded lazily by `MocksView` on first appearance and re-fetched
+    /// by pull-to-refresh.
+    func loadMockDrafts(force: Bool = false) async {
+        guard !isLoadingMockDrafts else { return }
+        if !force,
+           !mockDrafts.isEmpty,
+           let last = mockDraftsLoadedAt,
+           Date().timeIntervalSince(last) < 12 * 60 * 60 {
+            return
+        }
+        isLoadingMockDrafts = true
+        defer { isLoadingMockDrafts = false }
+        mockDraftsError = nil
+
+        do {
+            let rows = try await apiClient.fetchMockDrafts()
+            self.mockDrafts = rows
+            self.mockDraftsLoadedAt = Date()
+        } catch {
+            self.mockDraftsError = error
+        }
+    }
+
+    /// Fetch the weekly recap whose `period` matches the supplied
+    /// string (e.g. `"2025W04"`). Cached in `weeklyReportsByPeriod`
+    /// so subsequent reads on the same week return immediately. No-op
+    /// when the period is already cached or in-flight.
+    ///
+    /// Called from `MatchupsView` when the user expands a past,
+    /// scored week so the per-matchup blurbs can render inline.
+    func loadWeeklyReport(period: String, force: Bool = false) async {
+        guard !period.isEmpty else { return }
+        if !force,
+           weeklyReportsByPeriod[period] != nil {
+            return
+        }
+        guard !loadingWeeklyPeriods.contains(period) else { return }
+        loadingWeeklyPeriods.insert(period)
+        defer { loadingWeeklyPeriods.remove(period) }
+
+        do {
+            if let report = try await apiClient.fetchAIReportByPeriod(
+                type: .weekly,
+                period: period
+            ) {
+                weeklyReportsByPeriod[period] = report
+            }
+            // `nil` is a valid "no recap for this week yet" answer —
+            // leave the dictionary untouched so callers can fall back
+            // to the no-blurb empty state.
+        } catch {
+            self.error = error
+        }
+    }
+
+    /// Format a `(season, week)` pair into the wire period string the
+    /// backend stamps on weekly reports — e.g. `("2025", 4)` →
+    /// `"2025W04"`. Centralized here so the view doesn't have to know
+    /// the wire format.
+    static func weeklyPeriod(season: String, week: Int) -> String {
+        guard !season.isEmpty, week > 0 else { return "" }
+        return String(format: "%@W%02d", season, week)
+    }
+
     /// Clear all state and force a full reload — used by
     /// pull-to-refresh.
     func refresh() async {
         archive = []
         archiveCursor = nil
         latestByType = [:]
+        mockDrafts = []
+        mockDraftsLoadedAt = nil
+        weeklyReportsByPeriod = [:]
         lastLoadedAt = nil
         error = nil
         await loadArchive(force: true)

--- a/Xomper/Features/DraftHistory/Draft/MocksView.swift
+++ b/Xomper/Features/DraftHistory/Draft/MocksView.swift
@@ -1,19 +1,327 @@
 import SwiftUI
 
-/// Placeholder for the rookie-mock-draft engine. Copy + icon mirror
-/// the pre-F3 `DraftOrderView.mocksPlaceholder` verbatim. Replaced
-/// with the real engine in the separate Mock Drafts epic.
+/// Renders the three mock-draft personalities (BPA, Team Fit,
+/// Wildcard) as collapsible cards. Each card surfaces the first five
+/// rounds of the 60-pick mock as a table — round / slot / team /
+/// player / pos — with a "YOU" badge on the rows belonging to the
+/// signed-in user.
+///
+/// Data flow:
+/// 1. On appear, `aiReviewStore.loadMockDrafts()` pulls every
+///    `type=mock` report for the league. Cached for 12 hours.
+/// 2. Each report's `metadata.personality` field maps to a
+///    `MockDraftPersonality`; the 60-pick `metadata.picks[]` array
+///    is decoded via `AIReport.decodeMetadata(MockDraftMetadata.self)`.
+/// 3. The first personality card (BPA) is expanded by default; the
+///    other two start collapsed to keep the surface tight on first
+///    appearance.
+///
+/// Backend dependency: the `"mock"` AIReportType case must be
+/// recognized by the list endpoint (Xomware/xomper-back-end#62). On a
+/// stack where that PR hasn't deployed yet, the fetch returns zero
+/// rows and the view falls back to the empty state.
 struct MocksView: View {
+    var aiReviewStore: AIReviewStore
+    var userStore: UserStore
+
+    /// Tracks which personality cards are expanded. BPA expanded by
+    /// default per the spec ("first expanded, rest collapsed").
+    @State private var expanded: Set<MockDraftPersonality> = [.bpa]
+
     var body: some View {
-        EmptyStateView(
-            icon: "wand.and.stars",
-            title: "Mock Drafts Coming Soon",
-            message: "A 5-round rookie mock driven by team-need scoring + multiple draft personalities. Lands in the next update."
+        Group {
+            if aiReviewStore.isLoadingMockDrafts && aiReviewStore.mockDrafts.isEmpty {
+                LoadingView(message: "Loading mock drafts…")
+            } else if let error = aiReviewStore.mockDraftsError,
+                      aiReviewStore.mockDrafts.isEmpty {
+                ErrorView(message: error.localizedDescription) {
+                    Task { await aiReviewStore.loadMockDrafts(force: true) }
+                }
+            } else if aiReviewStore.mockDrafts.isEmpty {
+                EmptyStateView(
+                    icon: "wand.and.stars",
+                    title: "No Mock Drafts Yet",
+                    message: "The mock-draft engine hasn't published results for this year. Check back after the next run."
+                )
+            } else {
+                mocksContent
+            }
+        }
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .task {
+            await aiReviewStore.loadMockDrafts()
+        }
+        .refreshable {
+            await aiReviewStore.loadMockDrafts(force: true)
+        }
+    }
+
+    // MARK: - Content
+
+    private var mocksContent: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
+                ForEach(MockDraftPersonality.displayOrder, id: \.self) { personality in
+                    if let report = report(for: personality) {
+                        personalityCard(report: report, personality: personality)
+                    }
+                }
+            }
+            .padding(.horizontal, XomperTheme.Spacing.md)
+            .padding(.vertical, XomperTheme.Spacing.sm)
+        }
+    }
+
+    // MARK: - Personality Card
+
+    @ViewBuilder
+    private func personalityCard(report: AIReport, personality: MockDraftPersonality) -> some View {
+        if let metadata = report.decodeMetadata(MockDraftMetadata.self) {
+            personalityCardBody(
+                report: report,
+                personality: personality,
+                metadata: metadata
+            )
+        } else {
+            // Metadata couldn't be decoded — body markdown is still
+            // available, but the table view depends on the structured
+            // picks. Fall back to an empty card with a hint.
+            personalityHeaderOnly(personality: personality, report: report)
+        }
+    }
+
+    private func personalityCardBody(
+        report: AIReport,
+        personality: MockDraftPersonality,
+        metadata: MockDraftMetadata
+    ) -> some View {
+        let isExpanded = expanded.contains(personality)
+
+        return VStack(alignment: .leading, spacing: 0) {
+            cardHeader(
+                personality: personality,
+                report: report,
+                isExpanded: isExpanded
+            )
+
+            if isExpanded {
+                VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+                    Text(personality.blurb)
+                        .font(.caption)
+                        .foregroundStyle(XomperColors.textSecondary)
+                        .padding(.top, XomperTheme.Spacing.xs)
+
+                    Divider()
+                        .overlay(XomperColors.surfaceLight)
+                        .padding(.vertical, XomperTheme.Spacing.xs)
+
+                    picksTable(picks: metadata.picks)
+
+                    Text("Showing rounds 1–5 of \(metadata.picksCount / 12)")
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .padding(.top, XomperTheme.Spacing.xs)
+                }
+                .padding(.top, XomperTheme.Spacing.sm)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.25), lineWidth: 1)
         )
+    }
+
+    private func personalityHeaderOnly(
+        personality: MockDraftPersonality,
+        report: AIReport
+    ) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            cardHeader(personality: personality, report: report, isExpanded: false)
+            Text("Mock results couldn't be parsed.")
+                .font(.caption)
+                .foregroundStyle(XomperColors.textMuted)
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+    }
+
+    // MARK: - Header
+
+    private func cardHeader(
+        personality: MockDraftPersonality,
+        report: AIReport,
+        isExpanded: Bool
+    ) -> some View {
+        Button {
+            let generator = UIImpactFeedbackGenerator(style: .light)
+            generator.impactOccurred()
+            withAnimation(XomperTheme.defaultAnimation) {
+                if expanded.contains(personality) {
+                    expanded.remove(personality)
+                } else {
+                    expanded.insert(personality)
+                }
+            }
+        } label: {
+            HStack(spacing: XomperTheme.Spacing.sm) {
+                Image(systemName: "wand.and.stars")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(XomperColors.championGold)
+                    .frame(width: 24)
+
+                VStack(alignment: .leading, spacing: XomperTheme.Spacing.xxs) {
+                    Text(personality.displayName)
+                        .font(.headline)
+                        .foregroundStyle(XomperColors.textPrimary)
+                    Text(report.period)
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .monospacedDigit()
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.down")
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textMuted)
+                    .rotationEffect(.degrees(isExpanded ? 180 : 0))
+                    .animation(XomperTheme.defaultAnimation, value: isExpanded)
+            }
+            .frame(minHeight: XomperTheme.minTouchTarget)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityLabel("\(personality.displayName), \(report.period)")
+        .accessibilityHint(isExpanded ? "Collapse" : "Expand to see the first five rounds")
+    }
+
+    // MARK: - Picks Table
+
+    /// Renders rounds 1-5 as a simple table. Sleeper drafts are 12
+    /// teams × 60 picks (5 rounds), so for the typical mock this is
+    /// the entire roster. Filter on `round <= 5` defensively in case
+    /// the engine ever runs more.
+    private func picksTable(picks: [MockedPick]) -> some View {
+        let myUserId = userStore.myUser?.userId
+        let first5Rounds = picks
+            .filter { $0.round <= 5 }
+            .sorted { $0.pickNo < $1.pickNo }
+
+        return VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            tableHeader
+
+            ForEach(first5Rounds) { pick in
+                pickRow(pick: pick, isMine: !pick.userId.isEmpty && pick.userId == myUserId)
+            }
+        }
+    }
+
+    private var tableHeader: some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            Text("R")
+                .frame(width: 18, alignment: .center)
+            Text("Pick")
+                .frame(width: 38, alignment: .center)
+            Text("Team")
+                .frame(width: 90, alignment: .leading)
+            Text("Player")
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text("Pos")
+                .frame(width: 34, alignment: .center)
+        }
+        .font(.caption2.weight(.bold))
+        .foregroundStyle(XomperColors.textMuted)
+        .textCase(.uppercase)
+        .tracking(0.5)
+        .padding(.vertical, XomperTheme.Spacing.xxs)
+    }
+
+    private func pickRow(pick: MockedPick, isMine: Bool) -> some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            Text("\(pick.round)")
+                .frame(width: 18, alignment: .center)
+                .foregroundStyle(XomperColors.championGold)
+                .font(.caption.weight(.bold))
+                .monospacedDigit()
+
+            Text("#\(pick.pickNo)")
+                .frame(width: 38, alignment: .center)
+                .foregroundStyle(XomperColors.textMuted)
+                .font(.caption2)
+                .monospacedDigit()
+
+            Text(pick.team.isEmpty ? pick.handle : pick.team)
+                .frame(width: 90, alignment: .leading)
+                .font(.caption.weight(isMine ? .bold : .regular))
+                .foregroundStyle(isMine ? XomperColors.championGold : XomperColors.textSecondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                Text(pick.playerName)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                if isMine {
+                    Text("YOU")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(XomperColors.bgDark)
+                        .padding(.horizontal, XomperTheme.Spacing.xs)
+                        .padding(.vertical, 1)
+                        .background(XomperColors.championGold)
+                        .clipShape(Capsule())
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text(pick.position)
+                .frame(width: 34, alignment: .center)
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(XomperColors.bgDark)
+                .padding(.vertical, 2)
+                .background(positionColor(pick.position))
+                .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.sm))
+        }
+        .padding(.vertical, XomperTheme.Spacing.xxs)
+    }
+
+    // MARK: - Helpers
+
+    /// Resolves the `AIReport` for a personality by matching
+    /// `metadata.personality`. Personality strings ride in the flat
+    /// `metadata: [String: String]` map so we don't have to round-trip
+    /// the structured decoder for the lookup.
+    private func report(for personality: MockDraftPersonality) -> AIReport? {
+        aiReviewStore.mockDrafts.first { report in
+            let raw = report.metadata["personality"] ?? ""
+            return MockDraftPersonality.from(raw) == personality
+        }
+    }
+
+    private func positionColor(_ pos: String) -> Color {
+        switch pos.uppercased() {
+        case "QB": return Color(red: 0.95, green: 0.30, blue: 0.42)
+        case "RB": return Color(red: 0.20, green: 0.80, blue: 0.50)
+        case "WR": return Color(red: 0.30, green: 0.55, blue: 0.95)
+        case "TE": return Color(red: 0.95, green: 0.65, blue: 0.20)
+        case "K":  return Color(red: 0.65, green: 0.55, blue: 0.85)
+        case "DEF", "DST": return Color(red: 0.55, green: 0.55, blue: 0.55)
+        default: return XomperColors.surfaceLight
+        }
     }
 }
 
 #Preview {
-    MocksView()
-        .preferredColorScheme(.dark)
+    MocksView(
+        aiReviewStore: AIReviewStore(),
+        userStore: UserStore()
+    )
+    .preferredColorScheme(.dark)
 }

--- a/Xomper/Features/DraftHistory/DraftHistoryView.swift
+++ b/Xomper/Features/DraftHistory/DraftHistoryView.swift
@@ -76,7 +76,10 @@ struct DraftHistoryView: View {
                         nflStateStore: nflStateStore
                     )
                 case .mocks:
-                    MocksView()
+                    MocksView(
+                        aiReviewStore: aiReviewStore,
+                        userStore: userStore
+                    )
                 case .recap:
                     DraftRecapView(
                         aiReviewStore: aiReviewStore,

--- a/Xomper/Features/League/MatchupsView.swift
+++ b/Xomper/Features/League/MatchupsView.swift
@@ -4,6 +4,7 @@ struct MatchupsView: View {
     var leagueStore: LeagueStore
     var historyStore: HistoryStore
     var playerStore: PlayerStore
+    var aiReviewStore: AIReviewStore
     var router: AppRouter
 
     @Environment(\.selectedSeason) private var seasonStore: SeasonStore?
@@ -103,14 +104,78 @@ struct MatchupsView: View {
             if expandedWeek == weekData.week {
                 VStack(spacing: XomperTheme.Spacing.md) {
                     ForEach(weekData.matchups) { matchup in
-                        MatchupCardView(matchup: matchup) {
-                            selectedMatchup = matchup
+                        VStack(spacing: XomperTheme.Spacing.xs) {
+                            MatchupCardView(matchup: matchup) {
+                                selectedMatchup = matchup
+                            }
+
+                            // Inline AI-generated blurb under the matchup
+                            // card. Renders only when the weekly recap
+                            // is present + has a matching `matchup_id`.
+                            // Current weeks and weeks pre-AI-review
+                            // (none of 2024/2025 today, all backfilled)
+                            // produce no blurb — view is silently absent.
+                            if let blurb = blurb(for: matchup, weekData: weekData) {
+                                MatchupBlurbCardView(blurb: blurb)
+                            }
                         }
                     }
                 }
                 .padding(.top, XomperTheme.Spacing.sm)
                 .transition(.opacity.combined(with: .move(edge: .top)))
+                .task(id: weekRecapTaskId(weekData)) {
+                    // Only fetch the recap once a week is expanded AND
+                    // it has scores — otherwise we'd fan out a request
+                    // for every week and waste cycles on the
+                    // unscored current week.
+                    guard weekData.hasScores else { return }
+                    let period = AIReviewStore.weeklyPeriod(
+                        season: currentSeason,
+                        week: weekData.week
+                    )
+                    await aiReviewStore.loadWeeklyReport(period: period)
+                }
             }
+        }
+    }
+
+    /// Stable identifier used by the `.task(id:)` modifier so the
+    /// weekly-recap fetch fires once per (season, week) expansion and
+    /// doesn't repeat on every render. Embedding `currentSeason`
+    /// avoids stale fetches when the season chip flips.
+    private func weekRecapTaskId(_ weekData: WeekMatchups) -> String {
+        "\(currentSeason)-\(weekData.week)"
+    }
+
+    /// Resolves the per-matchup blurb for a rendered matchup. Looks
+    /// up the weekly recap by `(season, week)` period, then keys into
+    /// its `metadata.matchups[]` array by `matchup_id`. Falls back to
+    /// a team-name match if Sleeper rotated the matchup ids after a
+    /// re-roster cycle (rare, but defensive).
+    private func blurb(
+        for matchup: MatchupHistoryRecord,
+        weekData: WeekMatchups
+    ) -> WeeklyMatchupBlurb? {
+        let period = AIReviewStore.weeklyPeriod(
+            season: currentSeason,
+            week: weekData.week
+        )
+        guard !period.isEmpty,
+              let report = aiReviewStore.weeklyReportsByPeriod[period],
+              let recap = report.decodeMetadata(WeeklyRecapMetadata.self) else {
+            return nil
+        }
+
+        if let hit = recap.matchups.first(where: { $0.matchupId == matchup.matchupId }) {
+            return hit
+        }
+        // Fallback: same teams, regardless of `matchup_id`. Order
+        // doesn't matter because both pairings (A→B, B→A) are valid.
+        let aName = matchup.teamATeamName.isEmpty ? matchup.teamAUsername : matchup.teamATeamName
+        let bName = matchup.teamBTeamName.isEmpty ? matchup.teamBUsername : matchup.teamBTeamName
+        return recap.matchups.first { blurb in
+            (blurb.teamA == aName && blurb.teamB == bName) ||
+            (blurb.teamA == bName && blurb.teamB == aName)
         }
     }
 
@@ -327,12 +392,63 @@ private enum MatchupResult {
     }
 }
 
+// MARK: - Matchup Blurb Card
+
+/// Small markdown-rendered card that sits under a `MatchupCardView`
+/// when the week's AI recap has a per-matchup blurb. The blurb
+/// markdown leans on `**bold**` for team names + margins so
+/// `AttributedString(markdown:)` is sufficient — no need for the
+/// heavier interpreted-syntax setup.
+private struct MatchupBlurbCardView: View {
+    let blurb: WeeklyMatchupBlurb
+
+    var body: some View {
+        HStack(alignment: .top, spacing: XomperTheme.Spacing.sm) {
+            Image(systemName: "sparkles")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(XomperColors.championGold)
+                .padding(.top, 2)
+
+            renderedBlurb
+                .font(.caption)
+                .foregroundStyle(XomperColors.textPrimary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(XomperTheme.Spacing.sm)
+        .background(XomperColors.bgCard.opacity(0.6))
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md)
+                .strokeBorder(XomperColors.championGold.opacity(0.25), lineWidth: 0.5)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Recap: \(blurb.blurb)")
+    }
+
+    @ViewBuilder
+    private var renderedBlurb: some View {
+        if let attributed = try? AttributedString(
+            markdown: blurb.blurb,
+            options: AttributedString.MarkdownParsingOptions(
+                interpretedSyntax: .inlineOnlyPreservingWhitespace
+            )
+        ) {
+            Text(attributed)
+        } else {
+            Text(blurb.blurb)
+        }
+    }
+}
+
 #Preview {
     NavigationStack {
         MatchupsView(
             leagueStore: LeagueStore(),
             historyStore: HistoryStore(),
             playerStore: PlayerStore(),
+            aiReviewStore: AIReviewStore(),
             router: AppRouter()
         )
     }

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -149,6 +149,7 @@ struct MainShell: View {
                     leagueStore: leagueStore,
                     historyStore: historyStore,
                     playerStore: playerStore,
+                    aiReviewStore: aiReviewStore,
                     router: router
                 )
 

--- a/XomperTests/AIReviewStoreTests.swift
+++ b/XomperTests/AIReviewStoreTests.swift
@@ -120,7 +120,101 @@ final class AIReviewStoreTests: XCTestCase {
         XCTAssertEqual(mock.listCalls.count, listCallsBefore, "loadMore should be a no-op when cursor is nil")
     }
 
-    // MARK: - Test 6: mostRecentLatest picks newest across types
+    // MARK: - Test 6a: loadMockDrafts populates mockDrafts
+
+    func testLoadMockDrafts_populatesMockDrafts() async {
+        let r1 = makeReport(
+            id: "L1|REPORT#mock#2026-bpa",
+            type: .mock,
+            period: "2026-bpa"
+        )
+        let r2 = makeReport(
+            id: "L1|REPORT#mock#2026-team-fit",
+            type: .mock,
+            period: "2026-team-fit"
+        )
+        let r3 = makeReport(
+            id: "L1|REPORT#mock#2026-wildcard",
+            type: .mock,
+            period: "2026-wildcard"
+        )
+        let mock = MockXomperAPIClient(
+            listPagesByType: [
+                AIReportType.mock.rawValue: [(rows: [r1, r2, r3], cursor: nil)]
+            ]
+        )
+        let store = AIReviewStore(apiClient: mock)
+
+        await store.loadMockDrafts()
+
+        XCTAssertEqual(store.mockDrafts.count, 3)
+        XCTAssertEqual(store.mockDrafts.map(\.period), ["2026-bpa", "2026-team-fit", "2026-wildcard"])
+        XCTAssertNil(store.mockDraftsError)
+        XCTAssertEqual(mock.mockDraftsCallCount, 1)
+    }
+
+    // MARK: - Test 6b: loadMockDrafts short-circuits within freshness window
+
+    func testLoadMockDrafts_skipsWithinFreshnessWindow() async {
+        let r1 = makeReport(
+            id: "L1|REPORT#mock#2026-bpa",
+            type: .mock,
+            period: "2026-bpa"
+        )
+        let mock = MockXomperAPIClient(
+            listPagesByType: [
+                AIReportType.mock.rawValue: [(rows: [r1], cursor: nil)]
+            ]
+        )
+        let store = AIReviewStore(apiClient: mock)
+
+        await store.loadMockDrafts()
+        XCTAssertEqual(mock.mockDraftsCallCount, 1)
+
+        await store.loadMockDrafts()
+        XCTAssertEqual(mock.mockDraftsCallCount, 1, "Should short-circuit inside the 12-hour window")
+
+        await store.loadMockDrafts(force: true)
+        XCTAssertEqual(mock.mockDraftsCallCount, 2)
+    }
+
+    // MARK: - Test 6c: loadWeeklyReport caches by period
+
+    func testLoadWeeklyReport_cachesByPeriod() async {
+        let r = makeReport(
+            id: "L1|REPORT#weekly#2025W04",
+            type: .weekly,
+            period: "2025W04"
+        )
+        let mock = MockXomperAPIClient(
+            reportsByPeriod: ["2025W04": r]
+        )
+        let store = AIReviewStore(apiClient: mock)
+
+        await store.loadWeeklyReport(period: "2025W04")
+        XCTAssertEqual(store.weeklyReportsByPeriod["2025W04"]?.id, r.id)
+        XCTAssertEqual(mock.byPeriodCalls.count, 1)
+
+        // Second call for the same period — must short-circuit.
+        await store.loadWeeklyReport(period: "2025W04")
+        XCTAssertEqual(mock.byPeriodCalls.count, 1, "Cached period should not refetch")
+
+        // Different period — must fetch.
+        await store.loadWeeklyReport(period: "2025W05")
+        XCTAssertEqual(mock.byPeriodCalls.count, 2)
+    }
+
+    // MARK: - Test 6d: loadWeeklyReport ignores empty period
+
+    func testLoadWeeklyReport_ignoresEmptyPeriod() async {
+        let mock = MockXomperAPIClient()
+        let store = AIReviewStore(apiClient: mock)
+
+        await store.loadWeeklyReport(period: "")
+        XCTAssertEqual(mock.byPeriodCalls.count, 0)
+    }
+
+    // MARK: - Test 7: mostRecentLatest picks newest across types
 
     func testMostRecentLatest_picksNewestAcrossTypes() async {
         let older = makeReport(
@@ -155,17 +249,31 @@ final class AIReviewStoreTests: XCTestCase {
 final class MockXomperAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
     var latest: [AIReportType: AIReport]
     var listPages: [(rows: [AIReport], cursor: String?)]
+    /// Pages returned by `fetchAIReportsList` when a `type` filter is
+    /// passed. Keys are stringly the rawValue so tests don't need to
+    /// reach into the enum. Falls back to the unfiltered `listPages`
+    /// queue when no type-specific override is registered.
+    var listPagesByType: [String: [(rows: [AIReport], cursor: String?)]]
+    private var listPageIndexByType: [String: Int] = [:]
+    /// `(period, report)` rows returned by `fetchAIReportByPeriod`.
+    var reportsByPeriod: [String: AIReport]
 
     private(set) var latestCalls: [AIReportType] = []
     private(set) var listCalls: [(type: AIReportType?, limit: Int, cursor: String?)] = []
+    private(set) var byPeriodCalls: [(type: AIReportType, period: String)] = []
+    private(set) var mockDraftsCallCount = 0
     private var listPageIndex = 0
 
     init(
         latest: [AIReportType: AIReport] = [:],
-        listPages: [(rows: [AIReport], cursor: String?)] = []
+        listPages: [(rows: [AIReport], cursor: String?)] = [],
+        listPagesByType: [String: [(rows: [AIReport], cursor: String?)]] = [:],
+        reportsByPeriod: [String: AIReport] = [:]
     ) {
         self.latest = latest
         self.listPages = listPages
+        self.listPagesByType = listPagesByType
+        self.reportsByPeriod = reportsByPeriod
     }
 
     // MARK: AI Review
@@ -181,12 +289,31 @@ final class MockXomperAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
         cursor: String?
     ) async throws -> AIReportsListResponse {
         listCalls.append((type, limit, cursor))
+        if let type, let pages = listPagesByType[type.rawValue] {
+            let idx = listPageIndexByType[type.rawValue] ?? 0
+            guard idx < pages.count else {
+                return AIReportsListResponse(rows: [], nextCursor: nil)
+            }
+            let page = pages[idx]
+            listPageIndexByType[type.rawValue] = idx + 1
+            return AIReportsListResponse(rows: page.rows, nextCursor: page.cursor)
+        }
         guard listPageIndex < listPages.count else {
             return AIReportsListResponse(rows: [], nextCursor: nil)
         }
         let page = listPages[listPageIndex]
         listPageIndex += 1
         return AIReportsListResponse(rows: page.rows, nextCursor: page.cursor)
+    }
+
+    func fetchAIReportByPeriod(type: AIReportType, period: String) async throws -> AIReport? {
+        byPeriodCalls.append((type, period))
+        return reportsByPeriod[period]
+    }
+
+    func fetchMockDrafts() async throws -> [AIReport] {
+        mockDraftsCallCount += 1
+        return listPagesByType[AIReportType.mock.rawValue]?.flatMap(\.rows) ?? []
     }
 
     // MARK: Unused protocol surface — throw to catch accidental calls

--- a/XomperTests/AdminStoreTests.swift
+++ b/XomperTests/AdminStoreTests.swift
@@ -233,6 +233,14 @@ final class MockAdminAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
         AIReportsListResponse(rows: [], nextCursor: nil)
     }
 
+    func fetchAIReportByPeriod(type: AIReportType, period: String) async throws -> AIReport? {
+        nil
+    }
+
+    func fetchMockDrafts() async throws -> [AIReport] {
+        []
+    }
+
     func triggerPostDraftAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse {
         triggerCalls.append((dryRun, force))
         if let err = triggerError { throw err }

--- a/XomperTests/MockDraftMetadataTests.swift
+++ b/XomperTests/MockDraftMetadataTests.swift
@@ -1,0 +1,317 @@
+import XCTest
+@testable import Xomper
+
+/// Tests for `MockDraftMetadata` + `MockedPick` + `WeeklyMatchupBlurb`
+/// decoders. The wire payloads serialize numeric fields as either
+/// `Int` (clean Lambda-side floats) or `String` (boto3's
+/// `Decimal`-as-`String` quirk). The decoders must accept either.
+@MainActor
+final class MockDraftMetadataTests: XCTestCase {
+
+    // MARK: - MockDraftMetadata
+
+    func testMockDraftMetadata_picksCountAsInt_decodes() throws {
+        let json = """
+        {
+          "personality": "bpa",
+          "draft_year": "2026",
+          "mode": "pure",
+          "picks_count": 60,
+          "picks": []
+        }
+        """.data(using: .utf8)!
+
+        let metadata = try JSONDecoder().decode(MockDraftMetadata.self, from: json)
+
+        XCTAssertEqual(metadata.personality, "bpa")
+        XCTAssertEqual(metadata.draftYear, "2026")
+        XCTAssertEqual(metadata.mode, "pure")
+        XCTAssertEqual(metadata.picksCount, 60)
+        XCTAssertTrue(metadata.picks.isEmpty)
+    }
+
+    func testMockDraftMetadata_picksCountAsString_decodes() throws {
+        let json = """
+        {
+          "personality": "team-fit",
+          "draft_year": "2026",
+          "mode": "pure",
+          "picks_count": "60",
+          "picks": []
+        }
+        """.data(using: .utf8)!
+
+        let metadata = try JSONDecoder().decode(MockDraftMetadata.self, from: json)
+
+        XCTAssertEqual(metadata.personality, "team-fit")
+        XCTAssertEqual(metadata.picksCount, 60)
+    }
+
+    func testMockDraftMetadata_missingFields_defaultsSafely() throws {
+        let json = "{}".data(using: .utf8)!
+
+        let metadata = try JSONDecoder().decode(MockDraftMetadata.self, from: json)
+
+        XCTAssertEqual(metadata.personality, "")
+        XCTAssertEqual(metadata.draftYear, "")
+        XCTAssertEqual(metadata.mode, "pure")
+        XCTAssertEqual(metadata.picksCount, 0)
+        XCTAssertTrue(metadata.picks.isEmpty)
+    }
+
+    // MARK: - MockedPick
+
+    func testMockedPick_valueAsString_decodes() throws {
+        // Matches the in-session backfill: `value` serialized as String
+        // to avoid boto3 Decimal-as-float precision drift.
+        let json = """
+        {
+          "pick_no": 1,
+          "round": 1,
+          "slot": 1,
+          "user_id": "u1",
+          "team": "Brock Party",
+          "handle": "domgiordano",
+          "player_id": "p1",
+          "player_name": "Bijan Robinson",
+          "position": "RB",
+          "nfl_team": "ATL",
+          "value": "98.5"
+        }
+        """.data(using: .utf8)!
+
+        let pick = try JSONDecoder().decode(MockedPick.self, from: json)
+
+        XCTAssertEqual(pick.pickNo, 1)
+        XCTAssertEqual(pick.team, "Brock Party")
+        XCTAssertEqual(pick.value, 98.5, accuracy: 0.001)
+    }
+
+    func testMockedPick_valueAsDouble_decodes() throws {
+        let json = """
+        {
+          "pick_no": 12,
+          "round": 1,
+          "slot": 12,
+          "user_id": "u12",
+          "team": "Gangsters of Love",
+          "handle": "ozz",
+          "player_id": "p12",
+          "player_name": "Saquon Barkley",
+          "position": "RB",
+          "nfl_team": "PHI",
+          "value": 94.2
+        }
+        """.data(using: .utf8)!
+
+        let pick = try JSONDecoder().decode(MockedPick.self, from: json)
+
+        XCTAssertEqual(pick.pickNo, 12)
+        XCTAssertEqual(pick.value, 94.2, accuracy: 0.001)
+    }
+
+    func testMockedPick_pickNoAsString_decodes() throws {
+        // Defensive: boto3 sometimes stringifies *all* numerics. Make
+        // sure `pick_no` is happy with that too.
+        let json = """
+        {
+          "pick_no": "13",
+          "round": "2",
+          "slot": "12",
+          "user_id": "u12",
+          "team": "Gangsters of Love",
+          "handle": "ozz",
+          "player_id": "p13",
+          "player_name": "Player X",
+          "position": "WR",
+          "nfl_team": "PHI",
+          "value": "82.1"
+        }
+        """.data(using: .utf8)!
+
+        let pick = try JSONDecoder().decode(MockedPick.self, from: json)
+
+        XCTAssertEqual(pick.pickNo, 13)
+        XCTAssertEqual(pick.round, 2)
+        XCTAssertEqual(pick.slot, 12)
+    }
+
+    // MARK: - WeeklyMatchupBlurb
+
+    func testWeeklyMatchupBlurb_scoresAsString_decodes() throws {
+        let json = """
+        {
+          "matchup_id": 1,
+          "team_a": "Brock Party",
+          "team_b": "Gangsters of Love",
+          "handle_a": "domgiordano",
+          "handle_b": "ozz",
+          "user_id_a": "uA",
+          "user_id_b": "uB",
+          "score_a": "198.6",
+          "score_b": "92.1",
+          "margin":  "106.5",
+          "winner":  "a",
+          "blurb":   "**Brock Party obliterated Gangsters of Love 198.6-92.1**"
+        }
+        """.data(using: .utf8)!
+
+        let blurb = try JSONDecoder().decode(WeeklyMatchupBlurb.self, from: json)
+
+        XCTAssertEqual(blurb.matchupId, 1)
+        XCTAssertEqual(blurb.teamA, "Brock Party")
+        XCTAssertEqual(blurb.teamB, "Gangsters of Love")
+        XCTAssertEqual(blurb.scoreA, 198.6, accuracy: 0.001)
+        XCTAssertEqual(blurb.scoreB, 92.1, accuracy: 0.001)
+        XCTAssertEqual(blurb.margin, 106.5, accuracy: 0.001)
+        XCTAssertEqual(blurb.winner, "a")
+        XCTAssertTrue(blurb.blurb.contains("Brock Party obliterated"))
+    }
+
+    func testWeeklyMatchupBlurb_scoresAsDouble_decodes() throws {
+        let json = """
+        {
+          "matchup_id": 2,
+          "team_a": "Team X",
+          "team_b": "Team Y",
+          "handle_a": "x",
+          "handle_b": "y",
+          "user_id_a": "uX",
+          "user_id_b": "uY",
+          "score_a": 121.4,
+          "score_b": 118.9,
+          "margin":  2.5,
+          "winner":  "a",
+          "blurb":   "Squeaker."
+        }
+        """.data(using: .utf8)!
+
+        let blurb = try JSONDecoder().decode(WeeklyMatchupBlurb.self, from: json)
+
+        XCTAssertEqual(blurb.scoreA, 121.4, accuracy: 0.001)
+        XCTAssertEqual(blurb.scoreB, 118.9, accuracy: 0.001)
+        XCTAssertEqual(blurb.margin, 2.5, accuracy: 0.001)
+    }
+
+    func testWeeklyMatchupBlurb_missingOptionalFields_defaultsSafely() throws {
+        // Minimum-viable blurb — only `matchup_id` + `blurb` present.
+        let json = """
+        {
+          "matchup_id": 3,
+          "blurb": "Some recap text."
+        }
+        """.data(using: .utf8)!
+
+        let blurb = try JSONDecoder().decode(WeeklyMatchupBlurb.self, from: json)
+
+        XCTAssertEqual(blurb.matchupId, 3)
+        XCTAssertEqual(blurb.teamA, "")
+        XCTAssertEqual(blurb.scoreA, 0)
+        XCTAssertEqual(blurb.winner, "tie")
+        XCTAssertEqual(blurb.blurb, "Some recap text.")
+    }
+
+    // MARK: - WeeklyRecapMetadata
+
+    func testWeeklyRecapMetadata_decodesArrayOfBlurbs() throws {
+        let json = """
+        {
+          "matchups": [
+            {
+              "matchup_id": 1,
+              "team_a": "A", "team_b": "B",
+              "handle_a": "a", "handle_b": "b",
+              "user_id_a": "uA", "user_id_b": "uB",
+              "score_a": "100.0", "score_b": "80.0", "margin": "20.0",
+              "winner": "a", "blurb": "A win."
+            },
+            {
+              "matchup_id": 2,
+              "team_a": "C", "team_b": "D",
+              "handle_a": "c", "handle_b": "d",
+              "user_id_a": "uC", "user_id_b": "uD",
+              "score_a": "90.0", "score_b": "95.0", "margin": "5.0",
+              "winner": "b", "blurb": "D wins."
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let recap = try JSONDecoder().decode(WeeklyRecapMetadata.self, from: json)
+
+        XCTAssertEqual(recap.matchups.count, 2)
+        XCTAssertEqual(recap.matchups[0].teamA, "A")
+        XCTAssertEqual(recap.matchups[1].winner, "b")
+    }
+
+    // MARK: - AIReport.decodeMetadata round-trip
+
+    func testAIReport_decodeMetadata_extractsTypedMetadata() throws {
+        // Mirrors the actual wire shape returned by the list endpoint:
+        // the top-level `AIReport` JSON with `metadata` carrying a
+        // nested map containing `picks[]`.
+        let json = """
+        {
+          "pk": "LEAGUE#L1",
+          "sk": "REPORT#mock#2026-bpa",
+          "league_id": "L1",
+          "report_type": "mock",
+          "period": "2026-bpa",
+          "body_markdown": "## Mock Draft\\nBPA",
+          "metadata": {
+            "personality": "bpa",
+            "draft_year": "2026",
+            "mode": "pure",
+            "picks_count": "60",
+            "picks": [
+              {
+                "pick_no": 1, "round": 1, "slot": 1,
+                "user_id": "u1", "team": "Brock Party", "handle": "dom",
+                "player_id": "p1", "player_name": "Bijan Robinson",
+                "position": "RB", "nfl_team": "ATL",
+                "value": "98.5"
+              }
+            ]
+          },
+          "created_at": "2026-04-15T12:00:00Z"
+        }
+        """.data(using: .utf8)!
+
+        let report = try JSONDecoder().decode(AIReport.self, from: json)
+
+        XCTAssertEqual(report.reportType, .mock)
+        XCTAssertEqual(report.metadata["personality"], "bpa")
+        XCTAssertEqual(report.metadata["picks_count"], "60")
+
+        // Structured decode of the nested map.
+        let typed = report.decodeMetadata(MockDraftMetadata.self)
+        XCTAssertNotNil(typed)
+        XCTAssertEqual(typed?.personality, "bpa")
+        XCTAssertEqual(typed?.picksCount, 60)
+        XCTAssertEqual(typed?.picks.count, 1)
+        XCTAssertEqual(typed?.picks.first?.playerName, "Bijan Robinson")
+    }
+
+    // MARK: - AIReportType.mock case
+
+    func testAIReportType_mockCase_decodes() throws {
+        let json = "\"mock\"".data(using: .utf8)!
+        let type = try JSONDecoder().decode(AIReportType.self, from: json)
+        XCTAssertEqual(type, .mock)
+        XCTAssertEqual(type.displayName, "Mock Draft")
+    }
+
+    // MARK: - AIReviewStore.weeklyPeriod helper
+
+    func testWeeklyPeriod_padsWeekToTwoDigits() {
+        XCTAssertEqual(AIReviewStore.weeklyPeriod(season: "2025", week: 4), "2025W04")
+        XCTAssertEqual(AIReviewStore.weeklyPeriod(season: "2025", week: 12), "2025W12")
+        XCTAssertEqual(AIReviewStore.weeklyPeriod(season: "2024", week: 1), "2024W01")
+    }
+
+    func testWeeklyPeriod_emptySeasonOrInvalidWeek_returnsEmpty() {
+        XCTAssertEqual(AIReviewStore.weeklyPeriod(season: "", week: 4), "")
+        XCTAssertEqual(AIReviewStore.weeklyPeriod(season: "2025", week: 0), "")
+        XCTAssertEqual(AIReviewStore.weeklyPeriod(season: "2025", week: -1), "")
+    }
+}


### PR DESCRIPTION
## Summary

Two new iOS surfaces that consume data already sitting in DynamoDB from the in-session backfill.

### Surface 1 — MocksView renders 3 mock drafts

`Xomper/Features/DraftHistory/Draft/MocksView.swift` previously rendered an \"Coming Soon\" placeholder. Now it:

- Fetches every \`type=mock\` AI report for the active league via the new \`XomperAPIClient.fetchMockDrafts()\`.
- Renders three personality cards — **Best Player Available**, **Team Fit**, **Wildcard** — each as a tappable card. BPA is expanded by default; the other two start collapsed.
- Each expanded card shows the first five rounds of the 60-pick mock as a table (round / pick / team / player / position) with a **YOU** badge on rows belonging to the signed-in user.
- Loading / empty / error states.

### Surface 2 — MatchupsView shows per-matchup blurbs

`Xomper/Features/League/MatchupsView.swift` now:

- When a past, scored week is expanded, kicks off \`AIReviewStore.loadWeeklyReport(period:)\` (period is \`<season>W<week:02d>\`, e.g. \`2025W04\`).
- Decodes the recap's \`metadata.matchups[]\` into \`WeeklyMatchupBlurb\` objects.
- Renders the markdown blurb inline under each matchup card via \`AttributedString(markdown:)\` (inline-only). Lookup is by \`matchup_id\` first, then \`(team_a, team_b)\` as a fallback after re-roster cycles.
- Current weeks + weeks without a recap silently render no blurb.

## Backend dependency

Requires **Xomware/xomper-back-end#62** (adds \`\"mock\"\` to \`REPORT_TYPES\`) merged + deployed before MocksView can fetch successfully. iOS can ship in parallel — until backend rolls, MocksView surfaces the empty state and the new \`fetchMockDrafts()\` returns zero rows. Weekly blurbs work today (the 34 backfilled weekly reports already carry \`metadata.matchups[]\`).

## Decoder robustness

Numeric fields the backfill serialized as \`String\` (boto3 \`Decimal\`-as-\`String\` quirk) — \`picks_count\`, \`value\`, \`score_a\`, \`score_b\`, \`margin\` — are decoded via \`MockDraftDecoding.intOrString\` / \`doubleOrString\` helpers that try the native numeric form first, then fall back to a \`Double(String)\` parse. Same for any field the backend ever flips between Int and Double.

\`AIReport\` now also stashes the raw \`metadata\` JSON bytes during decode (\`metadataRawJSON: Data?\`) so the typed extractor \`AIReport.decodeMetadata(_:)\` can recover nested arrays (\`picks[]\`, \`matchups[]\`) that the legacy flat \`[String: String]\` map strips.

## Files

**New:**
- \`Xomper/Core/Models/MockDraftModels.swift\` — \`MockDraftMetadata\`, \`MockedPick\`, \`MockDraftPersonality\`, decoder helpers
- \`Xomper/Core/Models/WeeklyRecapMetadata.swift\` — \`WeeklyRecapMetadata\`, \`WeeklyMatchupBlurb\`
- \`XomperTests/MockDraftMetadataTests.swift\` — 14 new unit tests

**Modified:**
- \`Xomper/Core/Models/AIReport.swift\` — adds \`.mock\` case, \`metadataRawJSON\`, \`decodeMetadata(_:)\`, \`JSONValue\` helper
- \`Xomper/Core/Networking/XomperAPIClient.swift\` — \`fetchMockDrafts()\`, \`fetchAIReportByPeriod(type:period:)\`
- \`Xomper/Core/Stores/AIReviewStore.swift\` — \`mockDrafts\`, \`weeklyReportsByPeriod\`, \`loadMockDrafts()\`, \`loadWeeklyReport(period:)\`, \`weeklyPeriod(season:week:)\`
- \`Xomper/Features/DraftHistory/Draft/MocksView.swift\` — replaces placeholder
- \`Xomper/Features/DraftHistory/DraftHistoryView.swift\` — wires stores into \`MocksView\`
- \`Xomper/Features/League/MatchupsView.swift\` — fetches recap, renders blurb cards
- \`Xomper/Features/Shell/MainShell.swift\` — threads \`aiReviewStore\` into \`MatchupsView\`
- \`XomperTests/AIReviewStoreTests.swift\` + \`XomperTests/AdminStoreTests.swift\` — mock conformance + 4 new store tests

## Test plan

- [ ] On a stack where backend PR #62 is deployed, open Draft tab → Mocks sub-tab → see three personality cards. BPA expanded by default.
- [ ] Tap each personality header → card toggles expand/collapse with chevron rotation + haptic.
- [ ] Confirm the YOU badge highlights the signed-in user's rows.
- [ ] Pull-to-refresh on MocksView triggers a forced fetch.
- [ ] On a stack where backend PR #62 has NOT deployed, MocksView surfaces the empty state cleanly (no crash, no error toast).
- [ ] Open Matchups tab → select a past season (2024 or 2025) → expand any week → see the per-matchup blurb card below each matchup row.
- [ ] Markdown bold renders in the blurb (e.g. team names + scores show as bold).
- [ ] Current week (no AI report yet) → no blurb card appears (no empty-state cruft either).
- [ ] Switch between weeks within the same season → no duplicate fetches (cached by period).
- [ ] All 77 XomperTests still pass.
- [ ] Build is clean (no warnings, no deprecated API usage).