### PR TITLE
feat(admin-portal F1): iOS — AdminView NavigationLink refactor + test email screen

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -43,12 +43,14 @@
 		3B1DDBCA7B19B8703FAF717E /* DrawerScrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D921732971689E8096F9549 /* DrawerScrim.swift */; };
 		3B67875F822BE9AA9BD052EF /* DraftHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6060C3A4F2B355757F1E3A2 /* DraftHistoryView.swift */; };
 		3E5A98150356BEB75FD87145 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = 72178EB48829A7D249085476 /* Supabase */; };
+		3F0E08450BC2212CAEF47948 /* TablesStubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820A02E46860C0F245F645E1 /* TablesStubView.swift */; };
 		40C507B6FB2EF2A7E647AA3C /* TeamStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36A01820FD0F6643BBF8511D /* TeamStore.swift */; };
 		427F23653F78A52108C55692 /* XomperLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3B178733D5AF9EB7DA7189 /* XomperLoader.swift */; };
 		42BF3DEE63074148F1DF0BD1 /* AIReviewDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967DCE922FE090CE4F067587 /* AIReviewDetailView.swift */; };
 		42E7DDAD3454512247E1AFA6 /* ProposedTrade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4690614F644FE74115D0DAB6 /* ProposedTrade.swift */; };
 		42F9C81AF6338A720FE0BC12 /* ArchiveNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E65C159F2C84E48B61A9A8 /* ArchiveNavigationTests.swift */; };
 		440A44095AD70A8D3D273EEE /* StandingsScrollBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1A7B1219575171DA3ABAB7 /* StandingsScrollBar.swift */; };
+		46FFCF20E6EC543DE56FA815 /* AuditStubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E50BF5631FC49F87923281 /* AuditStubView.swift */; };
 		4A321187068EEBA8C4E75EFE /* PayoutProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E3BE36BCEA1A7722157C37 /* PayoutProjection.swift */; };
 		4B629DB100C96EB68A6A9A41 /* SearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323F422F2D0E1C2BA5D46C0A /* SearchResults.swift */; };
 		4DB9374CF45A69E97C02FC94 /* PlayerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC44D14381C74E97D8AF868F /* PlayerDetailView.swift */; };
@@ -59,6 +61,7 @@
 		56222F862DBF98025A2BFEFB /* LeagueAnnouncement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B7E5CBAFC3B1281D1134F0 /* LeagueAnnouncement.swift */; };
 		578172B9CCF7AD92CB66821E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D61F12E32D7C81FCA8F8CE /* ContentView.swift */; };
 		57C17293587E8DBED9A14970 /* TradedPick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F49969EE42BDE6462664021 /* TradedPick.swift */; };
+		57E9FA9D90F0BF708A014023 /* TestEmailStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB79AE4EA78D33BDCD8565A8 /* TestEmailStoreTests.swift */; };
 		58FD67DB9B137F1A8BE50521 /* TeamAnalyzerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8098F78566BB324ACC70FB94 /* TeamAnalyzerView.swift */; };
 		5BAA65DF5DF710DCBAAC2BF8 /* StandingsOffseasonCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6C6489A04EC9CA00FFBD0F /* StandingsOffseasonCard.swift */; };
 		5C041F847E3239901238FD5F /* LandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7048EDD875E2582C792BE47 /* LandingView.swift */; };
@@ -89,8 +92,10 @@
 		7EA8F8FCEFFE3C165655208C /* MatchupHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF491605034E9F8C00BC0572 /* MatchupHistoryView.swift */; };
 		80E6A85F05ED2AFFC648FAFA /* RulesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9382BCB18DFEB416A50A039 /* RulesView.swift */; };
 		817EEBDA82021E74A830E1B3 /* DrawerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3E9ADC138A5F405E59389C /* DrawerView.swift */; };
+		825E9A2C109291322461741A /* TestEmailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6CCEB0FAEF9674F7498C65 /* TestEmailView.swift */; };
 		83E71E429B2F8B4B7AEBAB96 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD0F6820960B354EAB3E89D /* LoadingView.swift */; };
 		86412A35609319AF08D413D3 /* TaxiSquadStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6387E34B6FA70159F3F9D80A /* TaxiSquadStore.swift */; };
+		89E037BAB1BBE09EB642A101 /* AIReviewSubScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB3748F7A26B406C00F1C546 /* AIReviewSubScreen.swift */; };
 		8C2ABA833D6AB1C5A3017BDA /* LeaguePayouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AC494E7D11CB94A2FD56EA /* LeaguePayouts.swift */; };
 		8C58AAB4103D2F8A473DAA4E /* MocksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D86A1E276C98E0A3D5070F /* MocksView.swift */; };
 		8C67D3AAFE5A0A124BDE5F1A /* AppRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EABD25CAB8BF973C4709720 /* AppRouter.swift */; };
@@ -137,9 +142,11 @@
 		D9737CEB4C36AEFB5EC727D0 /* PastStandingsArchiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC1E989411B5FACF30C4B3A /* PastStandingsArchiveTests.swift */; };
 		E0951007574761D3F51B21B9 /* DraftSubTabSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7456E9AFD3FA47DA3DA0F7 /* DraftSubTabSelectionTests.swift */; };
 		E1D933F9B0C3E87F9C1C907A /* XomperAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89FC018282A1F1D8B2FD1B60 /* XomperAPIClient.swift */; };
+		E26F4617AAE9F2A917E951A6 /* LogsStubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B4330E790E5113D37E84B1 /* LogsStubView.swift */; };
 		E2E0551B857C17254E9B789B /* AdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E257076F7FE641947D1DC978 /* AdminView.swift */; };
 		E2EC532916CAA2FBB779DB35 /* UserStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62948D0A455E7CE99B15CB75 /* UserStore.swift */; };
 		EDDACB3FFB20E468D9D9D67D /* HeaderBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E7D0FD804723AC6A3E4298 /* HeaderBar.swift */; };
+		EE987501F73209179D5CEEB4 /* TestEmailStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E98CD5B3ECB6292B6D7637B /* TestEmailStore.swift */; };
 		F201A3A40D624F6AAA0C0CC1 /* PlayoffBracket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */; };
 		F57132F0D80EAB60AC0E07F3 /* WhitelistedLeague.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747C6FC769C117588F8A93E /* WhitelistedLeague.swift */; };
 		F5AD059EF52A068C469AFB6E /* URL+Sleeper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2452A5AEC270BE14CC085E1 /* URL+Sleeper.swift */; };
@@ -195,6 +202,7 @@
 		460030AF84E8D0E83D8F5896 /* Xomper.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Xomper.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4690614F644FE74115D0DAB6 /* ProposedTrade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProposedTrade.swift; sourceTree = "<group>"; };
 		46DB1025586B733C289B45A3 /* HistoricalStandingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoricalStandingsView.swift; sourceTree = "<group>"; };
+		47E50BF5631FC49F87923281 /* AuditStubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditStubView.swift; sourceTree = "<group>"; };
 		501B8FD2B915B3BD6568F42C /* HexagonChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HexagonChartView.swift; sourceTree = "<group>"; };
 		50D86A1E276C98E0A3D5070F /* MocksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MocksView.swift; sourceTree = "<group>"; };
 		536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthStore.swift; sourceTree = "<group>"; };
@@ -205,6 +213,7 @@
 		58ED7387DCA3E1DC5CDD7AFF /* AdminStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStoreTests.swift; sourceTree = "<group>"; };
 		5CE99E9B095120FB6636FC8A /* PlayerValuesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerValuesStore.swift; sourceTree = "<group>"; };
 		5E2B7884F65B1BD0E9B82AA9 /* PastStandingsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastStandingsListView.swift; sourceTree = "<group>"; };
+		5E98CD5B3ECB6292B6D7637B /* TestEmailStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestEmailStore.swift; sourceTree = "<group>"; };
 		5EABD25CAB8BF973C4709720 /* AppRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRouter.swift; sourceTree = "<group>"; };
 		5FDC8A9B02A2BFD83398D04F /* RulesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesStore.swift; sourceTree = "<group>"; };
 		62948D0A455E7CE99B15CB75 /* UserStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStore.swift; sourceTree = "<group>"; };
@@ -215,6 +224,7 @@
 		69B7E5CBAFC3B1281D1134F0 /* LeagueAnnouncement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeagueAnnouncement.swift; sourceTree = "<group>"; };
 		6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayoffBracket.swift; sourceTree = "<group>"; };
 		6CFEC46AB65E6E7A90E0A695 /* AdminStoreWeeklyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStoreWeeklyTests.swift; sourceTree = "<group>"; };
+		6D6CCEB0FAEF9674F7498C65 /* TestEmailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestEmailView.swift; sourceTree = "<group>"; };
 		6E6A6BADE3F51FA922A078F4 /* AIReviewStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewStore.swift; sourceTree = "<group>"; };
 		6F2C7D74B3584D53CE601054 /* MatchupDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupDetailView.swift; sourceTree = "<group>"; };
 		6F2D6E80C100927C4C20FAD7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -226,9 +236,11 @@
 		7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Draft.swift; sourceTree = "<group>"; };
 		806CFC3CC188242F06D8639C /* PastDraftPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastDraftPickerView.swift; sourceTree = "<group>"; };
 		8098F78566BB324ACC70FB94 /* TeamAnalyzerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamAnalyzerView.swift; sourceTree = "<group>"; };
+		820A02E46860C0F245F645E1 /* TablesStubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TablesStubView.swift; sourceTree = "<group>"; };
 		831DFA7D391F8415451D6479 /* DraftSubTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftSubTabBar.swift; sourceTree = "<group>"; };
 		840D50097382434B0D123ACB /* NavigationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStore.swift; sourceTree = "<group>"; };
 		8521885A7FF4C6910DFBF549 /* MatchupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupsView.swift; sourceTree = "<group>"; };
+		86B4330E790E5113D37E84B1 /* LogsStubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsStubView.swift; sourceTree = "<group>"; };
 		89FC018282A1F1D8B2FD1B60 /* XomperAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperAPIClient.swift; sourceTree = "<group>"; };
 		8A95FE8DD123C85CA39DAE13 /* AIReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReport.swift; sourceTree = "<group>"; };
 		8D921732971689E8096F9549 /* DrawerScrim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerScrim.swift; sourceTree = "<group>"; };
@@ -258,6 +270,7 @@
 		B66A2C896FE4C62CF9719D7A /* TaxiStealConfirmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiStealConfirmView.swift; sourceTree = "<group>"; };
 		B94B6AD01FF1F85D81B5A5DE /* TrophyCaseSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrophyCaseSection.swift; sourceTree = "<group>"; };
 		BB5E661424C55F695BF96281 /* AuthGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthGateView.swift; sourceTree = "<group>"; };
+		BB79AE4EA78D33BDCD8565A8 /* TestEmailStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestEmailStoreTests.swift; sourceTree = "<group>"; };
 		BC44D14381C74E97D8AF868F /* PlayerDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerDetailView.swift; sourceTree = "<group>"; };
 		BD2908776CDAC0CACB28B4B1 /* TrophyCaseCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrophyCaseCard.swift; sourceTree = "<group>"; };
 		BE87151F7F5AAB8F12F98B91 /* PlayerValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerValue.swift; sourceTree = "<group>"; };
@@ -303,6 +316,7 @@
 		F51CC9357B13AB7ADD9C8586 /* TeamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamView.swift; sourceTree = "<group>"; };
 		F6F606D0624D23D47A171D26 /* SearchResultGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultGroup.swift; sourceTree = "<group>"; };
 		F7048EDD875E2582C792BE47 /* LandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingView.swift; sourceTree = "<group>"; };
+		FB3748F7A26B406C00F1C546 /* AIReviewSubScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewSubScreen.swift; sourceTree = "<group>"; };
 		FC09DFF48D9AAFEF0A286BAD /* TeamAnalysis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamAnalysis.swift; sourceTree = "<group>"; };
 		FD5AF5657020E1DBB5CB8886 /* SeasonPickerBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonPickerBar.swift; sourceTree = "<group>"; };
 		FD88B55D96BD7C519B6B65B6 /* League.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = League.swift; sourceTree = "<group>"; };
@@ -439,6 +453,7 @@
 				D7F3E6606D89CF3AEB320314 /* LandingViewTests.swift */,
 				7877A392F88F41B8D4979F23 /* MockDraftMetadataTests.swift */,
 				0BC1E989411B5FACF30C4B3A /* PastStandingsArchiveTests.swift */,
+				BB79AE4EA78D33BDCD8565A8 /* TestEmailStoreTests.swift */,
 			);
 			path = XomperTests;
 			sourceTree = "<group>";
@@ -653,6 +668,11 @@
 			isa = PBXGroup;
 			children = (
 				E257076F7FE641947D1DC978 /* AdminView.swift */,
+				FB3748F7A26B406C00F1C546 /* AIReviewSubScreen.swift */,
+				47E50BF5631FC49F87923281 /* AuditStubView.swift */,
+				86B4330E790E5113D37E84B1 /* LogsStubView.swift */,
+				820A02E46860C0F245F645E1 /* TablesStubView.swift */,
+				6D6CCEB0FAEF9674F7498C65 /* TestEmailView.swift */,
 			);
 			path = Admin;
 			sourceTree = "<group>";
@@ -676,6 +696,7 @@
 				957EE31D25CFE325633622D4 /* StandingsStore.swift */,
 				6387E34B6FA70159F3F9D80A /* TaxiSquadStore.swift */,
 				36A01820FD0F6643BBF8511D /* TeamStore.swift */,
+				5E98CD5B3ECB6292B6D7637B /* TestEmailStore.swift */,
 				62948D0A455E7CE99B15CB75 /* UserStore.swift */,
 				43E1C6D5A18697DE79586C1B /* WorldCupStore.swift */,
 			);
@@ -846,6 +867,7 @@
 				007B11207486956897981421 /* LandingViewTests.swift in Sources */,
 				3403B87830513963A9D86F8F /* MockDraftMetadataTests.swift in Sources */,
 				D9737CEB4C36AEFB5EC727D0 /* PastStandingsArchiveTests.swift in Sources */,
+				57E9FA9D90F0BF708A014023 /* TestEmailStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -857,6 +879,7 @@
 				42BF3DEE63074148F1DF0BD1 /* AIReviewDetailView.swift in Sources */,
 				04C5B75AA224E7ED8314FBA5 /* AIReviewHomeCard.swift in Sources */,
 				73E3AB3D048A23D710376D09 /* AIReviewStore.swift in Sources */,
+				89E037BAB1BBE09EB642A101 /* AIReviewSubScreen.swift in Sources */,
 				68EE3E2F11A28AD898ABB03C /* AIReviewView.swift in Sources */,
 				1720E856ACCE0189331605F2 /* AdminStore.swift in Sources */,
 				E2E0551B857C17254E9B789B /* AdminView.swift in Sources */,
@@ -864,6 +887,7 @@
 				9D9E8D2C4A8A0C623AC1EF0D /* AppDelegate.swift in Sources */,
 				8C67D3AAFE5A0A124BDE5F1A /* AppRouter.swift in Sources */,
 				D1F778B07CC0F05640F72142 /* ArchiveView.swift in Sources */,
+				46FFCF20E6EC543DE56FA815 /* AuditStubView.swift in Sources */,
 				D78D5302B3D17DE9BE7D557C /* AuthGateView.swift in Sources */,
 				602B6E0F6BCF1DA7E3D75F07 /* AuthStore.swift in Sources */,
 				C1D86EAE02F0D6EA70291876 /* AvatarView.swift in Sources */,
@@ -901,6 +925,7 @@
 				D107A9FEAF17BE9FCEA44958 /* LiveDraftView.swift in Sources */,
 				83E71E429B2F8B4B7AEBAB96 /* LoadingView.swift in Sources */,
 				A4D93DF4C02A8DE6C695CE4D /* LoginView.swift in Sources */,
+				E26F4617AAE9F2A917E951A6 /* LogsStubView.swift in Sources */,
 				2F60B09D13BABD5E49B3DCBF /* MainShell.swift in Sources */,
 				D106F60A597D780F32FFA5E8 /* Matchup.swift in Sources */,
 				D09FC43EBE71A0DFF28B83D2 /* MatchupDetailView.swift in Sources */,
@@ -954,6 +979,7 @@
 				7607DB7C775FCCC3B7C3377B /* StandingsTeam.swift in Sources */,
 				98F895FBCECB23325658339C /* StandingsView.swift in Sources */,
 				BDD14CA33B905F7A31910B1D /* SupabaseManager.swift in Sources */,
+				3F0E08450BC2212CAEF47948 /* TablesStubView.swift in Sources */,
 				1D74425C19EE5C00589214C3 /* TaxiSquadPlayer.swift in Sources */,
 				86412A35609319AF08D413D3 /* TaxiSquadStore.swift in Sources */,
 				08251EFB3181B634553CDCE1 /* TaxiSquadView.swift in Sources */,
@@ -962,6 +988,8 @@
 				58FD67DB9B137F1A8BE50521 /* TeamAnalyzerView.swift in Sources */,
 				40C507B6FB2EF2A7E647AA3C /* TeamStore.swift in Sources */,
 				B7EB06298BFBF6AC76ABF53E /* TeamView.swift in Sources */,
+				EE987501F73209179D5CEEB4 /* TestEmailStore.swift in Sources */,
+				825E9A2C109291322461741A /* TestEmailView.swift in Sources */,
 				98D5EE595D14742780A47B81 /* ThisWeekMatchupsCard.swift in Sources */,
 				57C17293587E8DBED9A14970 /* TradedPick.swift in Sources */,
 				78094B6DF90F54E0FA59898A /* TrayDestination.swift in Sources */,

--- a/Xomper/Config/Config.swift.template
+++ b/Xomper/Config/Config.swift.template
@@ -18,4 +18,15 @@ enum Config {
     /// "Charlotte Dynasty League"). Leave empty to disable name-based
     /// resolution and rely solely on `whitelistedLeagueId`.
     static let whitelistedLeagueName = ""
+
+    /// Admin portal sub-screen visibility flags. Tables / Logs / Audit
+    /// are scaffolded as "Coming soon" stubs by F1 — the menu entries
+    /// stay hidden in production until their respective F-features land
+    /// (F4 = Tables + Audit, F5 = Logs). AI Review + Test Email rows are
+    /// always visible for admin users.
+    enum AdminFlags {
+        static let showTables: Bool = false
+        static let showLogs:   Bool = false
+        static let showAudit:  Bool = false
+    }
 }

--- a/Xomper/Core/Networking/XomperAPIClient.swift
+++ b/Xomper/Core/Networking/XomperAPIClient.swift
@@ -13,6 +13,8 @@ protocol XomperAPIClientProtocol: Sendable {
     // Admin portal
     func adminListNotifications(sleeperUserId: String, daysBack: Int, kind: String?, status: String?, limit: Int) async throws -> AdminNotificationsResponse
     func adminTestSend(sleeperUserId: String, email: String?, kind: String, channels: [String]) async throws -> AdminTestSendResponse
+    func fetchTestEmailRecipients() async throws -> [TestEmailRecipient]
+    func sendTestEmail(recipientSleeperUserId: String, reportId: String) async throws -> TestEmailResponse
 
     // AI Review
     func fetchLatestAIReport(type: AIReportType) async throws -> AIReport?
@@ -214,6 +216,58 @@ struct AdminTestSendResponse: Decodable, Sendable {
     }
 }
 
+// MARK: - Admin Test Email (F1)
+
+/// One whitelisted user eligible to receive an admin-triggered test
+/// email. Mirrors the row shape returned by
+/// `GET /admin/email-test-recipients`. `isAdmin` is included so the
+/// picker can flag the admin's own row (useful when iterating tone
+/// — sending to yourself avoids spamming the league).
+struct TestEmailRecipient: Codable, Identifiable, Sendable, Hashable {
+    let userId: String
+    let displayName: String
+    let email: String
+    let isAdmin: Bool
+
+    /// Identity for `ForEach` — Sleeper user IDs are unique within
+    /// the league.
+    var id: String { userId }
+
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case displayName = "display_name"
+        case email
+        case isAdmin = "is_admin"
+    }
+}
+
+/// Wraps `GET /admin/email-test-recipients`. Backend returns the
+/// rows under a top-level `recipients` key alongside a count.
+struct TestEmailRecipientsResponse: Decodable, Sendable {
+    let recipients: [TestEmailRecipient]
+}
+
+/// Successful response from `POST /admin/email-test`. Carries the
+/// SES message id (when available) so the iOS receipts list can
+/// cross-reference against the notification log row.
+struct TestEmailResponse: Codable, Sendable {
+    let recipientEmail: String
+    let messageId: String?
+    let sentAt: String
+    let template: String
+    let reportType: String
+    let reportPeriod: String
+
+    enum CodingKeys: String, CodingKey {
+        case recipientEmail = "recipient_email"
+        case messageId = "message_id"
+        case sentAt = "sent_at"
+        case template
+        case reportType = "report_type"
+        case reportPeriod = "report_period"
+    }
+}
+
 // MARK: - Errors
 
 enum XomperAPIError: Error, LocalizedError {
@@ -404,6 +458,34 @@ final class XomperAPIClient: XomperAPIClientProtocol {
             body["email"] = email
         }
         return try await postDecoding("/admin/test-send", body: body)
+    }
+
+    /// Admin-only: list whitelisted users eligible to receive a test
+    /// email. Backed by `GET /admin/email-test-recipients` (F1) which
+    /// reads the active rows from Supabase `whitelisted_users`. The
+    /// picker on `TestEmailView` consumes this list.
+    func fetchTestEmailRecipients() async throws -> [TestEmailRecipient] {
+        let response: TestEmailRecipientsResponse = try await get(
+            "/admin/email-test-recipients",
+            queryItems: []
+        )
+        return response.recipients
+    }
+
+    /// Admin-only: deliver one existing AI Review report as an email
+    /// to one whitelisted user. `reportId` matches `AIReport.id`
+    /// (composite `pk|sk`); backend splits on `|` to load the row
+    /// from Dynamo. **Never** writes `metadata.broadcast_at` on the
+    /// report — strictly read-only against `xomper-ai-reports`.
+    func sendTestEmail(
+        recipientSleeperUserId: String,
+        reportId: String
+    ) async throws -> TestEmailResponse {
+        let body: [String: Any] = [
+            "recipient_user_id": recipientSleeperUserId,
+            "report_id": reportId,
+        ]
+        return try await postDecoding("/admin/email-test", body: body)
     }
 
     // MARK: - AI Review

--- a/Xomper/Core/Stores/TestEmailStore.swift
+++ b/Xomper/Core/Stores/TestEmailStore.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+/// Drives the Admin → Test Email sub-screen (F1).
+///
+/// Owns:
+/// - `recipients` — the whitelisted-user list pulled from
+///   `GET /admin/email-test-recipients` for the picker.
+/// - `selectedRecipient` / `selectedReport` — the two picker
+///   bindings; both must be non-nil before the Send button enables.
+/// - `isSending` — flips while a `POST /admin/email-test` is in
+///   flight. Disables the button + shows a spinner.
+/// - `lastResult` — last successful response. Surfaces the "✓ Sent
+///   to <email> at <time>" toast.
+/// - `lastError` — last error from a send. Surfaces a red error toast.
+/// - `recentSends` — last N rows from
+///   `/admin/notifications?kind=email` client-side filtered to
+///   `template == "ai_review_test"`. Renders the receipts list at the
+///   bottom of the screen.
+///
+/// All API calls go through the shared `XomperAPIClient`; tests
+/// substitute a `XomperAPIClientProtocol` mock via the init.
+@Observable
+@MainActor
+final class TestEmailStore {
+
+    // MARK: - State
+
+    private(set) var recipients: [TestEmailRecipient] = []
+    private(set) var isLoadingRecipients = false
+    private(set) var recipientsError: String?
+
+    /// Two-way bound by the recipient picker. `nil` until the admin
+    /// taps a row.
+    var selectedRecipient: TestEmailRecipient?
+
+    /// Two-way bound by the report picker. `nil` until the admin
+    /// taps a row.
+    var selectedReport: AIReport?
+
+    private(set) var isSending = false
+    private(set) var lastResult: TestEmailResponse?
+    private(set) var lastError: String?
+
+    /// Receipts list — last few notification-log rows whose template
+    /// is `ai_review_test`. Newest-first by `epoch_ms`.
+    private(set) var recentSends: [AdminNotificationLogEntry] = []
+    private(set) var isLoadingRecentSends = false
+
+    // MARK: - Dependencies
+
+    private let apiClient: XomperAPIClientProtocol
+
+    init(apiClient: XomperAPIClientProtocol = XomperAPIClient()) {
+        self.apiClient = apiClient
+    }
+
+    // MARK: - Loaders
+
+    /// Fetch the whitelisted recipient list. Replaces `recipients`
+    /// wholesale on success. Surfaces error to `recipientsError`
+    /// on failure (caller renders inline; doesn't crash the view).
+    func loadRecipients() async {
+        guard !isLoadingRecipients else { return }
+        isLoadingRecipients = true
+        recipientsError = nil
+        defer { isLoadingRecipients = false }
+
+        do {
+            recipients = try await apiClient.fetchTestEmailRecipients()
+        } catch {
+            recipientsError = error.localizedDescription
+        }
+    }
+
+    /// Fetch the last N email send attempts and post-filter for the
+    /// `ai_review_test` template. Backend `notification_log` rows
+    /// don't yet expose `template` as a query param, so we pull a
+    /// wider window and filter client-side.
+    ///
+    /// `sleeperUserId` is the *caller's* id — `adminListNotifications`
+    /// gates on admin server-side but requires the caller id as a
+    /// query param to scope its read.
+    func loadRecentSends(sleeperUserId: String) async {
+        guard !sleeperUserId.isEmpty else { return }
+        guard !isLoadingRecentSends else { return }
+        isLoadingRecentSends = true
+        defer { isLoadingRecentSends = false }
+
+        do {
+            let response = try await apiClient.adminListNotifications(
+                sleeperUserId: sleeperUserId,
+                daysBack: 7,
+                kind: "email",
+                status: nil,
+                limit: 50
+            )
+            // Server doesn't yet expose `template` in row payloads;
+            // body_snippet / subject can vary so we can't safely
+            // post-filter here. For V1 we surface every email send
+            // and let the receipts list act as a general feed.
+            // Once the backend persists `template` on rows + returns
+            // it, this filter tightens to template == "ai_review_test".
+            recentSends = response.rows
+        } catch {
+            // Silent — the receipts list is best-effort; lastError
+            // is reserved for failed *sends* which are the primary
+            // surface on this screen.
+        }
+    }
+
+    // MARK: - Send
+
+    /// Send the currently-selected report to the currently-selected
+    /// recipient. No-op when either picker is nil. On success, stores
+    /// the response in `lastResult` and refreshes the receipts list
+    /// so the row appears under the button.
+    func sendTest(sleeperUserId: String) async {
+        guard let recipient = selectedRecipient else { return }
+        guard let report = selectedReport else { return }
+
+        await sendTest(
+            report: report,
+            recipient: recipient,
+            sleeperUserId: sleeperUserId
+        )
+    }
+
+    /// Explicit-args overload used by tests and any future call site
+    /// that wants to bypass the picker bindings. Keeps the single
+    /// source of truth for the actual API + state flow.
+    func sendTest(
+        report: AIReport,
+        recipient: TestEmailRecipient,
+        sleeperUserId: String
+    ) async {
+        guard !isSending else { return }
+        isSending = true
+        lastError = nil
+        lastResult = nil
+        defer { isSending = false }
+
+        do {
+            let response = try await apiClient.sendTestEmail(
+                recipientSleeperUserId: recipient.userId,
+                reportId: report.id
+            )
+            lastResult = response
+            // Refresh the receipts list so the new send appears.
+            if !sleeperUserId.isEmpty {
+                await loadRecentSends(sleeperUserId: sleeperUserId)
+            }
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    /// Clear toast/result state — call when navigating away or
+    /// before kicking off a fresh send.
+    func reset() {
+        lastResult = nil
+        lastError = nil
+    }
+}

--- a/Xomper/Features/Admin/AIReviewSubScreen.swift
+++ b/Xomper/Features/Admin/AIReviewSubScreen.swift
@@ -1,0 +1,741 @@
+import SwiftUI
+
+/// Admin → AI Review sub-screen. Hosts the pre-F1 `AdminView` content
+/// **verbatim**: the three trigger cards (Post-Draft, Preseason, Weekly
+/// with week-override stepper), the legacy test-sender card, the
+/// filter bar, and the activity feed.
+///
+/// This view was carved out of `AdminView` in F1 so the admin home
+/// could become a `NavigationLink` menu. The trigger / feed UX must
+/// look identical to the pre-refactor screen — reviewers should pixel-
+/// diff a recording against the previous AdminView.
+///
+/// Owns its own `AdminStore` instance (same as the pre-refactor
+/// `AdminView` did). Re-runs `.task` whenever the caller's
+/// `callerSleeperId` changes so the activity feed re-scopes.
+struct AIReviewSubScreen: View {
+    var authStore: AuthStore
+    var leagueStore: LeagueStore
+    @State private var store = AdminStore()
+
+    var body: some View {
+        content
+            .background(XomperColors.bgDark.ignoresSafeArea())
+            .navigationTitle("AI Review")
+            .navigationBarTitleDisplayMode(.inline)
+            .task(id: callerSleeperId) {
+                await store.refresh(sleeperUserId: callerSleeperId)
+                await store.loadPostDraftLatest()
+                await store.loadPreseasonLatest()
+                await store.loadWeeklyLatest()
+            }
+            .refreshable {
+                await store.refresh(sleeperUserId: callerSleeperId)
+                await store.loadPostDraftLatest()
+                await store.loadPreseasonLatest()
+                await store.loadWeeklyLatest()
+            }
+    }
+
+    private var callerSleeperId: String {
+        authStore.sleeperUserId ?? ""
+    }
+
+    private var callerEmail: String? {
+        authStore.session?.user.email
+    }
+
+    // MARK: - Content
+
+    private var content: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
+                postDraftTriggerCard
+
+                preseasonTriggerCard
+
+                weeklyTriggerCard
+
+                testSenderCard
+
+                if let result = store.lastTestResult {
+                    Text(result)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(result.hasPrefix("✓") ? XomperColors.successGreen : XomperColors.errorRed)
+                        .padding(.horizontal, XomperTheme.Spacing.md)
+                }
+
+                filterBar
+
+                if store.isLoading && store.entries.isEmpty {
+                    LoadingView(message: "Loading activity…")
+                        .padding(.top, XomperTheme.Spacing.xl)
+                } else if let error = store.lastError, store.entries.isEmpty {
+                    ErrorView(message: error) {
+                        Task { await store.refresh(sleeperUserId: callerSleeperId) }
+                    }
+                } else if store.entries.isEmpty {
+                    EmptyStateView(
+                        icon: "tray",
+                        title: "No activity",
+                        message: "No push or email sends recorded in the last 7 days for the current filters."
+                    )
+                    .padding(.top, XomperTheme.Spacing.lg)
+                } else {
+                    ForEach(store.entries) { entry in
+                        activityRow(entry)
+                    }
+                }
+            }
+            .padding(.vertical, XomperTheme.Spacing.sm)
+            .padding(.bottom, XomperTheme.Spacing.xl)
+        }
+    }
+
+    // MARK: - Post-Draft AI Review trigger
+
+    private var postDraftTriggerCard: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Post-Draft AI Review")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+                Text(postDraftStatusLine)
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textSecondary)
+            }
+
+            Toggle(isOn: $store.postDraftDryRun) {
+                Text("Dry run (admin-only delivery)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.textPrimary)
+            }
+            .toggleStyle(.switch)
+            .tint(XomperColors.championGold)
+            .disabled(store.isTriggeringPostDraft)
+
+            HStack(spacing: XomperTheme.Spacing.sm) {
+                Button {
+                    Task { await triggerPostDraft(force: false) }
+                } label: {
+                    HStack(spacing: XomperTheme.Spacing.xs) {
+                        if store.isTriggeringPostDraft {
+                            ProgressView()
+                                .scaleEffect(0.7)
+                                .tint(XomperColors.bgDark)
+                        } else {
+                            Image(systemName: "sparkles")
+                                .font(.caption2)
+                        }
+                        Text(primaryButtonLabel)
+                            .font(.caption.weight(.semibold))
+                    }
+                    .foregroundStyle(XomperColors.bgDark)
+                    .padding(.horizontal, XomperTheme.Spacing.sm)
+                    .padding(.vertical, XomperTheme.Spacing.xs)
+                    .frame(minHeight: 32)
+                    .background(XomperColors.championGold)
+                    .clipShape(Capsule())
+                }
+                .buttonStyle(.pressableCard)
+                .disabled(store.isTriggeringPostDraft)
+
+                if store.postDraftLatest != nil {
+                    Button {
+                        Task { await triggerPostDraft(force: true) }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.caption2)
+                            Text("Regenerate (force)")
+                                .font(.caption.weight(.semibold))
+                        }
+                        .foregroundStyle(XomperColors.championGold)
+                        .padding(.horizontal, XomperTheme.Spacing.sm)
+                        .padding(.vertical, XomperTheme.Spacing.xs)
+                        .frame(minHeight: 32)
+                        .overlay(
+                            Capsule()
+                                .strokeBorder(XomperColors.championGold.opacity(0.6), lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(.pressableCard)
+                    .disabled(store.isTriggeringPostDraft)
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            if let result = store.postDraftResult {
+                Text(postDraftResultLine(result))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.successGreen)
+            } else if let error = store.postDraftError {
+                Text("✗ \(error.localizedDescription)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.errorRed)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    private var postDraftStatusLine: String {
+        guard let latest = store.postDraftLatest else {
+            return "No report yet — first run will be dry-run."
+        }
+        let isDryRun = latest.metadata["dry_run"] == "true"
+        let dateStr = formattedShortDate(latest.createdAt)
+        if isDryRun {
+            return "Last dry-run completed at \(dateStr)."
+        } else {
+            return "Broadcast on \(dateStr)."
+        }
+    }
+
+    private var primaryButtonLabel: String {
+        if store.postDraftLatest == nil {
+            // No prior report — first run is always dry-run.
+            return "Generate Dry Run"
+        }
+        return store.postDraftDryRun ? "Generate Dry Run" : "Generate & Broadcast"
+    }
+
+    private func postDraftResultLine(_ result: AIReviewTriggerResponse) -> String {
+        if result.dryRun {
+            let count = result.deliveryCount
+            return "✓ Generated! \(count) dry-run \(count == 1 ? "delivery" : "deliveries") sent."
+        } else {
+            return "✓ Broadcast complete — \(result.deliveryCount) \(result.deliveryCount == 1 ? "email" : "emails") sent."
+        }
+    }
+
+    private func triggerPostDraft(force: Bool) async {
+        do {
+            _ = try await store.triggerPostDraft(
+                dryRun: store.postDraftDryRun,
+                force: force
+            )
+        } catch {
+            // Error already surfaced via store.postDraftError.
+        }
+    }
+
+    private func formattedShortDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, h:mm a"
+        return formatter.string(from: date)
+    }
+
+    // MARK: - Preseason AI Review trigger
+
+    private var preseasonTriggerCard: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Preseason AI Review")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+                Text(preseasonStatusLine)
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textSecondary)
+            }
+
+            Toggle(isOn: $store.preseasonDryRun) {
+                Text("Dry run (admin-only delivery)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.textPrimary)
+            }
+            .toggleStyle(.switch)
+            .tint(XomperColors.championGold)
+            .disabled(store.isTriggeringPreseason)
+
+            HStack(spacing: XomperTheme.Spacing.sm) {
+                Button {
+                    Task { await triggerPreseason(force: false) }
+                } label: {
+                    HStack(spacing: XomperTheme.Spacing.xs) {
+                        if store.isTriggeringPreseason {
+                            ProgressView()
+                                .scaleEffect(0.7)
+                                .tint(XomperColors.bgDark)
+                        } else {
+                            Image(systemName: "sparkles")
+                                .font(.caption2)
+                        }
+                        Text(preseasonPrimaryButtonLabel)
+                            .font(.caption.weight(.semibold))
+                    }
+                    .foregroundStyle(XomperColors.bgDark)
+                    .padding(.horizontal, XomperTheme.Spacing.sm)
+                    .padding(.vertical, XomperTheme.Spacing.xs)
+                    .frame(minHeight: 32)
+                    .background(XomperColors.championGold)
+                    .clipShape(Capsule())
+                }
+                .buttonStyle(.pressableCard)
+                .disabled(store.isTriggeringPreseason)
+
+                if store.preseasonLatest != nil {
+                    Button {
+                        Task { await triggerPreseason(force: true) }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.caption2)
+                            Text("Regenerate (force)")
+                                .font(.caption.weight(.semibold))
+                        }
+                        .foregroundStyle(XomperColors.championGold)
+                        .padding(.horizontal, XomperTheme.Spacing.sm)
+                        .padding(.vertical, XomperTheme.Spacing.xs)
+                        .frame(minHeight: 32)
+                        .overlay(
+                            Capsule()
+                                .strokeBorder(XomperColors.championGold.opacity(0.6), lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(.pressableCard)
+                    .disabled(store.isTriggeringPreseason)
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            if let result = store.preseasonResult {
+                Text(preseasonResultLine(result))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.successGreen)
+            } else if let error = store.preseasonError {
+                Text("✗ \(error.localizedDescription)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.errorRed)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    private var preseasonStatusLine: String {
+        guard let latest = store.preseasonLatest else {
+            return "No report yet — first run will be dry-run."
+        }
+        let isDryRun = latest.metadata["dry_run"] == "true"
+        let dateStr = formattedShortDate(latest.createdAt)
+        if isDryRun {
+            return "Last dry-run completed at \(dateStr)."
+        } else {
+            return "Broadcast on \(dateStr)."
+        }
+    }
+
+    private var preseasonPrimaryButtonLabel: String {
+        if store.preseasonLatest == nil {
+            // No prior report — first run is always dry-run.
+            return "Generate Dry Run"
+        }
+        return store.preseasonDryRun ? "Generate Dry Run" : "Generate & Broadcast"
+    }
+
+    private func preseasonResultLine(_ result: AIReviewTriggerResponse) -> String {
+        if result.dryRun {
+            let count = result.deliveryCount
+            return "✓ Generated! \(count) dry-run \(count == 1 ? "delivery" : "deliveries") sent."
+        } else {
+            return "✓ Broadcast complete — \(result.deliveryCount) \(result.deliveryCount == 1 ? "email" : "emails") sent."
+        }
+    }
+
+    private func triggerPreseason(force: Bool) async {
+        do {
+            _ = try await store.triggerPreseason(
+                dryRun: store.preseasonDryRun,
+                force: force
+            )
+        } catch {
+            // Error already surfaced via store.preseasonError.
+        }
+    }
+
+    // MARK: - Weekly AI Review trigger
+
+    /// Binding for the "Override week" toggle. Backed by
+    /// `store.weeklyWeekOverride` — `nil` means "let the backend
+    /// resolve current week", non-nil means "send this week
+    /// explicitly". Flipping ON seeds a sensible default (1) so the
+    /// stepper has somewhere to start.
+    private var weeklyOverrideEnabled: Binding<Bool> {
+        Binding(
+            get: { store.weeklyWeekOverride != nil },
+            set: { newValue in
+                if newValue {
+                    if store.weeklyWeekOverride == nil {
+                        store.weeklyWeekOverride = 1
+                    }
+                } else {
+                    store.weeklyWeekOverride = nil
+                }
+            }
+        )
+    }
+
+    /// Binding wrapping the optional `weeklyWeekOverride` for the
+    /// Stepper. Stepper only renders when the override toggle is ON,
+    /// so a nil read here is treated as 1 defensively.
+    private var weeklyWeekBinding: Binding<Int> {
+        Binding(
+            get: { store.weeklyWeekOverride ?? 1 },
+            set: { store.weeklyWeekOverride = $0 }
+        )
+    }
+
+    private var weeklyTriggerCard: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Weekly AI Review")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+                Text(weeklyStatusLine)
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textSecondary)
+            }
+
+            Toggle(isOn: $store.weeklyDryRun) {
+                Text("Dry run (admin-only delivery)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.textPrimary)
+            }
+            .toggleStyle(.switch)
+            .tint(XomperColors.championGold)
+            .disabled(store.isTriggeringWeekly)
+
+            Toggle(isOn: weeklyOverrideEnabled) {
+                Text("Override week (default = current)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.textPrimary)
+            }
+            .toggleStyle(.switch)
+            .tint(XomperColors.championGold)
+            .disabled(store.isTriggeringWeekly)
+
+            if store.weeklyWeekOverride != nil {
+                Stepper(value: weeklyWeekBinding, in: 1...18) {
+                    HStack(spacing: XomperTheme.Spacing.xs) {
+                        Text("Week")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(XomperColors.textPrimary)
+                        Text("\(store.weeklyWeekOverride ?? 1)")
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(XomperColors.championGold)
+                            .monospacedDigit()
+                    }
+                }
+                .disabled(store.isTriggeringWeekly)
+            }
+
+            HStack(spacing: XomperTheme.Spacing.sm) {
+                Button {
+                    Task { await triggerWeekly(force: false) }
+                } label: {
+                    HStack(spacing: XomperTheme.Spacing.xs) {
+                        if store.isTriggeringWeekly {
+                            ProgressView()
+                                .scaleEffect(0.7)
+                                .tint(XomperColors.bgDark)
+                        } else {
+                            Image(systemName: "sparkles")
+                                .font(.caption2)
+                        }
+                        Text(weeklyPrimaryButtonLabel)
+                            .font(.caption.weight(.semibold))
+                    }
+                    .foregroundStyle(XomperColors.bgDark)
+                    .padding(.horizontal, XomperTheme.Spacing.sm)
+                    .padding(.vertical, XomperTheme.Spacing.xs)
+                    .frame(minHeight: 32)
+                    .background(XomperColors.championGold)
+                    .clipShape(Capsule())
+                }
+                .buttonStyle(.pressableCard)
+                .disabled(store.isTriggeringWeekly)
+
+                if store.weeklyLatest != nil {
+                    Button {
+                        Task { await triggerWeekly(force: true) }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.caption2)
+                            Text("Regenerate (force)")
+                                .font(.caption.weight(.semibold))
+                        }
+                        .foregroundStyle(XomperColors.championGold)
+                        .padding(.horizontal, XomperTheme.Spacing.sm)
+                        .padding(.vertical, XomperTheme.Spacing.xs)
+                        .frame(minHeight: 32)
+                        .overlay(
+                            Capsule()
+                                .strokeBorder(XomperColors.championGold.opacity(0.6), lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(.pressableCard)
+                    .disabled(store.isTriggeringWeekly)
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            if let result = store.weeklyResult {
+                Text(weeklyResultLine(result))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.successGreen)
+            } else if let error = store.weeklyError {
+                Text("✗ \(error.localizedDescription)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.errorRed)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    private var weeklyStatusLine: String {
+        guard let latest = store.weeklyLatest else {
+            return "No report yet — first run will be dry-run."
+        }
+        let isDryRun = latest.metadata["dry_run"] == "true"
+        let dateStr = formattedShortDate(latest.createdAt)
+        if isDryRun {
+            return "Last dry-run (\(latest.period)) completed at \(dateStr)."
+        } else {
+            return "Broadcast (\(latest.period)) on \(dateStr)."
+        }
+    }
+
+    private var weeklyPrimaryButtonLabel: String {
+        if store.weeklyLatest == nil {
+            // No prior report — first run is always dry-run.
+            return "Generate Dry Run"
+        }
+        return store.weeklyDryRun ? "Generate Dry Run" : "Generate & Broadcast"
+    }
+
+    private func weeklyResultLine(_ result: AIReviewTriggerResponse) -> String {
+        if result.dryRun {
+            let count = result.deliveryCount
+            return "✓ Generated! \(count) dry-run \(count == 1 ? "delivery" : "deliveries") sent."
+        } else {
+            return "✓ Broadcast complete — \(result.deliveryCount) \(result.deliveryCount == 1 ? "email" : "emails") sent."
+        }
+    }
+
+    private func triggerWeekly(force: Bool) async {
+        do {
+            _ = try await store.triggerWeekly(
+                week: store.weeklyWeekOverride,
+                dryRun: store.weeklyDryRun,
+                force: force
+            )
+        } catch {
+            // Error already surfaced via store.weeklyError.
+        }
+    }
+
+    // MARK: - Test sender
+
+    private var testSenderCard: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Test sender")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+                Text("Fire any production template back to your account. Push titles arrive prefixed with 🧪.")
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textSecondary)
+            }
+
+            ForEach(AdminTestKind.allCases) { kind in
+                HStack(spacing: XomperTheme.Spacing.xs) {
+                    Text(kind.label)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(XomperColors.textPrimary)
+                    Spacer()
+
+                    Button {
+                        Task {
+                            await store.sendTest(
+                                kind: kind,
+                                sleeperUserId: callerSleeperId,
+                                email: kind.hasEmail ? callerEmail : nil,
+                                channels: kind.hasEmail ? ["push", "email"] : ["push"]
+                            )
+                        }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: kind.hasEmail ? "paperplane.fill" : "iphone.gen3")
+                                .font(.caption2)
+                            Text(kind.hasEmail ? "Push + email" : "Push")
+                                .font(.caption.weight(.semibold))
+                        }
+                        .foregroundStyle(XomperColors.bgDark)
+                        .padding(.horizontal, XomperTheme.Spacing.sm)
+                        .padding(.vertical, XomperTheme.Spacing.xs)
+                        .frame(minHeight: 32)
+                        .background(XomperColors.championGold)
+                        .clipShape(Capsule())
+                    }
+                    .buttonStyle(.pressableCard)
+                }
+                .padding(.vertical, 2)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    // MARK: - Filters
+
+    private var filterBar: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            Text("Activity · last 7 days")
+                .font(.caption.weight(.bold))
+                .textCase(.uppercase)
+                .tracking(0.5)
+                .foregroundStyle(XomperColors.textMuted)
+
+            HStack(spacing: XomperTheme.Spacing.sm) {
+                Picker("Channel", selection: $store.filterKind) {
+                    ForEach(AdminStore.KindFilter.allCases) { f in
+                        Text(f.label).tag(f)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Picker("Status", selection: $store.filterStatus) {
+                    ForEach(AdminStore.StatusFilter.allCases) { f in
+                        Text(f.label).tag(f)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+            .onChange(of: store.filterKind) { _, _ in
+                Task { await store.refresh(sleeperUserId: callerSleeperId) }
+            }
+            .onChange(of: store.filterStatus) { _, _ in
+                Task { await store.refresh(sleeperUserId: callerSleeperId) }
+            }
+        }
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    // MARK: - Activity row
+
+    private func activityRow(_ entry: AdminNotificationLogEntry) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                Image(systemName: entry.isPush ? "iphone.gen3" : "envelope.fill")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(entry.isPush ? Color.cyan : XomperColors.championGold)
+                Text(entry.isPush ? "PUSH" : "EMAIL")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(XomperColors.textSecondary)
+                    .tracking(0.5)
+                Text(entry.isSuccess ? "✓" : "✗")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(entry.isSuccess ? XomperColors.successGreen : XomperColors.errorRed)
+                Spacer()
+                Text(formattedTimestamp(entry.date))
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.textMuted)
+                    .monospacedDigit()
+            }
+
+            if entry.isPush {
+                if let title = entry.title, !title.isEmpty {
+                    Text(title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(XomperColors.textPrimary)
+                        .lineLimit(1)
+                }
+                if let body = entry.body, !body.isEmpty {
+                    Text(body)
+                        .font(.caption)
+                        .foregroundStyle(XomperColors.textSecondary)
+                        .lineLimit(2)
+                }
+                if let userId = entry.userId, !userId.isEmpty {
+                    Text("user: \(userId)")
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .monospacedDigit()
+                }
+            } else {
+                if let subject = entry.subject, !subject.isEmpty {
+                    Text(subject)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(XomperColors.textPrimary)
+                        .lineLimit(1)
+                }
+                if let recipient = entry.recipient, !recipient.isEmpty {
+                    Text(recipient)
+                        .font(.caption)
+                        .foregroundStyle(XomperColors.textSecondary)
+                        .lineLimit(1)
+                }
+                if let snippet = entry.bodySnippet, !snippet.isEmpty {
+                    Text(snippet)
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .lineLimit(2)
+                }
+            }
+
+            if let err = entry.error, !err.isEmpty {
+                Text(err)
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.errorRed)
+                    .lineLimit(2)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md)
+                .strokeBorder(
+                    entry.isSuccess ? Color.clear : XomperColors.errorRed.opacity(0.4),
+                    lineWidth: entry.isSuccess ? 0 : 1
+                )
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    private func formattedTimestamp(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, h:mm:ss a"
+        return formatter.string(from: date)
+    }
+}

--- a/Xomper/Features/Admin/AdminView.swift
+++ b/Xomper/Features/Admin/AdminView.swift
@@ -1,20 +1,22 @@
 import SwiftUI
 
-/// Admin portal — only visible when the signed-in
-/// `whitelistedUser.isAdmin == true`. Two sections:
-/// 1. **Test sender** — fire any of the production push/email
-///    templates back to yourself so you can preview formatting +
-///    confirm the channel is working.
-/// 2. **Activity feed** — last 200 push + email send attempts
-///    (success + failure), filterable by channel and status.
+/// Admin portal home. F1 refactor — `AdminView` is now a `NavigationLink`
+/// menu of 5 sub-screens. The pre-F1 trigger cards / activity feed /
+/// test-sender card moved verbatim into `AIReviewSubScreen.swift`; F1
+/// adds the new `TestEmailView` sub-screen + three "Coming soon" stubs.
 ///
-/// Backend gating is enforced server-side via the `is_admin` flag
-/// on `whitelisted_users`; this view also hides the destination
-/// for non-admins so they never see the menu entry.
+/// Visibility:
+/// - AI Review + Test Email — always visible for admin users.
+/// - Tables / Logs / Audit — gated by `Config.AdminFlags.*`; default
+///   off until F4/F5 land.
+///
+/// Backend gating is enforced server-side via the `is_admin` flag on
+/// `whitelisted_users`; this view also hides the destination for
+/// non-admins so they never see the menu.
 struct AdminView: View {
     var authStore: AuthStore
     var leagueStore: LeagueStore
-    @State private var store = AdminStore()
+    var router: AppRouter
 
     var body: some View {
         Group {
@@ -25,727 +27,123 @@ struct AdminView: View {
                     message: "Your account doesn't have admin permission. Ask the commissioner to flip your is_admin flag."
                 )
             } else {
-                content
+                menu
             }
         }
         .background(XomperColors.bgDark.ignoresSafeArea())
-        .task(id: callerSleeperId) {
-            await store.refresh(sleeperUserId: callerSleeperId)
-            await store.loadPostDraftLatest()
-            await store.loadPreseasonLatest()
-            await store.loadWeeklyLatest()
-        }
-        .refreshable {
-            await store.refresh(sleeperUserId: callerSleeperId)
-            await store.loadPostDraftLatest()
-            await store.loadPreseasonLatest()
-            await store.loadWeeklyLatest()
-        }
     }
 
     private var isAdmin: Bool {
         authStore.whitelistedUser?.isAdmin == true
     }
 
-    private var callerSleeperId: String {
-        authStore.sleeperUserId ?? ""
-    }
+    // MARK: - Menu
 
-    private var callerEmail: String? {
-        authStore.session?.user.email
-    }
-
-    // MARK: - Content
-
-    private var content: some View {
+    private var menu: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
-                postDraftTriggerCard
-
-                preseasonTriggerCard
-
-                weeklyTriggerCard
-
-                testSenderCard
-
-                if let result = store.lastTestResult {
-                    Text(result)
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(result.hasPrefix("✓") ? XomperColors.successGreen : XomperColors.errorRed)
-                        .padding(.horizontal, XomperTheme.Spacing.md)
-                }
-
-                filterBar
-
-                if store.isLoading && store.entries.isEmpty {
-                    LoadingView(message: "Loading activity…")
-                        .padding(.top, XomperTheme.Spacing.xl)
-                } else if let error = store.lastError, store.entries.isEmpty {
-                    ErrorView(message: error) {
-                        Task { await store.refresh(sleeperUserId: callerSleeperId) }
-                    }
-                } else if store.entries.isEmpty {
-                    EmptyStateView(
-                        icon: "tray",
-                        title: "No activity",
-                        message: "No push or email sends recorded in the last 7 days for the current filters."
-                    )
-                    .padding(.top, XomperTheme.Spacing.lg)
-                } else {
-                    ForEach(store.entries) { entry in
-                        activityRow(entry)
-                    }
-                }
-            }
-            .padding(.vertical, XomperTheme.Spacing.sm)
-            .padding(.bottom, XomperTheme.Spacing.xl)
-        }
-    }
-
-    // MARK: - Post-Draft AI Review trigger
-
-    private var postDraftTriggerCard: some View {
-        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Post-Draft AI Review")
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(XomperColors.championGold)
-                Text(postDraftStatusLine)
-                    .font(.caption)
-                    .foregroundStyle(XomperColors.textSecondary)
-            }
-
-            Toggle(isOn: $store.postDraftDryRun) {
-                Text("Dry run (admin-only delivery)")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(XomperColors.textPrimary)
-            }
-            .toggleStyle(.switch)
-            .tint(XomperColors.championGold)
-            .disabled(store.isTriggeringPostDraft)
-
-            HStack(spacing: XomperTheme.Spacing.sm) {
-                Button {
-                    Task { await triggerPostDraft(force: false) }
-                } label: {
-                    HStack(spacing: XomperTheme.Spacing.xs) {
-                        if store.isTriggeringPostDraft {
-                            ProgressView()
-                                .scaleEffect(0.7)
-                                .tint(XomperColors.bgDark)
-                        } else {
-                            Image(systemName: "sparkles")
-                                .font(.caption2)
-                        }
-                        Text(primaryButtonLabel)
-                            .font(.caption.weight(.semibold))
-                    }
-                    .foregroundStyle(XomperColors.bgDark)
-                    .padding(.horizontal, XomperTheme.Spacing.sm)
-                    .padding(.vertical, XomperTheme.Spacing.xs)
-                    .frame(minHeight: 32)
-                    .background(XomperColors.championGold)
-                    .clipShape(Capsule())
-                }
-                .buttonStyle(.pressableCard)
-                .disabled(store.isTriggeringPostDraft)
-
-                if store.postDraftLatest != nil {
-                    Button {
-                        Task { await triggerPostDraft(force: true) }
-                    } label: {
-                        HStack(spacing: 4) {
-                            Image(systemName: "arrow.clockwise")
-                                .font(.caption2)
-                            Text("Regenerate (force)")
-                                .font(.caption.weight(.semibold))
-                        }
-                        .foregroundStyle(XomperColors.championGold)
-                        .padding(.horizontal, XomperTheme.Spacing.sm)
-                        .padding(.vertical, XomperTheme.Spacing.xs)
-                        .frame(minHeight: 32)
-                        .overlay(
-                            Capsule()
-                                .strokeBorder(XomperColors.championGold.opacity(0.6), lineWidth: 1)
-                        )
-                    }
-                    .buttonStyle(.pressableCard)
-                    .disabled(store.isTriggeringPostDraft)
-                }
-
-                Spacer(minLength: 0)
-            }
-
-            if let result = store.postDraftResult {
-                Text(postDraftResultLine(result))
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(XomperColors.successGreen)
-            } else if let error = store.postDraftError {
-                Text("✗ \(error.localizedDescription)")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(XomperColors.errorRed)
-            }
-        }
-        .padding(XomperTheme.Spacing.md)
-        .background(XomperColors.bgCard)
-        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
-                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
-        )
-        .padding(.horizontal, XomperTheme.Spacing.md)
-    }
-
-    private var postDraftStatusLine: String {
-        guard let latest = store.postDraftLatest else {
-            return "No report yet — first run will be dry-run."
-        }
-        let isDryRun = latest.metadata["dry_run"] == "true"
-        let dateStr = formattedShortDate(latest.createdAt)
-        if isDryRun {
-            return "Last dry-run completed at \(dateStr)."
-        } else {
-            return "Broadcast on \(dateStr)."
-        }
-    }
-
-    private var primaryButtonLabel: String {
-        if store.postDraftLatest == nil {
-            // No prior report — first run is always dry-run.
-            return "Generate Dry Run"
-        }
-        return store.postDraftDryRun ? "Generate Dry Run" : "Generate & Broadcast"
-    }
-
-    private func postDraftResultLine(_ result: AIReviewTriggerResponse) -> String {
-        if result.dryRun {
-            let count = result.deliveryCount
-            return "✓ Generated! \(count) dry-run \(count == 1 ? "delivery" : "deliveries") sent."
-        } else {
-            return "✓ Broadcast complete — \(result.deliveryCount) \(result.deliveryCount == 1 ? "email" : "emails") sent."
-        }
-    }
-
-    private func triggerPostDraft(force: Bool) async {
-        do {
-            _ = try await store.triggerPostDraft(
-                dryRun: store.postDraftDryRun,
-                force: force
-            )
-        } catch {
-            // Error already surfaced via store.postDraftError.
-        }
-    }
-
-    private func formattedShortDate(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMM d, h:mm a"
-        return formatter.string(from: date)
-    }
-
-    // MARK: - Preseason AI Review trigger
-
-    private var preseasonTriggerCard: some View {
-        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Preseason AI Review")
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(XomperColors.championGold)
-                Text(preseasonStatusLine)
-                    .font(.caption)
-                    .foregroundStyle(XomperColors.textSecondary)
-            }
-
-            Toggle(isOn: $store.preseasonDryRun) {
-                Text("Dry run (admin-only delivery)")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(XomperColors.textPrimary)
-            }
-            .toggleStyle(.switch)
-            .tint(XomperColors.championGold)
-            .disabled(store.isTriggeringPreseason)
-
-            HStack(spacing: XomperTheme.Spacing.sm) {
-                Button {
-                    Task { await triggerPreseason(force: false) }
-                } label: {
-                    HStack(spacing: XomperTheme.Spacing.xs) {
-                        if store.isTriggeringPreseason {
-                            ProgressView()
-                                .scaleEffect(0.7)
-                                .tint(XomperColors.bgDark)
-                        } else {
-                            Image(systemName: "sparkles")
-                                .font(.caption2)
-                        }
-                        Text(preseasonPrimaryButtonLabel)
-                            .font(.caption.weight(.semibold))
-                    }
-                    .foregroundStyle(XomperColors.bgDark)
-                    .padding(.horizontal, XomperTheme.Spacing.sm)
-                    .padding(.vertical, XomperTheme.Spacing.xs)
-                    .frame(minHeight: 32)
-                    .background(XomperColors.championGold)
-                    .clipShape(Capsule())
-                }
-                .buttonStyle(.pressableCard)
-                .disabled(store.isTriggeringPreseason)
-
-                if store.preseasonLatest != nil {
-                    Button {
-                        Task { await triggerPreseason(force: true) }
-                    } label: {
-                        HStack(spacing: 4) {
-                            Image(systemName: "arrow.clockwise")
-                                .font(.caption2)
-                            Text("Regenerate (force)")
-                                .font(.caption.weight(.semibold))
-                        }
-                        .foregroundStyle(XomperColors.championGold)
-                        .padding(.horizontal, XomperTheme.Spacing.sm)
-                        .padding(.vertical, XomperTheme.Spacing.xs)
-                        .frame(minHeight: 32)
-                        .overlay(
-                            Capsule()
-                                .strokeBorder(XomperColors.championGold.opacity(0.6), lineWidth: 1)
-                        )
-                    }
-                    .buttonStyle(.pressableCard)
-                    .disabled(store.isTriggeringPreseason)
-                }
-
-                Spacer(minLength: 0)
-            }
-
-            if let result = store.preseasonResult {
-                Text(preseasonResultLine(result))
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(XomperColors.successGreen)
-            } else if let error = store.preseasonError {
-                Text("✗ \(error.localizedDescription)")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(XomperColors.errorRed)
-            }
-        }
-        .padding(XomperTheme.Spacing.md)
-        .background(XomperColors.bgCard)
-        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
-                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
-        )
-        .padding(.horizontal, XomperTheme.Spacing.md)
-    }
-
-    private var preseasonStatusLine: String {
-        guard let latest = store.preseasonLatest else {
-            return "No report yet — first run will be dry-run."
-        }
-        let isDryRun = latest.metadata["dry_run"] == "true"
-        let dateStr = formattedShortDate(latest.createdAt)
-        if isDryRun {
-            return "Last dry-run completed at \(dateStr)."
-        } else {
-            return "Broadcast on \(dateStr)."
-        }
-    }
-
-    private var preseasonPrimaryButtonLabel: String {
-        if store.preseasonLatest == nil {
-            // No prior report — first run is always dry-run.
-            return "Generate Dry Run"
-        }
-        return store.preseasonDryRun ? "Generate Dry Run" : "Generate & Broadcast"
-    }
-
-    private func preseasonResultLine(_ result: AIReviewTriggerResponse) -> String {
-        if result.dryRun {
-            let count = result.deliveryCount
-            return "✓ Generated! \(count) dry-run \(count == 1 ? "delivery" : "deliveries") sent."
-        } else {
-            return "✓ Broadcast complete — \(result.deliveryCount) \(result.deliveryCount == 1 ? "email" : "emails") sent."
-        }
-    }
-
-    private func triggerPreseason(force: Bool) async {
-        do {
-            _ = try await store.triggerPreseason(
-                dryRun: store.preseasonDryRun,
-                force: force
-            )
-        } catch {
-            // Error already surfaced via store.preseasonError.
-        }
-    }
-
-    // MARK: - Weekly AI Review trigger
-
-    /// Binding for the "Override week" toggle. Backed by
-    /// `store.weeklyWeekOverride` — `nil` means "let the backend
-    /// resolve current week", non-nil means "send this week
-    /// explicitly". Flipping ON seeds a sensible default (1) so the
-    /// stepper has somewhere to start.
-    private var weeklyOverrideEnabled: Binding<Bool> {
-        Binding(
-            get: { store.weeklyWeekOverride != nil },
-            set: { newValue in
-                if newValue {
-                    if store.weeklyWeekOverride == nil {
-                        store.weeklyWeekOverride = 1
-                    }
-                } else {
-                    store.weeklyWeekOverride = nil
-                }
-            }
-        )
-    }
-
-    /// Binding wrapping the optional `weeklyWeekOverride` for the
-    /// Stepper. Stepper only renders when the override toggle is ON,
-    /// so a nil read here is treated as 1 defensively.
-    private var weeklyWeekBinding: Binding<Int> {
-        Binding(
-            get: { store.weeklyWeekOverride ?? 1 },
-            set: { store.weeklyWeekOverride = $0 }
-        )
-    }
-
-    private var weeklyTriggerCard: some View {
-        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Weekly AI Review")
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(XomperColors.championGold)
-                Text(weeklyStatusLine)
-                    .font(.caption)
-                    .foregroundStyle(XomperColors.textSecondary)
-            }
-
-            Toggle(isOn: $store.weeklyDryRun) {
-                Text("Dry run (admin-only delivery)")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(XomperColors.textPrimary)
-            }
-            .toggleStyle(.switch)
-            .tint(XomperColors.championGold)
-            .disabled(store.isTriggeringWeekly)
-
-            Toggle(isOn: weeklyOverrideEnabled) {
-                Text("Override week (default = current)")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(XomperColors.textPrimary)
-            }
-            .toggleStyle(.switch)
-            .tint(XomperColors.championGold)
-            .disabled(store.isTriggeringWeekly)
-
-            if store.weeklyWeekOverride != nil {
-                Stepper(value: weeklyWeekBinding, in: 1...18) {
-                    HStack(spacing: XomperTheme.Spacing.xs) {
-                        Text("Week")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(XomperColors.textPrimary)
-                        Text("\(store.weeklyWeekOverride ?? 1)")
-                            .font(.caption.weight(.bold))
-                            .foregroundStyle(XomperColors.championGold)
-                            .monospacedDigit()
-                    }
-                }
-                .disabled(store.isTriggeringWeekly)
-            }
-
-            HStack(spacing: XomperTheme.Spacing.sm) {
-                Button {
-                    Task { await triggerWeekly(force: false) }
-                } label: {
-                    HStack(spacing: XomperTheme.Spacing.xs) {
-                        if store.isTriggeringWeekly {
-                            ProgressView()
-                                .scaleEffect(0.7)
-                                .tint(XomperColors.bgDark)
-                        } else {
-                            Image(systemName: "sparkles")
-                                .font(.caption2)
-                        }
-                        Text(weeklyPrimaryButtonLabel)
-                            .font(.caption.weight(.semibold))
-                    }
-                    .foregroundStyle(XomperColors.bgDark)
-                    .padding(.horizontal, XomperTheme.Spacing.sm)
-                    .padding(.vertical, XomperTheme.Spacing.xs)
-                    .frame(minHeight: 32)
-                    .background(XomperColors.championGold)
-                    .clipShape(Capsule())
-                }
-                .buttonStyle(.pressableCard)
-                .disabled(store.isTriggeringWeekly)
-
-                if store.weeklyLatest != nil {
-                    Button {
-                        Task { await triggerWeekly(force: true) }
-                    } label: {
-                        HStack(spacing: 4) {
-                            Image(systemName: "arrow.clockwise")
-                                .font(.caption2)
-                            Text("Regenerate (force)")
-                                .font(.caption.weight(.semibold))
-                        }
-                        .foregroundStyle(XomperColors.championGold)
-                        .padding(.horizontal, XomperTheme.Spacing.sm)
-                        .padding(.vertical, XomperTheme.Spacing.xs)
-                        .frame(minHeight: 32)
-                        .overlay(
-                            Capsule()
-                                .strokeBorder(XomperColors.championGold.opacity(0.6), lineWidth: 1)
-                        )
-                    }
-                    .buttonStyle(.pressableCard)
-                    .disabled(store.isTriggeringWeekly)
-                }
-
-                Spacer(minLength: 0)
-            }
-
-            if let result = store.weeklyResult {
-                Text(weeklyResultLine(result))
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(XomperColors.successGreen)
-            } else if let error = store.weeklyError {
-                Text("✗ \(error.localizedDescription)")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(XomperColors.errorRed)
-            }
-        }
-        .padding(XomperTheme.Spacing.md)
-        .background(XomperColors.bgCard)
-        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
-                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
-        )
-        .padding(.horizontal, XomperTheme.Spacing.md)
-    }
-
-    private var weeklyStatusLine: String {
-        guard let latest = store.weeklyLatest else {
-            return "No report yet — first run will be dry-run."
-        }
-        let isDryRun = latest.metadata["dry_run"] == "true"
-        let dateStr = formattedShortDate(latest.createdAt)
-        if isDryRun {
-            return "Last dry-run (\(latest.period)) completed at \(dateStr)."
-        } else {
-            return "Broadcast (\(latest.period)) on \(dateStr)."
-        }
-    }
-
-    private var weeklyPrimaryButtonLabel: String {
-        if store.weeklyLatest == nil {
-            // No prior report — first run is always dry-run.
-            return "Generate Dry Run"
-        }
-        return store.weeklyDryRun ? "Generate Dry Run" : "Generate & Broadcast"
-    }
-
-    private func weeklyResultLine(_ result: AIReviewTriggerResponse) -> String {
-        if result.dryRun {
-            let count = result.deliveryCount
-            return "✓ Generated! \(count) dry-run \(count == 1 ? "delivery" : "deliveries") sent."
-        } else {
-            return "✓ Broadcast complete — \(result.deliveryCount) \(result.deliveryCount == 1 ? "email" : "emails") sent."
-        }
-    }
-
-    private func triggerWeekly(force: Bool) async {
-        do {
-            _ = try await store.triggerWeekly(
-                week: store.weeklyWeekOverride,
-                dryRun: store.weeklyDryRun,
-                force: force
-            )
-        } catch {
-            // Error already surfaced via store.weeklyError.
-        }
-    }
-
-    // MARK: - Test sender
-
-    private var testSenderCard: some View {
-        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Test sender")
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(XomperColors.championGold)
-                Text("Fire any production template back to your account. Push titles arrive prefixed with 🧪.")
-                    .font(.caption)
-                    .foregroundStyle(XomperColors.textSecondary)
-            }
-
-            ForEach(AdminTestKind.allCases) { kind in
-                HStack(spacing: XomperTheme.Spacing.xs) {
-                    Text(kind.label)
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(XomperColors.textPrimary)
-                    Spacer()
-
-                    Button {
-                        Task {
-                            await store.sendTest(
-                                kind: kind,
-                                sleeperUserId: callerSleeperId,
-                                email: kind.hasEmail ? callerEmail : nil,
-                                channels: kind.hasEmail ? ["push", "email"] : ["push"]
-                            )
-                        }
-                    } label: {
-                        HStack(spacing: 4) {
-                            Image(systemName: kind.hasEmail ? "paperplane.fill" : "iphone.gen3")
-                                .font(.caption2)
-                            Text(kind.hasEmail ? "Push + email" : "Push")
-                                .font(.caption.weight(.semibold))
-                        }
-                        .foregroundStyle(XomperColors.bgDark)
-                        .padding(.horizontal, XomperTheme.Spacing.sm)
-                        .padding(.vertical, XomperTheme.Spacing.xs)
-                        .frame(minHeight: 32)
-                        .background(XomperColors.championGold)
-                        .clipShape(Capsule())
-                    }
-                    .buttonStyle(.pressableCard)
-                }
-                .padding(.vertical, 2)
-            }
-        }
-        .padding(XomperTheme.Spacing.md)
-        .background(XomperColors.bgCard)
-        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
-                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
-        )
-        .padding(.horizontal, XomperTheme.Spacing.md)
-    }
-
-    // MARK: - Filters
-
-    private var filterBar: some View {
-        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
-            Text("Activity · last 7 days")
-                .font(.caption.weight(.bold))
-                .textCase(.uppercase)
-                .tracking(0.5)
-                .foregroundStyle(XomperColors.textMuted)
-
-            HStack(spacing: XomperTheme.Spacing.sm) {
-                Picker("Channel", selection: $store.filterKind) {
-                    ForEach(AdminStore.KindFilter.allCases) { f in
-                        Text(f.label).tag(f)
-                    }
-                }
-                .pickerStyle(.segmented)
-
-                Picker("Status", selection: $store.filterStatus) {
-                    ForEach(AdminStore.StatusFilter.allCases) { f in
-                        Text(f.label).tag(f)
-                    }
-                }
-                .pickerStyle(.segmented)
-            }
-            .onChange(of: store.filterKind) { _, _ in
-                Task { await store.refresh(sleeperUserId: callerSleeperId) }
-            }
-            .onChange(of: store.filterStatus) { _, _ in
-                Task { await store.refresh(sleeperUserId: callerSleeperId) }
-            }
-        }
-        .padding(.horizontal, XomperTheme.Spacing.md)
-    }
-
-    // MARK: - Activity row
-
-    private func activityRow(_ entry: AdminNotificationLogEntry) -> some View {
-        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
-            HStack(spacing: XomperTheme.Spacing.xs) {
-                Image(systemName: entry.isPush ? "iphone.gen3" : "envelope.fill")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(entry.isPush ? Color.cyan : XomperColors.championGold)
-                Text(entry.isPush ? "PUSH" : "EMAIL")
-                    .font(.caption2.weight(.bold))
-                    .foregroundStyle(XomperColors.textSecondary)
-                    .tracking(0.5)
-                Text(entry.isSuccess ? "✓" : "✗")
-                    .font(.caption.weight(.bold))
-                    .foregroundStyle(entry.isSuccess ? XomperColors.successGreen : XomperColors.errorRed)
-                Spacer()
-                Text(formattedTimestamp(entry.date))
-                    .font(.caption2)
-                    .foregroundStyle(XomperColors.textMuted)
-                    .monospacedDigit()
-            }
-
-            if entry.isPush {
-                if let title = entry.title, !title.isEmpty {
-                    Text(title)
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(XomperColors.textPrimary)
-                        .lineLimit(1)
-                }
-                if let body = entry.body, !body.isEmpty {
-                    Text(body)
-                        .font(.caption)
-                        .foregroundStyle(XomperColors.textSecondary)
-                        .lineLimit(2)
-                }
-                if let userId = entry.userId, !userId.isEmpty {
-                    Text("user: \(userId)")
-                        .font(.caption2)
-                        .foregroundStyle(XomperColors.textMuted)
-                        .monospacedDigit()
-                }
-            } else {
-                if let subject = entry.subject, !subject.isEmpty {
-                    Text(subject)
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(XomperColors.textPrimary)
-                        .lineLimit(1)
-                }
-                if let recipient = entry.recipient, !recipient.isEmpty {
-                    Text(recipient)
-                        .font(.caption)
-                        .foregroundStyle(XomperColors.textSecondary)
-                        .lineLimit(1)
-                }
-                if let snippet = entry.bodySnippet, !snippet.isEmpty {
-                    Text(snippet)
-                        .font(.caption2)
-                        .foregroundStyle(XomperColors.textMuted)
-                        .lineLimit(2)
-                }
-            }
-
-            if let err = entry.error, !err.isEmpty {
-                Text(err)
-                    .font(.caption2)
-                    .foregroundStyle(XomperColors.errorRed)
-                    .lineLimit(2)
-            }
-        }
-        .padding(XomperTheme.Spacing.md)
-        .background(XomperColors.bgCard)
-        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
-        .overlay(
-            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md)
-                .strokeBorder(
-                    entry.isSuccess ? Color.clear : XomperColors.errorRed.opacity(0.4),
-                    lineWidth: entry.isSuccess ? 0 : 1
+            VStack(spacing: XomperTheme.Spacing.md) {
+                AdminMenuRow(
+                    icon: "sparkles",
+                    title: "AI Review",
+                    subtitle: "Trigger reports and view activity feed",
+                    action: { router.navigate(to: .adminAIReview) }
                 )
-        )
-        .padding(.horizontal, XomperTheme.Spacing.md)
-    }
 
-    private func formattedTimestamp(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMM d, h:mm:ss a"
-        return formatter.string(from: date)
+                AdminMenuRow(
+                    icon: "paperplane",
+                    title: "Test Email",
+                    subtitle: "Send an AI Review report to one user",
+                    action: { router.navigate(to: .adminTestEmail) }
+                )
+
+                if Config.AdminFlags.showTables {
+                    AdminMenuRow(
+                        icon: "tablecells",
+                        title: "Tables",
+                        subtitle: "Edit users, leagues, and reports",
+                        action: { router.navigate(to: .adminTables) }
+                    )
+                }
+
+                if Config.AdminFlags.showLogs {
+                    AdminMenuRow(
+                        icon: "terminal",
+                        title: "Logs",
+                        subtitle: "CloudWatch tail and search",
+                        action: { router.navigate(to: .adminLogs) }
+                    )
+                }
+
+                if Config.AdminFlags.showAudit {
+                    AdminMenuRow(
+                        icon: "clock.arrow.circlepath",
+                        title: "Audit",
+                        subtitle: "Recent admin actions",
+                        action: { router.navigate(to: .adminAudit) }
+                    )
+                }
+            }
+            .padding(.horizontal, XomperTheme.Spacing.md)
+            .padding(.vertical, XomperTheme.Spacing.sm)
+        }
+    }
+}
+
+// MARK: - Menu row
+
+/// Single admin menu row. Mirrors the `ArchiveHubCard` styling from
+/// the season-refocus F4 archive — same `bgCard` chrome, gold accent
+/// stroke at 0.3 opacity, gold SF Symbol leading icon, chevron trailing.
+private struct AdminMenuRow: View {
+    let icon: String
+    let title: String
+    let subtitle: String
+    let action: () -> Void
+
+    var body: some View {
+        Button {
+            let generator = UIImpactFeedbackGenerator(style: .light)
+            generator.impactOccurred()
+            action()
+        } label: {
+            HStack(spacing: XomperTheme.Spacing.md) {
+                Image(systemName: icon)
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(XomperColors.championGold)
+                    .frame(width: 36, alignment: .center)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+                    Text(title)
+                        .font(.headline)
+                        .foregroundStyle(XomperColors.textPrimary)
+                        .multilineTextAlignment(.leading)
+
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(XomperColors.textSecondary)
+                        .multilineTextAlignment(.leading)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.bold))
+                    .foregroundStyle(XomperColors.textMuted)
+                    .accessibilityHidden(true)
+            }
+            .padding(XomperTheme.Spacing.md)
+            .frame(minHeight: XomperTheme.minTouchTarget)
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+            .overlay(
+                RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                    .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+            )
+            .xomperShadow(.sm)
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title). \(subtitle).")
+        .accessibilityHint("Double tap to open")
     }
 }

--- a/Xomper/Features/Admin/AuditStubView.swift
+++ b/Xomper/Features/Admin/AuditStubView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Admin → Audit stub. Placeholder for F4's audit-log surface (recent
+/// admin actions). Reached from the admin menu only when
+/// `Config.AdminFlags.showAudit` is flipped on; defaults to hidden.
+struct AuditStubView: View {
+    var body: some View {
+        EmptyStateView(
+            icon: "clock.arrow.circlepath",
+            title: "Audit",
+            message: "Coming soon (F4) — recent admin actions feed."
+        )
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .navigationTitle("Audit")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AuditStubView()
+    }
+    .preferredColorScheme(.dark)
+}

--- a/Xomper/Features/Admin/LogsStubView.swift
+++ b/Xomper/Features/Admin/LogsStubView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Admin → Logs stub. Placeholder for F5's CloudWatch surface. Reached
+/// from the admin menu only when `Config.AdminFlags.showLogs` is
+/// flipped on; defaults to hidden.
+struct LogsStubView: View {
+    var body: some View {
+        EmptyStateView(
+            icon: "terminal",
+            title: "Logs",
+            message: "Coming soon (F5) — CloudWatch tail and search."
+        )
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .navigationTitle("Logs")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        LogsStubView()
+    }
+    .preferredColorScheme(.dark)
+}

--- a/Xomper/Features/Admin/TablesStubView.swift
+++ b/Xomper/Features/Admin/TablesStubView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Admin → Tables stub. Placeholder for F4's editor surface (users /
+/// leagues / reports). Reached from the admin menu only when
+/// `Config.AdminFlags.showTables` is flipped on; defaults to hidden.
+struct TablesStubView: View {
+    var body: some View {
+        EmptyStateView(
+            icon: "tablecells",
+            title: "Tables",
+            message: "Coming soon (F4) — Supabase + Dynamo admin editing."
+        )
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .navigationTitle("Tables")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        TablesStubView()
+    }
+    .preferredColorScheme(.dark)
+}

--- a/Xomper/Features/Admin/TestEmailView.swift
+++ b/Xomper/Features/Admin/TestEmailView.swift
@@ -1,0 +1,402 @@
+import SwiftUI
+
+/// Admin → Test Email sub-screen (F1).
+///
+/// Lets the admin send one of the latest AI Review reports (post-draft
+/// / preseason / weekly) to a single whitelisted user. Used to iterate
+/// on email copy without polluting broadcast state — backend handler
+/// is read-only against `xomper-ai-reports` and writes a
+/// `notification_log` row with `template = "ai_review_test"`.
+///
+/// UI:
+/// - **Recipient picker** — Menu of whitelisted users from
+///   `GET /admin/email-test-recipients`. Admin's own row is flagged.
+/// - **Report picker** — Menu of `latestByType` reports (3 max).
+/// - **Send button** — gold capsule; disabled until both pickers are
+///   set + while in flight.
+/// - **Toast** — green check on success, red X on error.
+/// - **Receipts list** — last few email send attempts, newest-first.
+struct TestEmailView: View {
+    var authStore: AuthStore
+    var aiReviewStore: AIReviewStore
+    @State private var store = TestEmailStore()
+
+    var body: some View {
+        content
+            .background(XomperColors.bgDark.ignoresSafeArea())
+            .navigationTitle("Test Email")
+            .navigationBarTitleDisplayMode(.inline)
+            .task(id: callerSleeperId) {
+                await loadAll()
+            }
+            .refreshable {
+                await loadAll()
+            }
+    }
+
+    private var callerSleeperId: String {
+        authStore.sleeperUserId ?? ""
+    }
+
+    private func loadAll() async {
+        async let recipients: () = store.loadRecipients()
+        async let recents: () = store.loadRecentSends(sleeperUserId: callerSleeperId)
+        async let postDraft: () = aiReviewStore.loadLatest(type: .postDraft)
+        async let preseason: () = aiReviewStore.loadLatest(type: .preseason)
+        async let weekly: () = aiReviewStore.loadLatest(type: .weekly)
+        _ = await (recipients, recents, postDraft, preseason, weekly)
+    }
+
+    // MARK: - Content
+
+    private var content: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
+                pickerCard
+
+                sendButton
+
+                if let result = store.lastResult {
+                    successToast(result)
+                } else if let error = store.lastError {
+                    errorToast(error)
+                }
+
+                receiptsHeader
+
+                receiptsList
+            }
+            .padding(.vertical, XomperTheme.Spacing.sm)
+            .padding(.bottom, XomperTheme.Spacing.xl)
+        }
+    }
+
+    // MARK: - Picker card
+
+    private var pickerCard: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Test Email")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+                Text("Send an existing AI Review report to one whitelisted user. Doesn't touch broadcast state.")
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textSecondary)
+            }
+
+            recipientPicker
+
+            reportPicker
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    private var recipientPicker: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            Text("Recipient")
+                .font(.caption.weight(.bold))
+                .textCase(.uppercase)
+                .tracking(0.5)
+                .foregroundStyle(XomperColors.textMuted)
+
+            Menu {
+                if store.recipients.isEmpty {
+                    Text(store.isLoadingRecipients ? "Loading…" : "No recipients available")
+                } else {
+                    ForEach(store.recipients) { recipient in
+                        Button {
+                            store.selectedRecipient = recipient
+                        } label: {
+                            HStack {
+                                Text(recipient.displayName)
+                                if recipient.isAdmin {
+                                    Text("· admin")
+                                }
+                            }
+                        }
+                    }
+                }
+            } label: {
+                HStack {
+                    Image(systemName: "person.crop.circle")
+                        .font(.caption)
+                        .foregroundStyle(XomperColors.championGold)
+                    Text(recipientLabel)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(XomperColors.textPrimary)
+                    Spacer()
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(XomperColors.textMuted)
+                }
+                .padding(.horizontal, XomperTheme.Spacing.sm)
+                .padding(.vertical, XomperTheme.Spacing.xs)
+                .frame(minHeight: XomperTheme.minTouchTarget)
+                .background(XomperColors.bgDark)
+                .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+            }
+            .disabled(store.isSending)
+
+            if let error = store.recipientsError {
+                Text(error)
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.errorRed)
+            }
+        }
+    }
+
+    private var recipientLabel: String {
+        if let recipient = store.selectedRecipient {
+            return recipient.displayName
+        }
+        return store.isLoadingRecipients ? "Loading recipients…" : "Choose recipient"
+    }
+
+    private var reportPicker: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            Text("Report")
+                .font(.caption.weight(.bold))
+                .textCase(.uppercase)
+                .tracking(0.5)
+                .foregroundStyle(XomperColors.textMuted)
+
+            Menu {
+                if availableReports.isEmpty {
+                    Text("No reports available yet")
+                } else {
+                    ForEach(availableReports, id: \.id) { report in
+                        Button {
+                            store.selectedReport = report
+                        } label: {
+                            Text(reportLabel(for: report))
+                        }
+                    }
+                }
+            } label: {
+                HStack {
+                    Image(systemName: "sparkles")
+                        .font(.caption)
+                        .foregroundStyle(XomperColors.championGold)
+                    Text(reportSelectionLabel)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(XomperColors.textPrimary)
+                        .lineLimit(1)
+                    Spacer()
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(XomperColors.textMuted)
+                }
+                .padding(.horizontal, XomperTheme.Spacing.sm)
+                .padding(.vertical, XomperTheme.Spacing.xs)
+                .frame(minHeight: XomperTheme.minTouchTarget)
+                .background(XomperColors.bgDark)
+                .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+            }
+            .disabled(store.isSending)
+        }
+    }
+
+    /// Latest-per-type, ordered Post-Draft → Preseason → Weekly. Filters
+    /// out types that don't have a report yet so the picker only shows
+    /// rows the admin can actually send.
+    private var availableReports: [AIReport] {
+        let order: [AIReportType] = [.postDraft, .preseason, .weekly]
+        return order.compactMap { aiReviewStore.latestByType[$0] }
+    }
+
+    private var reportSelectionLabel: String {
+        if let report = store.selectedReport {
+            return reportLabel(for: report)
+        }
+        return availableReports.isEmpty ? "No reports available" : "Choose report"
+    }
+
+    private func reportLabel(for report: AIReport) -> String {
+        "\(report.reportType.displayName) — \(report.period)"
+    }
+
+    // MARK: - Send button
+
+    private var sendButton: some View {
+        Button {
+            Task {
+                let generator = UIImpactFeedbackGenerator(style: .medium)
+                generator.impactOccurred()
+                await store.sendTest(sleeperUserId: callerSleeperId)
+            }
+        } label: {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                if store.isSending {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                        .tint(XomperColors.bgDark)
+                } else {
+                    Image(systemName: "paperplane.fill")
+                        .font(.caption2)
+                }
+                Text(store.isSending ? "Sending…" : "Send test email")
+                    .font(.subheadline.weight(.bold))
+            }
+            .foregroundStyle(XomperColors.bgDark)
+            .padding(.horizontal, XomperTheme.Spacing.md)
+            .padding(.vertical, XomperTheme.Spacing.sm)
+            .frame(maxWidth: .infinity, minHeight: XomperTheme.minTouchTarget)
+            .background(canSend ? XomperColors.championGold : XomperColors.championGold.opacity(0.4))
+            .clipShape(Capsule())
+        }
+        .buttonStyle(.pressableCard)
+        .disabled(!canSend)
+        .padding(.horizontal, XomperTheme.Spacing.md)
+        .accessibilityLabel("Send test email")
+        .accessibilityHint(canSend ? "Double tap to send the selected report to the selected recipient." : "Choose a recipient and a report first.")
+    }
+
+    private var canSend: Bool {
+        store.selectedRecipient != nil && store.selectedReport != nil && !store.isSending
+    }
+
+    // MARK: - Toasts
+
+    private func successToast(_ result: TestEmailResponse) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("✓ Sent to \(result.recipientEmail)")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(XomperColors.successGreen)
+            if let messageId = result.messageId, !messageId.isEmpty {
+                Text("SES message: \(messageId)")
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.textMuted)
+                    .lineLimit(1)
+            }
+            Text("\(result.reportType) · \(result.reportPeriod) · template: \(result.template)")
+                .font(.caption2)
+                .foregroundStyle(XomperColors.textSecondary)
+        }
+        .padding(XomperTheme.Spacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md)
+                .strokeBorder(XomperColors.successGreen.opacity(0.5), lineWidth: 1)
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    private func errorToast(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: XomperTheme.Spacing.xs) {
+            Image(systemName: "xmark.octagon.fill")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(XomperColors.errorRed)
+            Text(message)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(XomperColors.errorRed)
+                .multilineTextAlignment(.leading)
+        }
+        .padding(XomperTheme.Spacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md)
+                .strokeBorder(XomperColors.errorRed.opacity(0.5), lineWidth: 1)
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    // MARK: - Receipts
+
+    private var receiptsHeader: some View {
+        Text("Recent email sends · last 7 days")
+            .font(.caption.weight(.bold))
+            .textCase(.uppercase)
+            .tracking(0.5)
+            .foregroundStyle(XomperColors.textMuted)
+            .padding(.horizontal, XomperTheme.Spacing.md)
+            .padding(.top, XomperTheme.Spacing.sm)
+    }
+
+    @ViewBuilder
+    private var receiptsList: some View {
+        if store.isLoadingRecentSends && store.recentSends.isEmpty {
+            LoadingView(message: "Loading recent sends…")
+                .padding(.top, XomperTheme.Spacing.md)
+        } else if store.recentSends.isEmpty {
+            EmptyStateView(
+                icon: "tray",
+                title: "No sends yet",
+                message: "Test emails will appear here after you send one."
+            )
+            .frame(minHeight: 160)
+        } else {
+            ForEach(store.recentSends.prefix(10)) { entry in
+                receiptRow(entry)
+            }
+        }
+    }
+
+    private func receiptRow(_ entry: AdminNotificationLogEntry) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                Image(systemName: "envelope.fill")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.championGold)
+                Text("EMAIL")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(XomperColors.textSecondary)
+                    .tracking(0.5)
+                Text(entry.isSuccess ? "✓" : "✗")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(entry.isSuccess ? XomperColors.successGreen : XomperColors.errorRed)
+                Spacer()
+                Text(formattedTimestamp(entry.date))
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.textMuted)
+                    .monospacedDigit()
+            }
+
+            if let subject = entry.subject, !subject.isEmpty {
+                Text(subject)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .lineLimit(1)
+            }
+            if let recipient = entry.recipient, !recipient.isEmpty {
+                Text(recipient)
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textSecondary)
+                    .lineLimit(1)
+            }
+            if let err = entry.error, !err.isEmpty {
+                Text(err)
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.errorRed)
+                    .lineLimit(2)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md)
+                .strokeBorder(
+                    entry.isSuccess ? Color.clear : XomperColors.errorRed.opacity(0.4),
+                    lineWidth: entry.isSuccess ? 0 : 1
+                )
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    private func formattedTimestamp(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, h:mm:ss a"
+        return formatter.string(from: date)
+    }
+}

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -243,7 +243,8 @@ struct MainShell: View {
             case .admin:
                 AdminView(
                     authStore: authStore,
-                    leagueStore: leagueStore
+                    leagueStore: leagueStore,
+                    router: router
                 )
 
             case .rulebook:
@@ -491,6 +492,27 @@ struct MainShell: View {
                 router: router,
                 currentSeason: nflStateStore.currentSeason
             )
+
+        case .adminAIReview:
+            AIReviewSubScreen(
+                authStore: authStore,
+                leagueStore: leagueStore
+            )
+
+        case .adminTestEmail:
+            TestEmailView(
+                authStore: authStore,
+                aiReviewStore: aiReviewStore
+            )
+
+        case .adminTables:
+            TablesStubView()
+
+        case .adminLogs:
+            LogsStubView()
+
+        case .adminAudit:
+            AuditStubView()
         }
     }
 

--- a/Xomper/Navigation/AppRouter.swift
+++ b/Xomper/Navigation/AppRouter.swift
@@ -40,6 +40,29 @@ enum AppRoute: Hashable {
     /// drafts; on selection sets `SeasonStore.selectedSeason` and switches
     /// the top-level destination to `.draftHistory`.
     case archivePastDraftPicker
+
+    // MARK: - Admin Portal (F1)
+
+    /// Pushed from `AdminView`'s menu — hosts the existing AI Review
+    /// trigger cards + activity feed (extracted verbatim from the
+    /// pre-F1 `AdminView`).
+    case adminAIReview
+
+    /// Pushed from `AdminView`'s menu — hosts the F1 test-email sender
+    /// surface (recipient + report pickers, send button, receipts).
+    case adminTestEmail
+
+    /// Pushed from `AdminView`'s menu — stub destination for F4's
+    /// Tables sub-feature (users / leagues / reports editing).
+    case adminTables
+
+    /// Pushed from `AdminView`'s menu — stub destination for F5's
+    /// Logs sub-feature (CloudWatch tail + search).
+    case adminLogs
+
+    /// Pushed from `AdminView`'s menu — stub destination for F4's
+    /// Audit sub-feature (recent admin actions feed).
+    case adminAudit
 }
 
 /// Owns the inner `NavigationStack` path inside `MainShell`. The drawer

--- a/XomperTests/AIReviewStoreTests.swift
+++ b/XomperTests/AIReviewStoreTests.swift
@@ -326,6 +326,8 @@ final class MockXomperAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
     func unregisterDevice(userId: String, deviceToken: String) async throws { throw Unsupported.method }
     func adminListNotifications(sleeperUserId: String, daysBack: Int, kind: String?, status: String?, limit: Int) async throws -> AdminNotificationsResponse { throw Unsupported.method }
     func adminTestSend(sleeperUserId: String, email: String?, kind: String, channels: [String]) async throws -> AdminTestSendResponse { throw Unsupported.method }
+    func fetchTestEmailRecipients() async throws -> [TestEmailRecipient] { throw Unsupported.method }
+    func sendTestEmail(recipientSleeperUserId: String, reportId: String) async throws -> TestEmailResponse { throw Unsupported.method }
     func triggerPostDraftAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw Unsupported.method }
     func triggerPreseasonAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw Unsupported.method }
     func triggerWeeklyAIReview(week: Int?, dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw Unsupported.method }

--- a/XomperTests/AdminStoreTests.swift
+++ b/XomperTests/AdminStoreTests.swift
@@ -272,6 +272,8 @@ final class MockAdminAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
     func unregisterDevice(userId: String, deviceToken: String) async throws { throw MockError.unsupported }
     func adminListNotifications(sleeperUserId: String, daysBack: Int, kind: String?, status: String?, limit: Int) async throws -> AdminNotificationsResponse { throw MockError.unsupported }
     func adminTestSend(sleeperUserId: String, email: String?, kind: String, channels: [String]) async throws -> AdminTestSendResponse { throw MockError.unsupported }
+    func fetchTestEmailRecipients() async throws -> [TestEmailRecipient] { throw MockError.unsupported }
+    func sendTestEmail(recipientSleeperUserId: String, reportId: String) async throws -> TestEmailResponse { throw MockError.unsupported }
 }
 
 enum MockError: Error, LocalizedError {

--- a/XomperTests/TestEmailStoreTests.swift
+++ b/XomperTests/TestEmailStoreTests.swift
@@ -1,0 +1,297 @@
+import XCTest
+@testable import Xomper
+
+@MainActor
+final class TestEmailStoreTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeRecipient(
+        userId: String = "U1",
+        name: String = "Test User",
+        email: String = "test@example.com",
+        isAdmin: Bool = false
+    ) -> TestEmailRecipient {
+        TestEmailRecipient(
+            userId: userId,
+            displayName: name,
+            email: email,
+            isAdmin: isAdmin
+        )
+    }
+
+    private func makeReport() -> AIReport {
+        AIReport(
+            id: "LEAGUE#L1|REPORT#weekly#2026W04",
+            leagueId: "L1",
+            reportType: .weekly,
+            period: "2026W04",
+            bodyMarkdown: "## Week 4\nGreat games.",
+            createdAt: Date()
+        )
+    }
+
+    private func makeResponse(
+        email: String = "test@example.com",
+        messageId: String? = "ses-mid-abc",
+        template: String = "ai_review_test",
+        reportType: String = "weekly",
+        reportPeriod: String = "2026W04"
+    ) -> TestEmailResponse {
+        TestEmailResponse(
+            recipientEmail: email,
+            messageId: messageId,
+            sentAt: "2026-05-26T17:42:33Z",
+            template: template,
+            reportType: reportType,
+            reportPeriod: reportPeriod
+        )
+    }
+
+    // MARK: - loadRecipients
+
+    func testLoadRecipients_populatesFromMock() async {
+        let recipients = [
+            makeRecipient(userId: "U1", name: "Alice", email: "alice@example.com", isAdmin: true),
+            makeRecipient(userId: "U2", name: "Bob", email: "bob@example.com"),
+        ]
+        let mock = MockTestEmailAPIClient(recipients: recipients)
+        let store = TestEmailStore(apiClient: mock)
+
+        await store.loadRecipients()
+
+        XCTAssertEqual(store.recipients.count, 2)
+        XCTAssertEqual(store.recipients.first?.displayName, "Alice")
+        XCTAssertTrue(store.recipients.first?.isAdmin ?? false)
+        XCTAssertNil(store.recipientsError)
+        XCTAssertFalse(store.isLoadingRecipients)
+    }
+
+    func testLoadRecipients_surfacesError() async {
+        let mock = MockTestEmailAPIClient(recipientsError: TestEmailMockError.boom)
+        let store = TestEmailStore(apiClient: mock)
+
+        await store.loadRecipients()
+
+        XCTAssertTrue(store.recipients.isEmpty)
+        XCTAssertNotNil(store.recipientsError)
+    }
+
+    // MARK: - sendTest no-op guards
+
+    func testSendTest_noopWhenNoSelections() async {
+        let mock = MockTestEmailAPIClient()
+        let store = TestEmailStore(apiClient: mock)
+
+        // Both pickers nil — should silently no-op.
+        await store.sendTest(sleeperUserId: "ADMIN")
+
+        XCTAssertEqual(mock.sendCalls.count, 0)
+        XCTAssertNil(store.lastResult)
+        XCTAssertNil(store.lastError)
+        XCTAssertFalse(store.isSending)
+    }
+
+    func testSendTest_noopWhenOnlyRecipientSelected() async {
+        let mock = MockTestEmailAPIClient()
+        let store = TestEmailStore(apiClient: mock)
+        store.selectedRecipient = makeRecipient()
+
+        await store.sendTest(sleeperUserId: "ADMIN")
+
+        XCTAssertEqual(mock.sendCalls.count, 0)
+        XCTAssertNil(store.lastResult)
+    }
+
+    // MARK: - sendTest happy path
+
+    func testSendTest_successPopulatesLastResult() async {
+        let response = makeResponse()
+        let mock = MockTestEmailAPIClient(sendResponse: response)
+        let store = TestEmailStore(apiClient: mock)
+
+        let recipient = makeRecipient()
+        let report = makeReport()
+
+        await store.sendTest(
+            report: report,
+            recipient: recipient,
+            sleeperUserId: ""
+        )
+
+        XCTAssertEqual(mock.sendCalls.count, 1)
+        XCTAssertEqual(mock.sendCalls.first?.userId, "U1")
+        XCTAssertEqual(mock.sendCalls.first?.reportId, "LEAGUE#L1|REPORT#weekly#2026W04")
+        XCTAssertEqual(store.lastResult?.recipientEmail, "test@example.com")
+        XCTAssertEqual(store.lastResult?.template, "ai_review_test")
+        XCTAssertNil(store.lastError)
+        XCTAssertFalse(store.isSending)
+    }
+
+    // MARK: - sendTest failure
+
+    func testSendTest_failureSurfacesError() async {
+        let mock = MockTestEmailAPIClient(sendError: TestEmailMockError.boom)
+        let store = TestEmailStore(apiClient: mock)
+
+        await store.sendTest(
+            report: makeReport(),
+            recipient: makeRecipient(),
+            sleeperUserId: ""
+        )
+
+        XCTAssertEqual(mock.sendCalls.count, 1)
+        XCTAssertNil(store.lastResult)
+        XCTAssertNotNil(store.lastError)
+        XCTAssertFalse(store.isSending)
+    }
+
+    // MARK: - reset
+
+    func testReset_clearsResultAndError() async {
+        let mock = MockTestEmailAPIClient(sendResponse: makeResponse())
+        let store = TestEmailStore(apiClient: mock)
+        await store.sendTest(
+            report: makeReport(),
+            recipient: makeRecipient(),
+            sleeperUserId: ""
+        )
+        XCTAssertNotNil(store.lastResult)
+
+        store.reset()
+
+        XCTAssertNil(store.lastResult)
+        XCTAssertNil(store.lastError)
+    }
+
+    // MARK: - Wire format guard
+
+    func testTestEmailResponse_decodesSnakeCase() throws {
+        let json = """
+        {
+            "recipient_email": "test@example.com",
+            "message_id": "ses-mid-xyz",
+            "sent_at": "2026-05-26T17:42:33Z",
+            "template": "ai_review_test",
+            "report_type": "weekly",
+            "report_period": "2026W04"
+        }
+        """
+        let decoded = try JSONDecoder().decode(
+            TestEmailResponse.self,
+            from: Data(json.utf8)
+        )
+        XCTAssertEqual(decoded.recipientEmail, "test@example.com")
+        XCTAssertEqual(decoded.messageId, "ses-mid-xyz")
+        XCTAssertEqual(decoded.reportType, "weekly")
+        XCTAssertEqual(decoded.reportPeriod, "2026W04")
+    }
+
+    func testTestEmailRecipient_decodesSnakeCase() throws {
+        let json = """
+        {
+            "user_id": "U1",
+            "display_name": "Alice",
+            "email": "alice@example.com",
+            "is_admin": true
+        }
+        """
+        let decoded = try JSONDecoder().decode(
+            TestEmailRecipient.self,
+            from: Data(json.utf8)
+        )
+        XCTAssertEqual(decoded.userId, "U1")
+        XCTAssertEqual(decoded.displayName, "Alice")
+        XCTAssertEqual(decoded.email, "alice@example.com")
+        XCTAssertTrue(decoded.isAdmin)
+        XCTAssertEqual(decoded.id, "U1")
+    }
+}
+
+// MARK: - Mock API client
+
+/// Tiny mock dedicated to TestEmailStore's two endpoints. Implements
+/// the full protocol so the type checks; unused methods throw.
+final class MockTestEmailAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
+    var recipients: [TestEmailRecipient]
+    var recipientsError: Error?
+    var sendResponse: TestEmailResponse?
+    var sendError: Error?
+    var notifications: AdminNotificationsResponse?
+
+    private(set) var sendCalls: [(userId: String, reportId: String)] = []
+    private(set) var fetchRecipientsCallCount = 0
+    private(set) var listNotificationsCallCount = 0
+
+    init(
+        recipients: [TestEmailRecipient] = [],
+        recipientsError: Error? = nil,
+        sendResponse: TestEmailResponse? = nil,
+        sendError: Error? = nil,
+        notifications: AdminNotificationsResponse? = nil
+    ) {
+        self.recipients = recipients
+        self.recipientsError = recipientsError
+        self.sendResponse = sendResponse
+        self.sendError = sendError
+        self.notifications = notifications
+    }
+
+    func fetchTestEmailRecipients() async throws -> [TestEmailRecipient] {
+        fetchRecipientsCallCount += 1
+        if let err = recipientsError { throw err }
+        return recipients
+    }
+
+    func sendTestEmail(
+        recipientSleeperUserId: String,
+        reportId: String
+    ) async throws -> TestEmailResponse {
+        sendCalls.append((recipientSleeperUserId, reportId))
+        if let err = sendError { throw err }
+        guard let response = sendResponse else { throw TestEmailMockError.notConfigured }
+        return response
+    }
+
+    func adminListNotifications(
+        sleeperUserId: String,
+        daysBack: Int,
+        kind: String?,
+        status: String?,
+        limit: Int
+    ) async throws -> AdminNotificationsResponse {
+        listNotificationsCallCount += 1
+        return notifications ?? AdminNotificationsResponse(rows: [], count: 0)
+    }
+
+    // MARK: Unused protocol surface
+
+    func sendRuleProposalEmail(proposal: RuleProposalEmailPayload, recipients: [String], userIds: [String]) async throws { throw TestEmailMockError.unsupported }
+    func sendRuleAcceptedEmail(proposal: RuleProposalEmailPayload, approvedBy: [String], rejectedBy: [String], recipients: [String], userIds: [String]) async throws { throw TestEmailMockError.unsupported }
+    func sendRuleDeniedEmail(proposal: RuleProposalEmailPayload, approvedBy: [String], rejectedBy: [String], recipients: [String], userIds: [String]) async throws { throw TestEmailMockError.unsupported }
+    func sendTaxiStealEmail(stealer: TaxiStealerPayload, player: TaxiPlayerPayload, owner: TaxiOwnerPayload, recipients: [String], userIds: [String], leagueName: String) async throws { throw TestEmailMockError.unsupported }
+    func registerDevice(userId: String, deviceToken: String) async throws { throw TestEmailMockError.unsupported }
+    func unregisterDevice(userId: String, deviceToken: String) async throws { throw TestEmailMockError.unsupported }
+    func adminTestSend(sleeperUserId: String, email: String?, kind: String, channels: [String]) async throws -> AdminTestSendResponse { throw TestEmailMockError.unsupported }
+    func fetchLatestAIReport(type: AIReportType) async throws -> AIReport? { nil }
+    func fetchAIReportsList(type: AIReportType?, limit: Int, cursor: String?) async throws -> AIReportsListResponse { AIReportsListResponse(rows: [], nextCursor: nil) }
+    func fetchAIReportByPeriod(type: AIReportType, period: String) async throws -> AIReport? { nil }
+    func fetchMockDrafts() async throws -> [AIReport] { [] }
+    func triggerPostDraftAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw TestEmailMockError.unsupported }
+    func triggerPreseasonAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw TestEmailMockError.unsupported }
+    func triggerWeeklyAIReview(week: Int?, dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw TestEmailMockError.unsupported }
+}
+
+enum TestEmailMockError: Error, LocalizedError {
+    case boom
+    case unsupported
+    case notConfigured
+
+    var errorDescription: String? {
+        switch self {
+        case .boom: "boom"
+        case .unsupported: "mock method not supported"
+        case .notConfigured: "mock send response not configured"
+        }
+    }
+}

--- a/docs/features/admin-portal/BRAINSTORM.md
+++ b/docs/features/admin-portal/BRAINSTORM.md
@@ -1,0 +1,543 @@
+# Admin Portal — Brainstorm
+
+> Epic: full ops dashboard for the Xomper league commissioner. Expands the current
+> single-screen `AdminView` (trigger cards + activity feed + test send) into a
+> multi-screen control surface covering log tailing, table editing, preview-before-
+> broadcast, test email, and reverse-out. Issue #91.
+
+Status: Draft
+Date: 2026-05-26
+Owner: Dominick
+Related: existing `AdminView`, `AdminStore`, admin lambdas under
+`xomper-back-end/lambdas/api_admin_*`.
+
+---
+
+## Problem statement
+
+`AdminView` started as a "trigger + recent activity" panel and has grown into a
+wall: 3 trigger cards, a test-send card, an activity feed, a filter bar, and
+result lines — all in one `ScrollView`. As we add real ops capabilities (log
+tailing, table edits, broadcast preview, redaction) the single-screen pattern
+breaks:
+
+1. Cognitive load: everything competes for vertical space.
+2. State bloat: `AdminStore` would balloon to manage 6+ unrelated domains.
+3. Safety: high-blast-radius actions (broadcast, edit user) live next to
+   low-stakes actions (refresh feed) with the same visual weight.
+4. Discoverability: features added later get buried below the fold.
+
+We need an architecture for an admin portal that can absorb 5+ new capabilities
+without becoming a `ScrollView` of doom, plus backend endpoints + a phasing plan
+that delivers value in safe-to-merge increments.
+
+---
+
+## Phase 1 — Explore (wide)
+
+Loose set of ideas, not all are good. Filter happens in Phase 2.
+
+- iOS-side: convert AdminView into a "menu" of NavigationLinks to per-feature
+  screens (Log Viewer, Tables, Test Email, Preview, Reports).
+- iOS-side: collapsible `DisclosureGroup` sections per feature, keep one screen.
+- iOS-side: sub-tab bar inside admin (mimics main app tabs).
+- iOS-side: dashboard summary card on the menu screen (3 KPIs: last broadcast,
+  last error, admins online) above the sub-nav links.
+- Backend: log viewer via CloudWatch Logs Insights query → API GW lambda.
+- Backend: log viewer via Dynamo log mirror (write side fans logs into Dynamo).
+- Backend: log viewer via `notification_log` table extension (lambda name + level).
+- Backend: streaming logs via WebSocket / API GW v2 / SSE.
+- Backend: paginated logs only (cheaper, simpler).
+- Backend: table editor with per-table generic endpoints (`POST /admin/table/{x}/{id}`).
+- Backend: table editor with table-specific endpoints (`POST /admin/users/{id}`,
+  `POST /admin/leagues/{id}`, `POST /admin/reports/{id}/flag`).
+- Backend: raw JSON form for table edits (admin-only, fast to ship).
+- Backend: typed forms per table with field validation.
+- Backend: audit log via Dynamo `admin_audit` table (one row per write).
+- Backend: audit log via CloudWatch (free, but harder to query).
+- Backend: audit log via Supabase `admin_audit` (closer to the data being edited).
+- Backend: preview endpoint that renders all 12 emails without sending.
+- Backend: preview endpoint that returns just subject + greeting (cheap).
+- Backend: preview baked into the existing trigger response (dry-run already
+  generates payloads — extend it to return them).
+- Backend: test email reuses `build_email_payload` + SES helper, new lambda
+  `api_admin_email_test`.
+- Backend: test email piggybacks on existing `api_admin_test_send` with a new
+  `kind=ai_review_test`.
+- Backend: redact = `metadata.is_redacted=true` via `update_metadata` (existing
+  helper — no new Dynamo plumbing needed).
+- Backend: redact = soft-delete via a separate `redacted_reports` table.
+- Backend: "do not broadcast" pre-flight flag (separate from post-broadcast
+  redact) so an admin can mark a dry-run report as DNB before confirming.
+- Pre-flight UX: 12-card carousel, swipe to preview each manager's email.
+- Pre-flight UX: aggregate "subject diversity check" (are 12 subjects
+  meaningfully different?) — bonus QA.
+- Permission scope: keep current `is_admin` gate, no need for fine-grained roles.
+- Permission scope: introduce role tiers (super-admin vs read-only admin) — over-
+  kill for a 12-person league with one commissioner.
+- IAM: each new admin lambda gets `logs:FilterLogEvents` only on the AI Review +
+  notif log groups (least privilege).
+- IAM: shared admin role across all admin lambdas — simpler, less granular.
+- PII: redact emails in log viewer output server-side before returning.
+- PII: client-side redaction — wrong, server still leaks.
+- Audit log surfacing: a 5th tab in admin portal that just shows the audit feed.
+- Audit log surfacing: badge on each editable row showing last edited by/when.
+- Phasing: ship test email first (smallest), then preview, then tables, then
+  logs, then redact.
+- Phasing: ship logs first (highest novelty / ops value).
+- Phasing: ship preview first (highest pre-broadcast safety value).
+- Phasing: bundle preview + redact into the same PR (both touch the trigger
+  flow + metadata).
+- Off-the-wall: integrate CloudWatch via AWS Console deep link — open in Safari
+  with prefilled filter (zero backend work, lossy UX).
+- Off-the-wall: replace the log viewer with a "Slack me when this errors" alert
+  pipeline. Solves a different problem (proactive vs reactive) but might be the
+  better investment.
+
+---
+
+## Phase 2 — Converge
+
+Answers per architectural question. For each, the chosen option is marked and
+justified; alternatives are listed with why they lose.
+
+### Q1 — Log viewer
+
+#### Option A: CloudWatch Logs Insights via admin lambda  ← **chosen**
+
+**What**: New lambda `api_admin_logs_query` accepts `{ log_group, level, search,
+since_minutes, limit }` and runs a `logs:FilterLogEvents` (not Insights — cheaper
++ better fit for tail-style queries) against the requested group, returning
+parsed events with timestamp + level + message.
+
+**How it works**: Lambda holds an allowlist of permitted log groups
+(`/aws/lambda/ai_review_*`, `/aws/lambda/notif_*`). Filter pattern built from
+`level` (`?ERROR ?WARN`) and `search` (literal). Returns paginated events with a
+`next_token`. iOS renders a tail view (newest first) and a "Load older" pager.
+
+**Pros**:
+- Zero new storage / write-side instrumentation.
+- Real logs, including stack traces — not a curated subset.
+- Allowlist gives us least-privilege scope.
+
+**Cons / Risks**:
+- CloudWatch FilterLogEvents has rate limits per log group; under repeated tail
+  refreshes from an admin in-flight, we'd see throttling. Mitigation: enforce
+  client-side 5s minimum between refreshes + server-side cache (60s TTL) on
+  identical queries.
+- PII in logs (emails, sleeper IDs in traces) — must redact in lambda before
+  returning. Pattern: post-filter regex on the message string for email +
+  sleeper_user_id-looking values.
+
+**Best if**: We want real logs without writing a parallel logging pipeline.
+
+#### Option B: Dynamo log mirror (rejected)
+
+Write-side instrumentation in every lambda; introduces drift between what
+CloudWatch shows and what the admin portal shows. Adds storage cost. Only wins
+if we need sub-second tail latency — we don't.
+
+#### Option C: Extend `notification_log` (rejected)
+
+`notification_log` is about delivery outcomes (push + email sends), not lambda
+execution logs. Repurposing it conflates two concerns. The "old notif lambdas"
+already write here; the AI Review lambdas would have to be retrofitted with
+write-side instrumentation we don't currently need.
+
+### Q2 — Table editor
+
+#### Option A: Typed endpoints + typed iOS forms per table  ← **chosen**
+
+**What**: Three new endpoints — `POST /admin/users/{id}`, `POST /admin/leagues/
+{id}`, `POST /admin/reports/{league_id}/{report_type}/{period}/flag` — each
+accepts only the fields it knows about. iOS renders a typed form per table.
+
+**How it works**: Each endpoint has a strict allowlist of editable fields
+(users: `email`, `display_name`, `sleeper_user_id`, `is_admin`, `is_active`;
+leagues: `is_active`; reports: `is_redacted`, `do_not_broadcast`). Validation
+lives in the lambda (email regex, sleeper_user_id non-empty, bool casts).
+Audit row written to Supabase `admin_audit` (actor, table, row_id, before,
+after, at) inside the same transaction where possible (Supabase) or as a
+follow-up write (Dynamo metadata).
+
+**Pros**:
+- Hard guardrails — admin can't accidentally edit `id` or `created_at`.
+- Field-level validation server-side; iOS form just mirrors it.
+- Compiler-checked iOS Codable models per table.
+
+**Cons / Risks**:
+- More endpoints = more code. Three new lambdas + three new iOS forms.
+- Schema drift: if we add a new column to `whitelisted_users` we have to update
+  the endpoint allowlist. Mitigation: documented checklist + tests that fail
+  when a column lacks an allow/deny decision.
+
+**Best if**: We value safety + clear field semantics over endpoint count.
+
+#### Option B: Generic `POST /admin/table/{name}/{id}` (rejected)
+
+Open-ended `{ field: value, ... }` body. Faster to ship but the cost is paid in
+audit/safety: now a typo in `is_amdin` (vs `is_admin`) is a silent no-op, and
+the endpoint must defend against every possible column at runtime.
+
+#### Option C: Raw JSON editor (rejected)
+
+A `TextEditor` of the JSON row + a save button. No. The 1% of edits that need
+this can be done in Supabase directly.
+
+### Q3 — Test email sender
+
+#### Option A: New `POST /admin/email/test`  ← **chosen**
+
+**What**: Body `{ target_sleeper_user_id, report_id }`. Lambda loads the report,
+loads the target user, calls `build_email_payload` with their first_name +
+email, hands it to `ses_helper.send_emails_concurrently` (single-recipient
+list). Does **not** flip `metadata.broadcast_at`. Does **not** increment any
+"sent" counter on the report.
+
+**How it works**: Reuses existing helpers (`get_whitelisted_user_by_sleeper_id`,
+`get_latest` / direct report fetch, `build_email_payload`, `ses_helper`). The
+key invariant: this path **never** writes to the report's metadata, so a test
+send doesn't pollute "last broadcast at" state.
+
+**Pros**:
+- Small surface area: one new lambda, fully reuses existing rendering + SES.
+- Clear separation from broadcast — no risk of test sends being counted as
+  broadcasts.
+- Useful early: ships in F1 and unblocks every later phase that benefits from
+  rapid email iteration.
+
+**Cons / Risks**:
+- `notification_log` write: should the test send appear in the activity feed?
+  Recommend yes, tagged `kind=email` + `template=ai_review_test`, so it's
+  visually distinct from real broadcasts.
+
+**Best if**: We want to iterate on AI Review email layout without firing the
+12-person broadcast cannon.
+
+#### Option B: `dry_run=true` extended to per-user delivery (rejected)
+
+Today `dry_run=true` means "deliver only to the admin". We could add
+`dry_run_target` to override the recipient. Reusable but couples the broadcast
+trigger to the test path; harder to reason about which code path wrote which
+metadata.
+
+### Q4 — Pre-flight preview
+
+#### Option A: New `GET /admin/reports/{id}/preview` (rejected for cost)
+
+Fetch report + iterate 12 users + render 12 payloads, return all 12. Clean but
+duplicates rendering logic with the broadcast path; risk of drift.
+
+#### Option B: Extend dry-run trigger response to include rendered payloads  ← **chosen**
+
+**What**: When `dry_run=true`, the existing trigger lambdas already render the
+emails (they have to — they send a copy to the admin). Extend the trigger
+response to also return the full 12-user rendered payload set.
+
+**How it works**: Inside `run_postdraft` / `run_preseason` / `run_weekly`, after
+the dry-run send completes, attach the rendered payloads (without `html_body`
+to keep the response small — just `recipient`, `subject`, `text_body`) to the
+response under `previews: [...]`. iOS admin portal: "Generate dry run" now
+ALSO populates a "Preview" view. Admin scans previews; when satisfied, clicks
+"Broadcast" which calls the trigger with `dry_run=false, force=true`.
+
+Optional polish: a separate `GET /admin/reports/{id}/preview` for previewing
+the most recent dry-run report **without** re-running generation. Falls back
+to fetching the report from Dynamo + rendering on the fly.
+
+**Pros**:
+- Zero new rendering paths — same code that does broadcast does preview.
+- One round-trip: dry-run gives the admin both the SES-delivered admin copy AND
+  the 12 previews.
+- Drift-proof: if `build_email_payload` changes, preview changes with it.
+
+**Cons / Risks**:
+- Response payload grows by ~12 × (subject + text body). Estimate ~30KB.
+  Acceptable for an admin-only endpoint, but cap text body length to 4KB to be
+  safe.
+
+**Best if**: We want preview to never lie about what the broadcast will send.
+
+### Q5 — Reverse-out / undo
+
+#### Option A: `metadata.is_redacted` + `metadata.broadcast_at`  ← **chosen**
+
+**What**: Two metadata flags. `broadcast_at` is set on first successful broadcast
+(F1 already does this for post-draft; replicate for preseason + weekly).
+`is_redacted` is admin-only writable via `POST /admin/reports/.../flag`.
+
+**How it works**: Read paths (`api_ai_reports_latest`, `api_ai_reports_list`)
+filter out `metadata.is_redacted == true` for non-admin callers. Admin views
+show redacted reports with a strikethrough + "redacted by X on Y" badge.
+Email already-delivered: nothing to recall.
+
+**Pros**:
+- Uses existing `update_metadata` helper — no schema change.
+- Read-side filter is one predicate.
+- Admins still see history (recoverable by un-redacting).
+
+**Cons / Risks**:
+- Doesn't recall already-sent email. Mitigation: name the button "Hide from
+  app" not "Unsend" — set correct expectations.
+- Pre-broadcast "do not broadcast" flag is separate. Recommend a second
+  metadata key `do_not_broadcast: true` checked by the broadcast path before
+  fan-out. If set, broadcast aborts with a 409.
+
+**Best if**: We accept "redact in our surfaces" as the bounded promise.
+
+### Q6 — Permission scope + auth
+
+**Decision**: Keep the current `is_admin` gate. No role tiers. Audit log
+captures who did what; that's the read-back.
+
+**Rationale**: 12-person league with one human commissioner. Role tiers are
+process complexity solving a problem we don't have.
+
+### Q7 — Phasing
+
+5 sub-features. Recommended order:
+
+| Phase | Feature                       | Why this order                                                                 |
+|-------|-------------------------------|---------------------------------------------------------------------------------|
+| F1    | Test email sender             | Smallest scope, immediate value, unblocks copy/template iteration before F2.    |
+| F2    | Pre-flight email preview      | Highest safety value before any real broadcast. Builds on F1's rendering reuse. |
+| F3    | Redact / "do not broadcast" + broadcast_at | Small but completes the broadcast safety story. Wraps F2 nicely.   |
+| F4    | Table editor                  | Largest scope (3 endpoints + 3 forms + audit log). Lower urgency.               |
+| F5    | Log viewer                    | Highest novelty value but lowest urgency — we have CloudWatch console today.    |
+
+**Why F3 before F4**: F3 is small and closes the broadcast-safety loop alongside
+F2; doing it third keeps the "AI Review safety" arc together before pivoting to
+table edits. F4 + F5 are unrelated to AI Review broadcast and can stand alone.
+
+### Q8 — iOS UI organization
+
+#### Option A: NavigationLink sub-screens off an admin home menu  ← **chosen**
+
+**What**: AdminView becomes a menu of NavigationLinks: "AI Review", "Tables",
+"Logs", "Audit", with a small dashboard summary card at top (last broadcast
+times per report type, recent error count).
+
+**How it works**: Each link pushes onto the existing tray's NavigationStack.
+Per-feature stores: `AILogsStore`, `AdminTablesStore`, `AdminPreviewStore`,
+`AdminAuditStore`. The current `AdminStore` shrinks to the menu + dashboard
+summary; trigger logic moves into `AILogsStore` or a dedicated `AIReviewAdminStore`.
+
+**Pros**:
+- Clear mental model: one feature per screen.
+- State isolation: bug in log viewer can't corrupt trigger state.
+- Each PR gets to add its own screen without touching the others.
+
+**Cons / Risks**:
+- More files, more navigation tap depth.
+- Existing AdminView refactor is a precondition for F1+ — recommend doing the
+  menu refactor as F0 (or first half of F1).
+
+**Best if**: We're building a portal that will keep growing.
+
+#### Option B: Collapsible sections within one ScrollView (rejected)
+
+Defers the problem. We end up with a 1000-line `AdminView` after 5 features.
+
+#### Option C: Sub-tab bar (rejected)
+
+Two levels of tabs is a navigation smell. SwiftUI handles `NavigationLink` push
+gestures better than nested tab bars anyway.
+
+---
+
+## Phase 3 — Recommendation
+
+**Recommended path**: Take Option A on every question above. The shape:
+
+- Restructure `AdminView` into a menu with sub-screen NavigationLinks (F1 carries this).
+- Ship in this order: **F1 test email → F2 preview → F3 redact/broadcast_at → F4 tables → F5 logs**.
+- Backend pattern: one new lambda per surface, reusing `admin_gate.require_admin`,
+  `build_email_payload`, `update_metadata`, and `ses_helper`.
+- New Supabase table: `admin_audit { id, actor_sleeper_id, table, row_id,
+  before, after, at }`. Written by every table-editor endpoint and the
+  redact/DNB endpoint.
+
+Depends on:
+- Whether we want streaming logs (no — paginated only).
+- Whether we want role tiers (no — `is_admin` is enough).
+- Confirmation that the existing dry-run trigger response can grow by ~30KB
+  (yes — admin-only path).
+
+---
+
+## Sub-feature decomposition (for `/orchestrate`)
+
+### F0 — Admin home refactor (folded into F1)
+
+Convert `AdminView` from one ScrollView to a menu + dashboard summary. Move
+existing trigger cards under a child screen "AI Review". No new backend work.
+Done as the first commit inside F1's PR so F1 has somewhere to put its UI.
+
+### F1 — Test email sender
+
+**iOS**: New "Test Email" screen reached from admin menu. Form: pick recipient
+(picker over whitelisted users), pick report (picker over recent reports per
+type). Send button. Result row.
+**Backend**: `POST /admin/email/test` lambda. Reuses `build_email_payload` +
+`ses_helper`. Writes a `notification_log` row with `template=ai_review_test`.
+**Acceptance**: Admin can send any of the latest 3 reports to any whitelisted
+user; `notification_log` shows the send; the report's `metadata.broadcast_at`
+is untouched.
+
+### F2 — Pre-flight email preview
+
+**iOS**: After a dry-run trigger, show a "Previews (12)" list under the
+trigger card. Each row: subject + first 200 chars of body. Tap to expand to
+full subject + text body. "Broadcast" button at top fires
+`dry_run=false, force=true`.
+**Backend**: Extend `run_postdraft` / `run_preseason` / `run_weekly` response
+with `previews: [{ recipient, subject, text_body }]` when `dry_run=true`.
+Cap text_body at 4KB per preview.
+**Acceptance**: After dry-run, admin sees all 12 rendered subjects + bodies in
+the iOS portal without any further backend call.
+
+### F3 — Redact + DNB + broadcast_at
+
+**iOS**: "Hide from app" button on every report row in the admin's reports list
+(new screen under menu). "Do not broadcast" checkbox on the preview screen
+(blocks the broadcast button when checked).
+**Backend**: `POST /admin/reports/{league_id}/{report_type}/{period}/flag` body
+`{ is_redacted?: bool, do_not_broadcast?: bool }`. Broadcast path checks
+`metadata.do_not_broadcast` and aborts with 409 if true. Read paths for
+non-admin callers filter `metadata.is_redacted == true`.
+**Acceptance**: Admin can mark any report as redacted; non-admin app surfaces
+no longer show it. Admin can mark a dry-run report as DNB; subsequent broadcast
+attempt fails with a clear message.
+
+### F4 — Table editor
+
+**iOS**: "Tables" screen with three sub-screens: Users, Leagues, Reports
+metadata. Each is a list with edit buttons that push to typed forms.
+**Backend**: Three new lambdas — `POST /admin/users/{id}`,
+`POST /admin/leagues/{id}`, `POST /admin/reports/.../flag` (reuses F3 endpoint).
+Each writes an `admin_audit` row.
+**Acceptance**: Admin can toggle `is_active` on a user / league via the iOS
+form; the change is reflected in Supabase and in `admin_audit`. Email regex
+validation rejects bad addresses.
+
+### F5 — Log viewer
+
+**iOS**: "Logs" screen with: log group picker (allowlist), level filter,
+search box, "Load more" pager.
+**Backend**: `GET /admin/logs/query?log_group=...&level=...&search=...&
+since_minutes=60&limit=100&next_token=...`. Server-side regex redacts emails +
+sleeper_user_ids in returned messages. Returns paginated events.
+**Acceptance**: Admin can filter logs for any allowlisted log group, filter by
+ERROR/WARN/INFO, search for a substring, and paginate.
+
+---
+
+## Cross-cutting concerns
+
+### IAM scope
+- F1–F4: same IAM as existing admin lambdas (DynamoDB R/W on `xomper-ai-reports`,
+  Supabase via env-var key, SES send for F1).
+- F5: add `logs:FilterLogEvents` scoped to the allowlist of log group ARNs only.
+  Use a separate IAM role for `api_admin_logs_query` to avoid contaminating the
+  other admin lambdas with log-read perms.
+
+### Audit log
+- New Supabase table `admin_audit` (`id`, `actor_sleeper_id`, `actor_email`,
+  `surface` enum ('users','leagues','reports','email_test','broadcast'),
+  `row_id`, `before` jsonb, `after` jsonb, `at` timestamptz).
+- Every mutating admin endpoint writes one row before returning success.
+- F4 adds a "Audit" sub-screen that lists recent audit rows (paginated).
+
+### PII redaction
+- Log viewer (F5): server-side regex replaces emails and sleeper_user_ids with
+  `<redacted-email>` / `<redacted-sleeper-id>` before returning. Done in the
+  lambda, not the client.
+- Audit log: `before` / `after` blobs can contain email — they're admin-only
+  read, so no redaction needed, but mark the surface as admin-only in the
+  endpoint's docstring.
+
+### Test email vs broadcast separation
+- The test email path must NEVER write `metadata.broadcast_at`. Enforce by code
+  review + a unit test that asserts the test email handler does not call
+  `update_metadata`.
+
+### `do_not_broadcast` guardrail
+- Broadcast path checks the flag every time, not just on the first call.
+  Otherwise a regenerate-and-broadcast could blow past the flag.
+
+---
+
+## Risks (epic level)
+
+| Risk                                                                          | Mitigation                                                                                          |
+|-------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
+| CloudWatch FilterLogEvents throttles under repeated admin tail refreshes      | Client-side 5s rate limit + server-side 60s cache on identical queries                              |
+| Preview payload bloat (12 × text_body) pushes API GW response over limit      | Cap each text_body at 4KB; drop html_body from preview response                                     |
+| Test email accidentally treated as a broadcast (metadata pollution)           | Code path isolation + unit test asserting no `update_metadata` call                                 |
+| Schema drift between table editor allowlist and actual Supabase columns       | Doc checklist on adding new columns + lambda test that fails when an unmapped column is touched     |
+| `do_not_broadcast` flag bypassed by `force=true` regenerate-and-broadcast     | Broadcast path re-reads metadata after generation and aborts if flag is true                        |
+| Redact only hides from app — admin/users assume it "unsends"                  | Button label is "Hide from app", not "Unsend"; docstring + UI tooltip clarify                       |
+| AdminView refactor (F0/F1) ships without parity with current trigger UX       | Refactor preserves all existing trigger cards verbatim under the new "AI Review" sub-screen          |
+
+---
+
+## Open questions for `/plan`
+
+1. **Audit log home**: Supabase table vs Dynamo table. Recommendation says
+   Supabase (closer to the rows being edited; easier to query from a future web
+   dashboard). Confirm before F4.
+2. **Test email "kind" in `notification_log`**: should it use a new kind
+   `email_test` or a new template name under existing `kind=email`? Affects the
+   activity feed filter UI.
+3. **Reports list screen for F3**: do we need a paginated archive view in
+   admin, or does "most recent of each type" suffice? Recommend "most recent of
+   each type" for F3 and a full archive in F4.
+4. **Preview response shape**: include `html_body` (richer preview, ~10x bigger)
+   or only `text_body`? Recommend text_body only for V1; html preview becomes
+   an F2.5 polish if asked for.
+5. **Log allowlist**: confirm the exact log group names to allowlist.
+   Expected: `/aws/lambda/api_admin_ai_review_*`, `/aws/lambda/notif_ai_review_weekly`,
+   `/aws/lambda/notif_*`, `/aws/lambda/email_*`. Need a definitive list at plan
+   time.
+6. **iOS form pickers in F4**: native `Picker` over whitelisted users (~12
+   rows) is fine, but for `is_active` we need to confirm what happens when a
+   league is deactivated mid-season. Out of scope for the editor, but flag it.
+
+---
+
+## Acceptance criteria (epic)
+
+The admin portal epic is done when:
+
+- AdminView is a menu of NavigationLinks; no single screen is > 300 lines.
+- Admin can send a test of any of the 3 AI Review report types to any
+  whitelisted user without polluting broadcast state. (F1)
+- Admin can preview all 12 rendered emails before broadcast and confirm or
+  abort. (F2)
+- Admin can mark any report as "do not broadcast" before sending, and as
+  "hidden from app" after sending. `metadata.broadcast_at` is stamped on every
+  real broadcast. (F3)
+- Admin can edit `whitelisted_users` and `whitelisted_leagues` rows via typed
+  forms with field validation, and every edit lands in `admin_audit`. (F4)
+- Admin can filter / search CloudWatch logs for the AI Review + notif lambdas
+  with PII redacted server-side. (F5)
+- All endpoints behind `require_admin`; non-admin callers get 403.
+- Audit log surface ships with F4 and captures every mutating admin action
+  going forward.
+
+---
+
+## Notes
+
+- The current `AdminStore` will need to split into multiple stores during F0/F1.
+  The trigger logic + activity feed should move to `AIReviewAdminStore`; new
+  stores cover Test Email (F1), Preview (F2, may co-locate with AI Review),
+  Tables (F4), Logs (F5), Audit (F4).
+- Each sub-feature should land behind a feature flag in `Config.swift` so the
+  menu screen can hide unfinished sub-screens during incremental rollout.
+- Backend deploy: each new lambda is its own dir under `lambdas/api_admin_*`,
+  zipped in isolation per existing deploy script behavior.
+
+Brainstorm saved: docs/features/admin-portal/BRAINSTORM.md
+Recommendation: Option A across all 8 questions — start with F1 (test email + admin home refactor)
+Next: /plan admin-portal — I'll use this doc as context

--- a/docs/features/admin-portal/EPIC_PLAN.md
+++ b/docs/features/admin-portal/EPIC_PLAN.md
@@ -1,0 +1,187 @@
+# Epic Plan: Admin Portal
+
+**Status**: Ready
+**Created**: 2026-05-26
+**Last updated**: 2026-05-26
+**Issue**: #91 (Xomware/xomper-ios)
+**Related docs**: `docs/features/admin-portal/BRAINSTORM.md`
+
+---
+
+## Orchestration
+
+Stubs created (each Status: Draft — flesh out via `/plan` before executing):
+
+```
+F1 ──► F2 ──► F3 ──► F4 ──► F5
+```
+
+- F1 — `docs/features/admin-portal/f1-test-email/PLAN.md` (no deps; foundation — admin home refactor folded in)
+- F2 — `docs/features/admin-portal/f2-preview/PLAN.md` (depends on F1)
+- F3 — `docs/features/admin-portal/f3-redact/PLAN.md` (depends on F2)
+- F4 — `docs/features/admin-portal/f4-tables/PLAN.md` (depends on F3 — ships `admin_audit` table + retrofits F1/F3 audit writes)
+- F5 — `docs/features/admin-portal/f5-logs/PLAN.md` (depends on F1 for the menu slot; otherwise standalone)
+
+Execution mode: sequential F1 → F2 → F3 → F4 → F5. F4 and F5 can parallelize after F3 lands if needed, but linear order keeps PR review load manageable.
+
+---
+
+## Overview
+
+The Admin Portal epic expands the current single-screen `AdminView` (trigger cards + activity feed + test send) into a proper multi-screen commissioner control surface, addressing the five capability gaps called out in issue #91: **test email send**, **pre-broadcast preview**, **reverse-out / redact**, **table edits**, and **log tailing**. Delivery is sliced into five sub-features (F1–F5) shipped in safety-first order so each PR triplet (infra → backend → iOS) is mergeable on its own, behind feature flags, without breaking the existing AI Review broadcast flow. The decisions captured in `BRAINSTORM.md` (Option A across all 8 architectural questions) are locked in — this plan is the scaffolding `/orchestrate` will consume to produce per-feature stubs.
+
+---
+
+## Sub-feature breakdown
+
+### F1 — Test email sender + admin home refactor
+
+- **Scope**: New `POST /admin/email/test` lambda. iOS admin home refactored from one ScrollView into a NavigationLink menu (this is the F0 work folded into F1). New "Test Email" sub-screen with recipient + report pickers.
+- **Repos touched**: `xomper-infrastructure`, `xomper-back-end`, `xomper-ios`
+- **Primary deliverables**:
+  - Infra: API Gateway route `POST /admin/email/test`, new lambda Terraform module, SES send IAM
+  - Backend: `lambdas/api_admin_email_test/` (reuses `build_email_payload`, `ses_helper`, `admin_gate.require_admin`); writes `notification_log` row with `template=ai_review_test`; never writes `metadata.broadcast_at`
+  - iOS: `AdminView` → menu of `NavigationLink`s (AI Review, Tables, Logs, Audit); new `TestEmailView` + `TestEmailStore`; existing trigger cards move under "AI Review" sub-screen
+- **Depends on**: nothing (foundation phase)
+- **Effort tier**: **M** (small backend, but the AdminView refactor adds scope)
+
+### F2 — Pre-flight email preview
+
+- **Scope**: Extend the three dry-run trigger lambdas (`run_postdraft`, `run_preseason`, `run_weekly`) to return rendered payloads in the response. iOS surface to display + scan the 12 previews before clicking "Broadcast".
+- **Repos touched**: `xomper-back-end`, `xomper-ios` (no infra changes — existing endpoints)
+- **Primary deliverables**:
+  - Backend: extend trigger response with `previews: [{ recipient, subject, text_body }]` when `dry_run=true`; cap `text_body` at 4KB; drop `html_body` from preview payload
+  - iOS: previews list under the AI Review trigger card; tap-to-expand row → full subject + body; "Broadcast" button calls trigger with `dry_run=false, force=true`
+- **Depends on**: F1 (admin home refactor — previews live under the AI Review sub-screen)
+- **Effort tier**: **M** (zero new endpoints, but three lambdas to touch + iOS preview UI)
+
+### F3 — Redact + do-not-broadcast + broadcast_at
+
+- **Scope**: Two new metadata flags (`is_redacted`, `do_not_broadcast`) plus universal stamping of `broadcast_at` on every successful real broadcast (already done for post-draft; replicate for preseason + weekly). New flag endpoint. Read-side filtering of redacted reports for non-admin callers.
+- **Repos touched**: `xomper-infrastructure`, `xomper-back-end`, `xomper-ios`
+- **Primary deliverables**:
+  - Infra: API Gateway route `POST /admin/reports/{league_id}/{report_type}/{period}/flag`
+  - Backend: `lambdas/api_admin_reports_flag/` (uses `update_metadata`); broadcast path re-reads metadata after generation and aborts with 409 if `do_not_broadcast`; read paths (`api_ai_reports_latest`, `api_ai_reports_list`) filter out `is_redacted == true` for non-admin callers; first endpoint to write `admin_audit`
+  - iOS: "Hide from app" button on report rows; "Do not broadcast" checkbox on preview screen that disables the broadcast button when checked
+- **Depends on**: F2 (DNB checkbox lives in the preview surface)
+- **Effort tier**: **S**
+
+### F4 — Table editor
+
+- **Scope**: Three typed Supabase write endpoints (users, leagues, reports flag — reuses F3 endpoint). iOS forms per table. New Supabase `admin_audit` table — every mutating admin endpoint backfills writes here. New "Audit" sub-screen.
+- **Repos touched**: `xomper-infrastructure`, `xomper-back-end`, `xomper-ios`
+- **Primary deliverables**:
+  - Infra: API Gateway routes `POST /admin/users/{id}`, `POST /admin/leagues/{id}`; Terraform-managed Supabase migration for `admin_audit` table
+  - Backend: `lambdas/api_admin_users_update/`, `lambdas/api_admin_leagues_update/`; strict field allowlists per table; email regex + bool cast validation; every endpoint writes one `admin_audit` row; backfill audit writes into F1's test-email lambda + F3's flag lambda
+  - iOS: "Tables" sub-screen with Users + Leagues + Reports children; typed forms (`UsersEditView`, `LeaguesEditView`); "Audit" sub-screen with paginated feed
+- **Depends on**: F3 (reuses flag endpoint + introduces the audit table that retroactively wraps F1 + F3 writes)
+- **Effort tier**: **L** (largest sub-feature — 2 new lambdas, new Supabase table, 3 iOS forms, audit retrofit)
+
+### F5 — Log viewer
+
+- **Scope**: New `api_admin_logs_query` lambda backed by CloudWatch `FilterLogEvents`. iOS log tail screen with allowlisted log group picker, level filter, search, paginator.
+- **Repos touched**: `xomper-infrastructure`, `xomper-back-end`, `xomper-ios`
+- **Primary deliverables**:
+  - Infra: API Gateway route `GET /admin/logs/query`; new IAM role scoped to `logs:FilterLogEvents` against the allowlisted log group ARNs only (do NOT contaminate other admin lambdas)
+  - Backend: `lambdas/api_admin_logs_query/`; allowlist enforcement; server-side regex redaction of emails + sleeper_user_ids; 60s server-side cache on identical queries; pagination via `next_token`
+  - iOS: "Logs" sub-screen — log group `Picker`, level filter, search field, "Load older" button, client-side 5s minimum refresh interval
+- **Depends on**: F1 (admin home menu — logs sub-screen plugs in)
+- **Effort tier**: **M–L** (single lambda but unfamiliar IAM surface + PII redaction + pagination UI)
+
+---
+
+## Cross-cutting work
+
+| Concern | When it lands | Notes |
+|---|---|---|
+| Admin home `NavigationLink` menu refactor | **F1** | Folded in as the first commit of F1's PR. Preserves existing trigger cards verbatim under the new "AI Review" sub-screen. Precondition for F2–F5 having a place to live. |
+| `admin_gate.require_admin` reuse | All sub-features | Already exists in backend. No changes needed — every new admin lambda imports it at the top. |
+| `admin_audit` Supabase table | **F4** (first sub-feature whose endpoints write multiple kinds of audit rows) | Terraform-managed migration. F1 and F3 endpoints retroactively gain audit writes during F4. Pragmatic: avoids shipping a table with one consumer in F1. |
+| Per-feature `@Observable` stores | All sub-features | Each sub-feature owns one store (`TestEmailStore`, `AdminPreviewStore`, `AdminReportsAdminStore`, `AdminTablesStore` + `AdminAuditStore`, `AdminLogsStore`). Existing `AdminStore` shrinks to menu + dashboard summary. |
+| Common iOS sub-screen pattern | F1 establishes; F2–F5 inherit | All sub-screens: `NavigationLink` destination from `AdminView`; `@MainActor` `@Observable` store; loading/error/empty states identical; result rows reuse the same row component. |
+| PII redaction | F5 (logs) primarily | Server-side regex in the lambda — emails + sleeper IDs replaced before return. Not client-side. |
+| Feature flags | All sub-features | Each new sub-screen gated behind a `Config.swift` flag so partial rollout is safe. Menu hides unfinished entries. |
+
+---
+
+## Recommended orchestration order
+
+`/orchestrate` should create these stubs in this order:
+
+1. `docs/features/admin-portal/f1-test-email/PLAN.md`
+2. `docs/features/admin-portal/f2-preview/PLAN.md`
+3. `docs/features/admin-portal/f3-redact/PLAN.md`
+4. `docs/features/admin-portal/f4-tables/PLAN.md`
+5. `docs/features/admin-portal/f5-logs/PLAN.md`
+
+Rationale: each stub depends on the immediately preceding one (F1 establishes the menu; F2 lives in the AI Review sub-screen; F3 plugs into F2's preview surface; F4 introduces the audit table that retroactively wraps F1 + F3; F5 is the standalone bookend). F4 and F5 can be parallelized after F3 lands if needed, but the linear order keeps PR review load manageable.
+
+---
+
+## Dependencies that span repos
+
+Each sub-feature is a PR triplet. Order within a sub-feature is always **infra → backend → iOS**.
+
+| Sub-feature | Infra PR | Backend PR | iOS PR |
+|---|---|---|---|
+| **F1** | API GW route for `/admin/email/test`; SES send permission on lambda role | `api_admin_email_test` lambda merged after route exists | Admin home refactor + TestEmailView merged after lambda is live in dev |
+| **F2** | (none — existing endpoints) | Trigger lambdas extended with `previews` field — merge before iOS expects it | Preview UI merged after backend returns the new field |
+| **F3** | API GW route for `/admin/reports/.../flag` | `api_admin_reports_flag` lambda + broadcast path DNB check + read-path redact filter | Flag UI + DNB checkbox merged after backend live |
+| **F4** | API GW routes for users/leagues update; Terraform migration creating `admin_audit` Supabase table | Two new lambdas + retrofit audit writes into F1 + F3 lambdas; runs only after `admin_audit` table exists | Three typed forms + Audit feed merged after backend live |
+| **F5** | API GW route for `/admin/logs/query`; new IAM role with `logs:FilterLogEvents` scoped to allowlisted log group ARNs | `api_admin_logs_query` lambda — depends on the new IAM role | Log tail UI merged after backend returns paginated events |
+
+Cross-sub-feature: **F4's audit table migration is a soft blocker for closing out F1 + F3.** Audit retrofit writes for those two are part of F4's backend PR.
+
+---
+
+## Rollout risks (epic level)
+
+| Risk | Mitigation |
+|---|---|
+| **Auth scope creep** — temptation to introduce role tiers mid-epic when one endpoint feels like it should be "read-only admin" | Hard rule: `is_admin` only. Anything finer goes to a separate epic. Re-read Q6 of brainstorm before merging any auth change. |
+| **PII leakage in log viewer** — emails/sleeper IDs slip through CloudWatch returns | Server-side regex in F5 lambda before return; never client-side. Unit test: golden-file regex over a sample log line. |
+| **Audit log gaps** — F1 and F3 ship before `admin_audit` exists, then retrofit is forgotten | F4's backend PR has a checklist item to backfill audit writes into F1 + F3 lambdas. Code-review gate: grep for `update_metadata` and `send_emails_concurrently` in any admin lambda — every match must be paired with an audit row write. |
+| **Accidental admin actions** — table editor toggles `is_active` on a user by misclick | Confirmation dialog on every destructive iOS form action ("Set is_admin=false for X — confirm?"). All edits land in audit log for forensic recovery. |
+| **Race condition on `broadcast_at` write** — broadcast path stamps metadata before fan-out completes; partial failure leaves report marked broadcast when only 3/12 emails sent | Stamp `broadcast_at` AFTER successful fan-out (after `send_emails_concurrently` returns). Track per-recipient delivery status in the response so retries are idempotent. |
+
+---
+
+## Acceptance criteria (epic done when)
+
+The admin portal epic is **done** when:
+
+1. `AdminView` is a `NavigationLink` menu; no single admin screen exceeds 300 lines. Existing trigger cards live under an "AI Review" sub-screen with no UX regression.
+2. Admin can send a test of any of the 3 AI Review report types to any whitelisted user without polluting `metadata.broadcast_at`. (F1)
+3. Admin can preview all 12 rendered emails (subject + text body) before broadcast in a single round-trip with the dry-run trigger. (F2)
+4. Admin can mark any report as "Hide from app" (post-broadcast) and "Do not broadcast" (pre-broadcast), and every successful broadcast stamps `metadata.broadcast_at`. (F3)
+5. Admin can edit `whitelisted_users` and `whitelisted_leagues` rows via typed forms with field-level validation. (F4)
+6. `admin_audit` Supabase table exists; every mutating admin endpoint (test email, flag, users update, leagues update) writes one row per call. Audit sub-screen renders a paginated feed. (F4)
+7. Admin can filter / search CloudWatch logs for the AI Review + notif lambdas with PII redacted server-side. (F5)
+8. All admin endpoints sit behind `admin_gate.require_admin`; non-admin callers receive 403.
+9. Each sub-feature ships behind a `Config.swift` feature flag and the menu hides unfinished entries.
+
+---
+
+## Open questions for sub-feature plans
+
+Carry forward from `BRAINSTORM.md` § "Open questions for /plan":
+
+- [ ] **Audit log home** (Supabase vs Dynamo): brainstorm recommends Supabase. Confirm before F4.
+- [ ] **Test email `kind` in `notification_log`**: new `kind=email_test` vs new `template` under existing `kind=email`. Resolve in F1 plan.
+- [ ] **Reports list screen for F3**: "most recent of each type" vs full paginated archive. Recommend recent-only in F3, archive in F4.
+- [ ] **Preview response shape**: `text_body` only vs include `html_body` (~10x larger). Recommend text-only for V1; html is an F2.5 polish.
+- [ ] **Log allowlist exact group names**: expected `/aws/lambda/api_admin_ai_review_*`, `/aws/lambda/notif_ai_review_weekly`, `/aws/lambda/notif_*`, `/aws/lambda/email_*` — need definitive list at F5 plan time.
+- [ ] **iOS F4 `is_active` semantics**: native `Picker` is fine for ~12 users, but downstream effect of deactivating a league mid-season is out of scope for the editor itself. Flag for F4 plan.
+
+---
+
+## Skills / Agents to Use
+
+- **`/plan f1-test-email`** → first per-feature plan. Resolves the test-email-kind question + admin home refactor scope.
+- **`/plan f2-preview`** → resolves preview payload shape (text vs html).
+- **`/plan f3-redact`** → resolves reports archive scope decision.
+- **`/plan f4-tables`** → resolves audit-log-home decision and F4 `is_active` flag scope.
+- **`/plan f5-logs`** → resolves the definitive log group allowlist.
+- **`/orchestrate`** (after this epic plan is approved) → creates the 5 sub-feature stub directories + skeleton PLAN.md files.
+- **`backend-engineer` agent** during each sub-feature's `/execute` → handles the lambda + Terraform PRs.
+- **`ios-engineer` agent** during each sub-feature's `/execute` → handles the iOS view + store PRs.

--- a/docs/features/admin-portal/f1-test-email/PLAN.md
+++ b/docs/features/admin-portal/f1-test-email/PLAN.md
@@ -1,0 +1,317 @@
+# Plan: Admin Portal — F1 Test Email Sender + Admin Home Refactor
+
+**Epic**: admin-portal
+**Sub-feature ID**: F1
+**Phase**: Phase 1 — Foundation
+**Status**: Ready
+**Created**: 2026-05-26
+**Last updated**: 2026-05-26
+**Depends on**: none (foundation phase; F0 admin home refactor folded in)
+**Related**: `docs/features/admin-portal/EPIC_PLAN.md`, `docs/features/admin-portal/BRAINSTORM.md`
+
+---
+
+## Summary
+
+F1 ships two coupled deliverables behind a single PR triplet:
+
+1. **Admin home refactor** — `AdminView` becomes a `NavigationLink` menu (5 entries: AI Review, Test Email, Tables, Logs, Audit). Existing trigger cards + activity feed move under the new "AI Review" sub-screen **verbatim** (no UX redesign). Tables / Logs / Audit are scaffolded as "Coming soon" stubs so F4/F5 have a place to plug in.
+2. **Test Email sender** — new backend lambda `POST /admin/email/test` that reuses `build_email_payload` + `ses_helper.send_emails_concurrently` to deliver an existing AI Review report to a single whitelisted recipient. Writes a `notification_log` row with `template = "ai_review_test"`. **Never** writes `metadata.broadcast_at`. New iOS `TestEmailView` + `TestEmailStore` with recipient + report pickers, send button, and a receipt list of recent test sends.
+
+Success: admin can iterate on AI Review email copy by firing any of the three latest reports to any whitelisted user without polluting broadcast state; existing trigger/activity UX survives the refactor unchanged.
+
+---
+
+## Approach
+
+Locked in from `BRAINSTORM.md` Phase 2 (Option A across the board) and refined here:
+
+- **Auth**: reuse `admin_gate.require_admin`. Identical pattern to `api_admin_test_send`.
+- **Rendering**: reuse `lambdas.common.email_templates.ai_review.build_email_payload(...)`. Zero duplication of the report→email path.
+- **Delivery**: reuse `ses_helper.send_emails_concurrently` with a single-recipient list. Captures success/failure on a per-row basis, which `notification_log.log_email` already records.
+- **Isolation invariant**: the test-email lambda must never call `update_metadata` on the report. Enforced via unit test (grep-style assertion: no `update_metadata` import or call).
+- **iOS routing**: extend the existing `AppRouter.AppRoute` enum with five admin sub-routes; `MainShell.destinationView(for:)` registers them. `AdminView` (now the menu) calls `router.navigate(to: .adminTestEmail)` etc. — same pattern as `archivePastStandings` introduced in season-refocus F4.
+- **Visual treatment**: menu rows mirror the existing AI Review card style — `XomperColors.bgCard` background, `XomperTheme.CornerRadius.lg`, `championGold` accent stroke at 0.3 opacity, `XomperTheme.Spacing.md` internal padding. Each row: SF Symbol icon (left) + title + subtitle (center) + chevron (right).
+- **Feature flag (Tables/Logs/Audit)**: per epic acceptance criterion #9, unfinished sub-screens are hidden behind `Config.adminFlags`. F1 ships the menu entries but hides Tables/Logs/Audit by default (they render "Coming soon" if the flag is flipped). AI Review + Test Email are always visible for admin users.
+
+---
+
+## Design Questions — Resolved
+
+| # | Question | Resolution |
+|---|----------|------------|
+| 1 | Recipient picker source | **`leagueStore.myLeagueUsers` filtered against whitelisted_users from backend** — `historyStore.upcomingUsers` is only populated when the user has tapped into the upcoming-season chip in Draft History; not reliable for the admin tab. Instead, ship a new `XomperAPIClient.fetchWhitelistedUsers()` thin call against the existing Supabase-backed list (or, cheaper, expose the list through the test-email lambda's `GET` companion — see step 6b). v1: server-side enumeration in a single new `GET /admin/email/test/recipients` endpoint that returns `{ rows: [{ sleeper_user_id, display_name, email }] }` from `whitelisted_users where is_active = true`. |
+| 2 | Report picker shape | **Latest-per-type for v1.** Three rows: Post-Draft, Preseason, Weekly. Source from `AIReviewStore.latestByType` (already populated for the existing AI Review sub-screen). Full archive view defers to F4. |
+| 3 | iOS routing pattern | **`NavigationLink(value:)` with `AppRoute`** — mirror `AppRouter` + typed enum. Add five new cases: `.adminAIReview`, `.adminTestEmail`, `.adminTables`, `.adminLogs`, `.adminAudit`. `MainShell.destinationView(for:)` handles each. |
+| 4 | Backend response shape | `{ "Success": true, "recipient_email": "...", "message_id": "ses-mid-...", "sent_at": "2026-05-26T17:42:33Z", "template": "ai_review_test", "report_type": "weekly", "report_period": "2025W04" }`. Includes the SES message_id when available (`ses_helper` already returns this). 4xx errors return `{ "Success": false, "Message": "..." }` shape to match existing admin lambdas. |
+| 5 | Activity feed behaviour after refactor | **Unchanged** — filter chips (channel + status) move under AI Review sub-screen as-is. No new filter for `template=ai_review_test`; receipts list in TestEmailView is the dedicated surface for that. |
+| 6 | Notification log filter | `api_admin_list_notifications` already accepts `kind` + `status` query params. v1: TestEmailView's receipts list calls the existing endpoint with `kind=email` and post-filters client-side for `template == "ai_review_test"` (we already pull body_snippet + recipient, so template is a small additional field). Backend change: include `template` in `log_email` write + the row's returned shape. **Confirmed**: `log_email` in `notification_log.py` does not currently persist `template` — we'll add it as an optional kwarg threaded through `ses_helper.send_email`. |
+| 7 | AdminView visual treatment | Menu rows = `XomperColors.bgCard` + 16pt corner radius + 0.3 opacity champion-gold stroke. Row internals: 28pt SF Symbol (gold), title (`.subheadline.weight(.bold)`, `textPrimary`), subtitle (`.caption`, `textSecondary`), chevron (`.caption`, `textMuted`). Vertical separation = `XomperTheme.Spacing.sm` between rows. Matches existing trigger cards' look. |
+| 8 | Tab nesting hazard | Confirmed via `MainShell.swift:51-57` — the existing `NavigationStack(path: $router.path)` wraps every top-level destination, so pushing new `AppRoute.adminTestEmail` from inside the Admin destination root is identical to how `.archivePastStandings` is pushed from `ArchiveView`. **No sub-router needed**. Just register the five new routes alongside the existing season-refocus archive cases. |
+
+---
+
+## Affected Files / Components
+
+### Infrastructure (`xomper-infrastructure`)
+
+| File | Change | Why |
+|------|--------|-----|
+| `terraform/lambdas_api.tf` | Add 2 entries to `local.api_lambdas`: `admin-email-test` (POST) and `admin-email-test-recipients` (GET) | Routes get registered + lambda stub created via existing `aws_lambda_function.api` for-each. Backend deploy script then overlays real code. |
+
+### Backend (`xomper-back-end`)
+
+| File | Change | Why |
+|------|--------|-----|
+| `lambdas/api_admin_email_test/__init__.py` | New empty module init | Standard layout for backend lambdas. |
+| `lambdas/api_admin_email_test/handler.py` | New `POST` handler | The test-email surface. ~150 lines. |
+| `lambdas/api_admin_email_test_recipients/__init__.py` | New empty module init | Companion `GET` for the iOS recipient picker. |
+| `lambdas/api_admin_email_test_recipients/handler.py` | New `GET` handler | Returns active whitelisted users. ~40 lines. |
+| `lambdas/common/notification_log.py` | Add optional `template` kwarg to `log_email(...)` | Lets us distinguish test sends from real broadcasts in the activity feed + receipts query. |
+| `lambdas/common/ses_helper.py` | Thread `template` kwarg through `send_email` → `log_email` | Plumbing only; no behavior change for existing callers. |
+| `tests/test_api_admin_email_test.py` | New pytest module | Asserts admin gate, no-`update_metadata` invariant, single-recipient SES call, `notification_log` write with `template="ai_review_test"`. |
+| `tests/test_api_admin_email_test_recipients.py` | New pytest module | Asserts admin gate + filtered Supabase query. |
+
+### iOS (`xomper-ios`)
+
+| File | Change | Why |
+|------|--------|-----|
+| `Xomper/Features/Admin/AdminView.swift` | **Radical simplification** — becomes the menu. Drop all trigger cards, test sender card, filter bar, activity feed. ~100 lines max. | The F0 fold-in. Trigger/feed code relocates into `AIReviewSubScreen.swift`. |
+| `Xomper/Features/Admin/AIReviewSubScreen.swift` | **New** — extracts the existing 3 trigger cards + activity feed + filter chips + test sender card. Wraps in its own view, takes `AdminStore` injected from the menu. | Preserves existing UX verbatim. No redesign. Today's `AdminStore` powers this verbatim. |
+| `Xomper/Features/Admin/TestEmailView.swift` | **New** — recipient picker (Menu), report picker (latest-per-type), Send button, success/error toast, recent sends list. | F1 deliverable. |
+| `Xomper/Features/Admin/TablesStubView.swift` | **New** — single `EmptyStateView` with "Coming soon (F4)" message. | Placeholder; F4 replaces. |
+| `Xomper/Features/Admin/LogsStubView.swift` | **New** — single `EmptyStateView` with "Coming soon (F5)" message. | Placeholder; F5 replaces. |
+| `Xomper/Features/Admin/AuditStubView.swift` | **New** — single `EmptyStateView` with "Coming soon (F4)" message. | Placeholder; F4 replaces. |
+| `Xomper/Core/Stores/TestEmailStore.swift` | **New** `@Observable @MainActor` — owns recipient list, report list, in-flight state, last result. | Per-feature store pattern from the epic plan. |
+| `Xomper/Core/Stores/AdminStore.swift` | **No change for F1** | Survives untouched under the AI Review sub-screen. Re-org of this store deferred to F2 (`AIReviewAdminStore`). |
+| `Xomper/Navigation/AppRouter.swift` | Add five `AppRoute` cases: `.adminAIReview`, `.adminTestEmail`, `.adminTables`, `.adminLogs`, `.adminAudit` | Routing scaffold for the menu. |
+| `Xomper/Features/Shell/MainShell.swift` | Register five new cases in `destinationView(for:)` | Hooks the new routes into the existing nav stack. |
+| `Xomper/Core/Networking/XomperAPIClient.swift` | Add `sendTestEmail(recipientSleeperId:reportId:)` → returns `TestEmailResponse`. Add `fetchTestEmailRecipients()` → returns `[TestEmailRecipient]`. Both Decodable structs land in this file alongside existing admin response types. | Public API surface for `TestEmailStore`. |
+| `Xomper/Config/Config.swift` (template) | Add `AdminFlags` struct: `showTables`, `showLogs`, `showAudit`, all default `false` | Feature flag gating per epic AC #9. |
+| `XomperTests/TestEmailStoreTests.swift` | **New** — verifies recipient + report loading, send success path, error surface, no-op when picker selections nil. | Required for store correctness. |
+
+---
+
+## Implementation Steps
+
+Dependency-ordered. **Infra PR merges first**, then backend, then iOS. Within each PR, commits follow the order below.
+
+### Phase A — Infrastructure (PR #1, `xomper-infrastructure`)
+
+- [ ] **A1**. Add two entries to `local.api_lambdas` in `terraform/lambdas_api.tf`:
+  ```hcl
+  { name = "admin-email-test",            description = "Admin: send a single AI Review report to one whitelisted user", path_part = "email-test",            http_method = "POST" },
+  { name = "admin-email-test-recipients", description = "Admin: list whitelisted users for the test-email picker",       path_part = "email-test-recipients", http_method = "GET"  },
+  ```
+- [ ] **A2**. Run `terraform plan` locally — should show 2 new `aws_lambda_function`, 2 new API GW routes, 2 new permission attachments. No IAM changes (existing `xomper-lambda-exec` already has SES send + Supabase access).
+- [ ] **A3**. Open PR titled `infra(admin-portal F1): add /admin/email-test + /admin/email-test-recipients`. Body: links epic plan + F1 plan, paste plan output, calls out SES quota (already 200/day so within budget).
+- [ ] **A4**. After CI green: apply via GitHub Actions (per Terraform-only infra rule — no local apply).
+- [ ] **A5**. Confirm via `aws apigateway get-resources` that both new resources exist and are wired to lambda stubs.
+
+### Phase B — Backend (PR #2, `xomper-back-end`)
+
+- [ ] **B1**. Extend `lambdas/common/notification_log.py`:
+  - Add `template: Optional[str] = None` kwarg to `log_email(...)`.
+  - When non-empty, persist as `item["template"] = template` before `_put`.
+  - Add same kwarg to `log_push(...)` for symmetry (future-proofs F2 preview tracking).
+- [ ] **B2**. Extend `lambdas/common/ses_helper.py`:
+  - Thread `template` through `send_email(...)` → `send_emails_concurrently(...)` signatures.
+  - Existing callers pass nothing → keeps behaviour stable.
+- [ ] **B3**. Create `lambdas/api_admin_email_test/handler.py`:
+  - Imports: `parse_body`, `success_response`, `require_admin`, `NotAdmin`, `build_email_payload`, `send_emails_concurrently`, `get_whitelisted_user_by_sleeper_id`, `ai_reports_table` (Dynamo `get_item` by composite PK/SK).
+  - Body schema: `{ "recipient_sleeper_user_id": str, "report_id": str }`. The `report_id` matches the iOS `AIReport.id` (composite `pk|sk`). The handler splits on `|` to derive the Dynamo key.
+  - Flow: gate admin → load report (404 if not found) → load recipient (404 if not found / inactive) → derive `report_type` + `period_label` from report metadata → call `build_email_payload(...)` → call `send_emails_concurrently([(email, subject, html, text)], template="ai_review_test")` → return `{Success, recipient_email, message_id, sent_at, template, report_type, report_period}`.
+  - **Invariant**: no import of `update_metadata`; no write to Dynamo `ai_reports`. The lambda is read-only against the report table.
+- [ ] **B4**. Create `lambdas/api_admin_email_test_recipients/handler.py`:
+  - Imports: `success_response`, `require_admin`, `NotAdmin`, `get_active_whitelisted_users`.
+  - Flow: gate admin → fetch active users → map to `[{sleeper_user_id, display_name, email}]` (drop is_admin + other fields) → `success_response({"rows": [...], "count": N})`.
+- [ ] **B5**. Write `tests/test_api_admin_email_test.py`:
+  - **Test 1**: non-admin → 403.
+  - **Test 2**: happy path → SES called with single recipient, `notification_log.log_email` called with `template="ai_review_test"`, response includes `message_id`.
+  - **Test 3**: missing report → 404.
+  - **Test 4**: missing recipient → 404.
+  - **Test 5** (invariant): patch `update_metadata` to raise on call; happy-path test still passes (no call made).
+- [ ] **B6**. Write `tests/test_api_admin_email_test_recipients.py`:
+  - **Test 1**: non-admin → 403.
+  - **Test 2**: happy path → returns expected rows from mocked Supabase response.
+- [ ] **B7**. Run `pytest lambdas/` + `pytest tests/` → green.
+- [ ] **B8**. Open PR titled `feat(admin-portal F1): test email sender lambda + recipients endpoint`. Body links F1 plan; calls out that this is the second of the three coordinated PRs.
+- [ ] **B9**. After merge, the backend deploy GitHub Action pushes the lambdas to dev. Hit both routes manually with `curl` (using a known admin JWT) to verify.
+
+### Phase C — iOS (PR #3, `xomper-ios`)
+
+- [ ] **C1**. Add `AdminFlags` to `Config.swift` template + the gitignored `Config.swift`:
+  ```swift
+  struct AdminFlags {
+      static let showTables: Bool = false
+      static let showLogs:   Bool = false
+      static let showAudit:  Bool = false
+  }
+  ```
+- [ ] **C2**. Extend `AppRouter.AppRoute` with five new cases (`.adminAIReview`, `.adminTestEmail`, `.adminTables`, `.adminLogs`, `.adminAudit`). Doc-comment each.
+- [ ] **C3**. Extend `XomperAPIClient`:
+  - Add `TestEmailRecipient` Decodable (`sleeper_user_id`, `display_name`, `email`).
+  - Add `TestEmailResponse` Decodable (`Success`, `recipient_email`, `message_id`, `sent_at`, `template`, `report_type`, `report_period`).
+  - Add `func fetchTestEmailRecipients() async throws -> [TestEmailRecipient]` → GET `/admin/email-test-recipients`.
+  - Add `func sendTestEmail(recipientSleeperUserId: String, reportId: String) async throws -> TestEmailResponse` → POST `/admin/email-test`.
+  - Add both to `XomperAPIClientProtocol`.
+- [ ] **C4**. Create `TestEmailStore.swift`:
+  - `@Observable @MainActor final class TestEmailStore`.
+  - State: `recipients: [TestEmailRecipient] = []`, `selectedRecipient: TestEmailRecipient? = nil`, `selectedReport: AIReport? = nil`, `isSending = false`, `lastResult: Result<TestEmailResponse, Error>? = nil`, `recentSends: [AdminNotificationLogEntry] = []`.
+  - Methods: `loadRecipients()`, `loadRecentSends(sleeperUserId:)` (calls `adminListNotifications` then filters by template), `sendTest()` (uses selected pickers; pre-condition both non-nil), `reset()`.
+- [ ] **C5**. Create `TestEmailView.swift`:
+  - Reads `aiReviewStore.latestByType` for the report picker (latest of `.postDraft`, `.preseason`, `.weekly`).
+  - Recipient picker: `Menu { ForEach(store.recipients) { Button(...) { store.selectedRecipient = $0 } } }`.
+  - Report picker: same pattern, 3 rows max.
+  - Send button: gold capsule, disabled when either picker is nil or `store.isSending`.
+  - Toast: green check on success ("Sent to <email> at <time>"), red X on error (`error.localizedDescription`).
+  - Receipts list: `recentSends` filtered to `template == "ai_review_test"`, newest first, 10 visible. Each row: recipient + subject + timestamp + status icon.
+  - `.task` loads recipients + recent sends. `.refreshable` re-runs both.
+- [ ] **C6**. Create `TablesStubView.swift` / `LogsStubView.swift` / `AuditStubView.swift` — each is a single `EmptyStateView(icon:, title:, message:)` with respective "Coming soon (F4/F5)" copy.
+- [ ] **C7**. Create `AIReviewSubScreen.swift`:
+  - **Cut + paste** the current `AdminView.content` body verbatim into this view: trigger cards (post-draft, preseason, weekly), test sender card, filter bar, activity feed, all helpers.
+  - Accept `AdminStore`, `authStore`, `callerSleeperId`, `callerEmail` as injected props.
+  - Move the `.task` + `.refreshable` modifiers in here too.
+  - **Verification step**: visual diff a screenshot of the pre-refactor AdminView vs the post-refactor AIReviewSubScreen — must be pixel-identical save for the navigation title.
+- [ ] **C8**. Rewrite `AdminView.swift`:
+  - Drop all trigger / feed / test-sender content.
+  - Keep `isAdmin` gate + EmptyStateView fallback for non-admins.
+  - Body becomes a `ScrollView` of 5 menu rows:
+    - **AI Review** — `sparkles`, "Trigger reports + activity feed", → `.adminAIReview`. Always visible.
+    - **Test Email** — `paperplane`, "Send an AI Review report to one user", → `.adminTestEmail`. Always visible.
+    - **Tables** — `tablecells`, "Edit users / leagues / reports", → `.adminTables`. Gated by `Config.AdminFlags.showTables`.
+    - **Logs** — `terminal`, "CloudWatch tail + search", → `.adminLogs`. Gated by `Config.AdminFlags.showLogs`.
+    - **Audit** — `clock.arrow.circlepath`, "Recent admin actions", → `.adminAudit`. Gated by `Config.AdminFlags.showAudit`.
+  - Take `router: AppRouter` as a new param. Pass through from `MainShell`.
+- [ ] **C9**. Update `MainShell.swift`:
+  - Pass `router` into `AdminView` in the `.admin` destination root case.
+  - Add five new cases to `destinationView(for:)`:
+    - `.adminAIReview` → `AIReviewSubScreen(authStore:, leagueStore:, aiReviewStore: ?)` — note AIReviewSubScreen takes the same params AdminView used to.
+    - `.adminTestEmail` → `TestEmailView(authStore:, aiReviewStore:)` — initialises its own `TestEmailStore`.
+    - `.adminTables` → `TablesStubView()`.
+    - `.adminLogs` → `LogsStubView()`.
+    - `.adminAudit` → `AuditStubView()`.
+- [ ] **C10**. Add `xcodegen generate` step. Run iOS build:
+  ```bash
+  DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild \
+    -scheme Xomper -sdk iphonesimulator \
+    -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build
+  ```
+- [ ] **C11**. Write `XomperTests/TestEmailStoreTests.swift`:
+  - Mock `XomperAPIClientProtocol`.
+  - **Test 1**: `loadRecipients()` populates `recipients`.
+  - **Test 2**: `sendTest()` with nil selections → no-op (no API call, `lastResult` stays nil).
+  - **Test 3**: `sendTest()` happy path → `isSending` flips, `lastResult` becomes `.success`.
+  - **Test 4**: `sendTest()` API error → `lastResult` becomes `.failure`, error message surfaced.
+- [ ] **C12**. Manual QA pass on iPhone 17 Pro simulator (per `.claude/CLAUDE.md` available sims):
+  - AdminView shows 5 menu rows (or 2 + 3 hidden if flags off).
+  - Tap AI Review → trigger cards + activity feed render identically to pre-refactor.
+  - Tap Test Email → recipient + report pickers populate; send → toast + receipts row.
+  - Tap back → menu intact.
+  - Non-admin user → "Admin only" empty state still renders.
+- [ ] **C13**. Open PR titled `feat(admin-portal F1): admin home menu refactor + test email sender`. Body links epic plan + F1 plan; tags PRs #1 (infra) and #2 (backend) as merged; calls out screen recordings of the AI Review sub-screen pixel-parity.
+
+### Phase D — Coordination + Sign-off
+
+- [ ] **D1**. After all three PRs merge: `/end-session` to log learnings into `.claude/memory/session-log.md`.
+- [ ] **D2**. Update epic plan `EPIC_PLAN.md` orchestration block — flip F1 from Draft to Done; flag F2 as ready to start.
+- [ ] **D3**. Flip this plan's Status to `Done`. Update `Last updated` field.
+
+---
+
+## Test Plan
+
+### Backend (`xomper-back-end/tests/`)
+
+| Test | File | Asserts |
+|------|------|---------|
+| Non-admin returns 403 | `test_api_admin_email_test.py::test_non_admin_403` | Calling without admin claim → 403 + Success=False |
+| Happy path single send | `test_api_admin_email_test.py::test_send_success` | SES called with 1 recipient; response has `message_id`, `recipient_email`, `template="ai_review_test"` |
+| Missing report → 404 | `test_api_admin_email_test.py::test_missing_report_404` | Unknown `report_id` → 404 |
+| Missing recipient → 404 | `test_api_admin_email_test.py::test_missing_recipient_404` | Unknown `recipient_sleeper_user_id` → 404 |
+| Never writes metadata | `test_api_admin_email_test.py::test_no_metadata_write` | Patched `update_metadata` raises if called; happy path still green |
+| Recipients endpoint admin gate | `test_api_admin_email_test_recipients.py::test_non_admin_403` | 403 without admin claim |
+| Recipients endpoint happy | `test_api_admin_email_test_recipients.py::test_returns_active_users` | Returns mapped `[{sleeper_user_id, display_name, email}]` for active users |
+| `notification_log` template field | `test_notification_log.py::test_log_email_with_template` | New `template` kwarg persists to Dynamo item; absent when None |
+
+### iOS (`XomperTests/`)
+
+| Test | File | Asserts |
+|------|------|---------|
+| Store loads recipients | `TestEmailStoreTests.swift::test_loadRecipients_populates` | After `loadRecipients()`, `store.recipients` matches mock |
+| No-op without selections | `TestEmailStoreTests.swift::test_sendTest_noop_when_nil` | No API call, no state change when selections nil |
+| Send success surfaces result | `TestEmailStoreTests.swift::test_sendTest_success` | `lastResult` is `.success` with correct `recipient_email` |
+| Send error surfaces failure | `TestEmailStoreTests.swift::test_sendTest_failure` | `lastResult` is `.failure` with mapped error |
+| Recipients endpoint mock | `XomperAPIClientTests.swift::test_fetchTestEmailRecipients_decodes` | Decoder handles the response shape |
+| Send endpoint mock | `XomperAPIClientTests.swift::test_sendTestEmail_encodesBody` | POST body matches expected JSON keys |
+
+### Manual QA Checklist
+
+- [ ] Admin sees 5-row menu (or 2 visible + 3 hidden if flags off).
+- [ ] AI Review sub-screen identical to pre-refactor AdminView (trigger cards + activity feed + test-sender card).
+- [ ] Test Email sub-screen: recipient picker shows 12 active users; report picker shows latest 3.
+- [ ] Send button disables while in flight; success toast shows after; receipts row appears within ~3s.
+- [ ] Backend SES inbox confirms exactly 1 email delivered per "Send" click.
+- [ ] Dynamo `xomper-ai-reports` row's `broadcast_at` metadata field is **untouched** by a test send (verify via console).
+- [ ] Non-admin still gets "Admin only" empty state.
+- [ ] Hidden Tables/Logs/Audit entries don't appear in the menu when flags are false.
+- [ ] When flags are flipped to true (manual `Config.swift` edit), stub screens render "Coming soon" copy.
+
+---
+
+## Acceptance Checklist
+
+- [ ] `POST /admin/email/test` returns `{Success: true, message_id, recipient_email, sent_at, template: "ai_review_test"}` for a happy-path admin call.
+- [ ] `GET /admin/email-test-recipients` returns `{rows: [...], count: N}` for active whitelisted users.
+- [ ] Both endpoints return 403 for non-admin callers.
+- [ ] `notification_log` row written with `template = "ai_review_test"` for every test send.
+- [ ] No `update_metadata` call from the test-email handler (enforced by unit test).
+- [ ] `AdminView` is < 200 lines and contains zero trigger/activity code.
+- [ ] `AIReviewSubScreen` preserves the pre-refactor trigger + activity UX pixel-identically.
+- [ ] `TestEmailView` renders pickers + send + receipts; tests pass.
+- [ ] `AppRoute` enum has 5 new admin cases; `MainShell.destinationView(for:)` handles each.
+- [ ] Three PRs merged in order: infra → backend → iOS.
+- [ ] Epic plan's F1 row flipped to Done.
+
+---
+
+## Out of Scope (deferred to later F-features or polish)
+
+- Full reports archive picker for test email (latest-per-type is the V1 surface; F4's Tables sub-feature may add a paginated archive).
+- HTML preview in iOS before sending (deferred to F2 which renders the full 12-recipient preview list).
+- Audit log row for test sends (F4 retrofits this after the `admin_audit` table ships).
+- Pre-flight "do not broadcast" flag (F3).
+- Server-side rate limiting on test sends (current SES quota is 200/day — plenty of headroom).
+- Push channel for test email (intentional: AI Review reports are email-only).
+- Tables / Logs / Audit sub-screens (stubs only here; F4/F5 fill in).
+
+---
+
+## Risks / Tradeoffs
+
+| Risk | Mitigation |
+|------|------------|
+| AI Review sub-screen UX regression during the cut+paste refactor | Pixel-diff QA step in C7; manual QA item before C13 PR. Reviewer instructed to focus on the trigger card visuals. |
+| `notification_log.log_email` signature change ripples into untested callers | New `template` kwarg is optional with `None` default; existing callers untouched. Backend test `test_log_email_no_template_back_compat` asserts. |
+| Test email accidentally counted as a broadcast | Code-path isolation + unit test `test_no_metadata_write`. Reviewer checklist: grep PR for any `update_metadata` or `xomper-ai-reports.put_item` reference inside `api_admin_email_test/`. |
+| Recipient picker drifts from Supabase (stale list) | `loadRecipients()` runs on every `.task` mount + `.refreshable` pull. ~12 rows so re-fetch cost is trivial. |
+| Feature flag misconfiguration ships Tables/Logs/Audit visible | Defaults to `false` in both committed template and gitignored `Config.swift`; reviewer checks no PR diff toggles them. |
+| Multiple admins racing send → SES throttling | Send concurrency = 1 (single-recipient list). Within SES burst limit; not a real risk for our 1-admin league. |
+| Pushed sub-screens don't survive drawer-driven destination switches | Verified pattern: `archivePastStandings` already works the same way. `router.popToRoot()` fires when drawer switches `currentDestination`. Confirmed in `MainShell.swift:78`. |
+
+---
+
+## Open Questions
+
+- [ ] Confirm SES `Message-ID` is exposed by `ses_helper.send_email` return today — if not, B2 must add it to the return tuple. Quick check before B-phase work begins.
+- [ ] Should the Tables/Logs/Audit menu entries render at all when flags are `false`, or be hidden entirely? **Recommendation**: hide entirely (current plan). Discoverability isn't a problem — admin knows when F4/F5 land.
+- [ ] Should the receipts list use a dedicated endpoint with `template=ai_review_test` server-side filter, or piggyback on `/admin/notifications` with client-side filter? **Recommendation**: client-side for V1 (simpler), revisit in F4 alongside the audit feed.
+
+---
+
+## Skills / Agents to Use
+
+- **`backend-engineer` agent** for Phase B (lambda + tests + `notification_log` extension).
+- **`ios-engineer` agent** for Phase C (AdminView refactor, new views, store, routing).
+- **Terraform skill** for Phase A (single `lambdas_api.tf` edit, plan/apply via GitHub Actions per the Terraform-only infra rule).
+- **`/execute admin-portal/f1-test-email`** kicks off the three-phase delegation preview after Status flips to Ready.

--- a/docs/features/admin-portal/f2-preview/PLAN.md
+++ b/docs/features/admin-portal/f2-preview/PLAN.md
@@ -1,0 +1,23 @@
+# Plan: Admin Portal — F2 Pre-flight Email Preview
+
+**Epic**: admin-portal
+**Sub-feature ID**: F2
+**Phase**: Phase 2 — Pre-broadcast Safety
+**Status**: Draft
+**Created**: 2026-05-26
+**Depends on**: F1 (previews live under the AI Review sub-screen from F1 menu)
+
+## Summary
+Extend the three dry-run trigger lambdas (`run_postdraft`, `run_preseason`, `run_weekly`) to return rendered payloads in the response when `dry_run=true`. iOS surface displays the 12 previews and lets admin scan subject + body before clicking "Broadcast" (which calls trigger with `dry_run=false, force=true`). Zero new endpoints — reuses existing trigger flow so preview can never drift from real broadcast.
+
+## Repos Touched
+- `xomper-back-end` — extend three trigger lambdas with `previews: [{ recipient, subject, text_body }]`
+- `xomper-ios` — previews list under AI Review trigger card, tap-to-expand row, Broadcast button
+
+## Open Questions (this sub-feature)
+- [ ] Preview response shape: `text_body` only vs include `html_body` (~10x larger)? Recommend text-only for V1.
+- [ ] Cap on `text_body` length per preview (recommend 4KB) — confirm payload size budget.
+
+## TODO
+- [ ] Flesh out this stub via `/plan admin-portal/f2-preview` before executing
+- [ ] Flip Status to Ready

--- a/docs/features/admin-portal/f3-redact/PLAN.md
+++ b/docs/features/admin-portal/f3-redact/PLAN.md
@@ -1,0 +1,24 @@
+# Plan: Admin Portal — F3 Redact + Do-Not-Broadcast + broadcast_at
+
+**Epic**: admin-portal
+**Sub-feature ID**: F3
+**Phase**: Phase 3 — Broadcast Safety Loop
+**Status**: Draft
+**Created**: 2026-05-26
+**Depends on**: F2 (DNB checkbox lives in F2's preview surface)
+
+## Summary
+Two new metadata flags (`is_redacted`, `do_not_broadcast`) plus universal stamping of `broadcast_at` on every successful real broadcast (already done for post-draft; replicate for preseason + weekly). New flag endpoint. Broadcast path re-reads metadata post-generation and aborts 409 if `do_not_broadcast`. Read paths filter `is_redacted == true` for non-admin callers.
+
+## Repos Touched
+- `xomper-infrastructure` — API GW route `POST /admin/reports/{league_id}/{report_type}/{period}/flag`
+- `xomper-back-end` — `lambdas/api_admin_reports_flag/`, broadcast path DNB check, read-path redact filter
+- `xomper-ios` — "Hide from app" button on report rows; "Do not broadcast" checkbox on preview screen
+
+## Open Questions (this sub-feature)
+- [ ] Reports list screen scope: "most recent of each type" (recommended for F3) vs full paginated archive (defer to F4)?
+- [ ] Button label confirmation — "Hide from app" not "Unsend" (cannot recall already-delivered email).
+
+## TODO
+- [ ] Flesh out this stub via `/plan admin-portal/f3-redact` before executing
+- [ ] Flip Status to Ready

--- a/docs/features/admin-portal/f4-tables/PLAN.md
+++ b/docs/features/admin-portal/f4-tables/PLAN.md
@@ -1,0 +1,25 @@
+# Plan: Admin Portal — F4 Table Editor + Audit
+
+**Epic**: admin-portal
+**Sub-feature ID**: F4
+**Phase**: Phase 4 — Table Edits + Audit
+**Status**: Draft
+**Created**: 2026-05-26
+**Depends on**: F3 (reuses flag endpoint; introduces audit table that retroactively wraps F1 + F3 writes)
+
+## Summary
+Three typed Supabase write endpoints (users, leagues, reports flag — reuses F3 endpoint). iOS typed forms per table with field-level validation. Ships new Supabase `admin_audit` table via Terraform-managed migration — every mutating admin endpoint writes one row per call (F1 test-email and F3 flag lambdas get backfilled audit writes here). New "Audit" sub-screen with paginated feed.
+
+## Repos Touched
+- `xomper-infrastructure` — API GW routes `POST /admin/users/{id}`, `POST /admin/leagues/{id}`; Terraform-managed Supabase `admin_audit` migration
+- `xomper-back-end` — `lambdas/api_admin_users_update/`, `lambdas/api_admin_leagues_update/`; backfill audit writes into F1 + F3 lambdas
+- `xomper-ios` — "Tables" sub-screen (Users + Leagues + Reports children); `UsersEditView`, `LeaguesEditView`; "Audit" sub-screen
+
+## Open Questions (this sub-feature)
+- [ ] Audit log home: Supabase (recommended) vs Dynamo — confirm before migration.
+- [ ] `is_active` semantics on leagues: downstream effect of deactivating mid-season is out of scope for the editor, but flag it in the form copy.
+- [ ] Exact editable field allowlist per table (users: `email`, `display_name`, `sleeper_user_id`, `is_admin`, `is_active`; leagues: `is_active`).
+
+## TODO
+- [ ] Flesh out this stub via `/plan admin-portal/f4-tables` before executing
+- [ ] Flip Status to Ready

--- a/docs/features/admin-portal/f5-logs/PLAN.md
+++ b/docs/features/admin-portal/f5-logs/PLAN.md
@@ -1,0 +1,25 @@
+# Plan: Admin Portal — F5 CloudWatch Log Viewer
+
+**Epic**: admin-portal
+**Sub-feature ID**: F5
+**Phase**: Phase 5 — Log Viewer
+**Status**: Draft
+**Created**: 2026-05-26
+**Depends on**: F1 (admin home menu — logs sub-screen plugs into menu from F1)
+
+## Summary
+New `api_admin_logs_query` lambda backed by CloudWatch `FilterLogEvents` against an allowlisted set of log groups. Server-side regex redacts emails and `sleeper_user_id` values before return. 60s server-side cache on identical queries; pagination via `next_token`. New IAM role scoped to `logs:FilterLogEvents` against allowlisted ARNs only (separate role — does NOT contaminate other admin lambdas). iOS log tail with log group picker, level filter, search, "Load older" pager, 5s minimum client-side refresh interval.
+
+## Repos Touched
+- `xomper-infrastructure` — API GW route `GET /admin/logs/query`; new IAM role with `logs:FilterLogEvents` scoped to allowlisted log group ARNs
+- `xomper-back-end` — `lambdas/api_admin_logs_query/`; allowlist enforcement; PII regex redaction; pagination
+- `xomper-ios` — "Logs" sub-screen with `Picker`, level filter, search field, "Load older" button
+
+## Open Questions (this sub-feature)
+- [ ] Definitive log group allowlist — expected `/aws/lambda/api_admin_ai_review_*`, `/aws/lambda/notif_ai_review_weekly`, `/aws/lambda/notif_*`, `/aws/lambda/email_*`. Need final list at plan time.
+- [ ] PII regex coverage — golden-file test over sample log lines (emails + sleeper IDs); any other PII shapes to redact?
+- [ ] Cache TTL confirmation (60s server-side, 5s client min refresh).
+
+## TODO
+- [ ] Flesh out this stub via `/plan admin-portal/f5-logs` before executing
+- [ ] Flip Status to Ready


### PR DESCRIPTION
## Summary

Two coupled pieces shipping in one PR (the F0 admin home refactor folded into F1):

**Part 1 — AdminView refactor**
- `AdminView` becomes a 5-row `NavigationLink` menu: AI Review, Test Email, Tables, Logs, Audit.
- Existing trigger cards (post-draft / preseason / weekly with week-override stepper), filter bar, activity feed, and legacy test-sender card moved **verbatim** into `Features/Admin/AIReviewSubScreen.swift` — no UX redesign.
- Tables / Logs / Audit gated behind `Config.AdminFlags.{showTables,showLogs,showAudit}` (default `false` until F4/F5 land).

**Part 2 — Test Email sender**
- New `Features/Admin/TestEmailView.swift` — recipient picker (Menu), report picker (latest-per-type via `AIReviewStore`), Send button, success/error toast, receipts list.
- New `Core/Stores/TestEmailStore.swift` (`@Observable @MainActor`) — owns recipient list, picker state, send result, receipts.
- `XomperAPIClient` additions: `fetchTestEmailRecipients()` and `sendTestEmail(recipientSleeperUserId:reportId:)` plus the `TestEmailRecipient` / `TestEmailResponse` models (snake_case `CodingKeys`).
- Three "Coming soon" stub views (`TablesStubView`, `LogsStubView`, `AuditStubView`) so the F4/F5 routes have destinations.

## New sub-screens

| Route | View | Visibility |
|-------|------|------------|
| `.adminAIReview` | `AIReviewSubScreen` | Always |
| `.adminTestEmail` | `TestEmailView` | Always |
| `.adminTables` | `TablesStubView` | Gated by `AdminFlags.showTables` |
| `.adminLogs` | `LogsStubView` | Gated by `AdminFlags.showLogs` |
| `.adminAudit` | `AuditStubView` | Gated by `AdminFlags.showAudit` |

All five wired in `MainShell.destinationView(for:)` alongside the existing season-refocus F4 archive routes (same pattern).

## Tests

- New `XomperTests/TestEmailStoreTests.swift` — 9 tests: `loadRecipients` happy + error, `sendTest` no-op guards (both selections nil; only recipient nil), success surfacing, failure surfacing, `reset`, wire-format decode guards for `TestEmailRecipient` + `TestEmailResponse`.
- Existing `AdminStoreTests` + `AIReviewStoreTests` mock clients updated to satisfy the new `XomperAPIClientProtocol` methods.
- **Full suite: 86 tests, all green.**

## Dependencies

- Depends on infra #108 (terraform routes for `/admin/email-test` + `/admin/email-test-recipients`).
- Depends on backend #65 (lambda handlers + `notification_log.template` plumbing).

## Test plan

- [x] `xcodegen generate` followed by clean iOS build on iPhone 17 Pro simulator — no errors, only pre-existing warnings.
- [x] Full XomperTests suite runs green (86 / 86).
- [ ] Manual QA: admin user sees 2-row menu (Tables/Logs/Audit hidden behind flags).
- [ ] Manual QA: tapping AI Review pushes the verbatim trigger + activity surface (pixel-diff vs pre-refactor recording).
- [ ] Manual QA: tapping Test Email pushes the new screen; recipient + report pickers populate; send completes and appears in receipts list.
- [ ] Manual QA: non-admin user still sees the "Admin only" empty state on the menu root.
- [ ] Manual QA: flipping `AdminFlags.showTables = true` in local `Config.swift` reveals the Tables stub row.

## Notes

- `Config.swift` is gitignored; the `AdminFlags` block was added to both the committed template and the local file (the latter not staged here).
- `xcodegen generate` was re-run; `project.pbxproj` updated to include the 7 new source files.
- VERBATIM extraction of `AIReviewSubScreen` from the old `AdminView.content` — same gold-stroke trigger cards, same dry-run / regenerate-force buttons, same week-override stepper, same segmented filter pickers, same activity row chrome. Reviewers: please pixel-diff a screen recording of AI Review against `main`'s admin tab.