### PR TITLE
chore: bump GitHub Actions to Node 24 + standings playoff fix

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/Xomper/Core/Models/NflState.swift
+++ b/Xomper/Core/Models/NflState.swift
@@ -29,6 +29,19 @@ struct NflState: Codable, Sendable {
         seasonType == "regular"
     }
 
+    var isPostseason: Bool {
+        seasonType == "post"
+    }
+
+    /// True during regular season AND playoffs — i.e. any time
+    /// fantasy standings are live and meaningful. Use this for the
+    /// "show live standings vs offseason countdown" gate so that
+    /// week-15-17 playoffs don't incorrectly flip the Standings view
+    /// to the offseason empty state (F4 follow-up).
+    var hasLiveStandings: Bool {
+        isRegularSeason || isPostseason
+    }
+
     var displayLabel: String {
         "Week \(displayWeek ?? week) - \(seasonType?.uppercased() ?? "OFF") Season"
     }

--- a/Xomper/Core/Stores/NflStateStore.swift
+++ b/Xomper/Core/Stores/NflStateStore.swift
@@ -40,4 +40,12 @@ final class NflStateStore {
     var isRegularSeason: Bool {
         nflState?.isRegularSeason ?? false
     }
+
+    var isPostseason: Bool {
+        nflState?.isPostseason ?? false
+    }
+
+    var hasLiveStandings: Bool {
+        nflState?.hasLiveStandings ?? false
+    }
 }

--- a/Xomper/Features/League/StandingsView.swift
+++ b/Xomper/Features/League/StandingsView.swift
@@ -22,7 +22,7 @@ struct StandingsView: View {
 
     var body: some View {
         Group {
-            if nflStateStore.isRegularSeason {
+            if nflStateStore.hasLiveStandings {
                 liveStandings
             } else {
                 offseason


### PR DESCRIPTION
## Summary

Bundles two fixes:
1. **Node 24 migration** — bumps `actions/checkout@v4` → `@v6` in `testflight-deploy.yml` ahead of the Node 20 deprecation deadline (~2026-06-02).
2. **Standings playoff fix (#101)** — `StandingsView` was gated on `nflStateStore.isRegularSeason` which only matches `seasonType == "regular"`. During playoffs (`seasonType == "post"`), Standings incorrectly flipped to the offseason countdown card. Now gates on a new `hasLiveStandings` computed property (`isRegularSeason || isPostseason`).

## Test plan

- [ ] CI passes
- [ ] TestFlight build green
- [ ] Manual QA next playoff season: Standings shows live data through Week 17 (not the offseason card)

Closes #101