### PR TITLE
feat(admin-portal F2): iOS — pre-flight email preview screen

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		4B629DB100C96EB68A6A9A41 /* SearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323F422F2D0E1C2BA5D46C0A /* SearchResults.swift */; };
 		4DB9374CF45A69E97C02FC94 /* PlayerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC44D14381C74E97D8AF868F /* PlayerDetailView.swift */; };
 		4E0CAC9964BF3F2B59EDD844 /* DraftHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A789B8D49FA4430886626289 /* DraftHistory.swift */; };
+		50E9D9254D779960D0D2C5B1 /* EmailPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D0F4D0BBA2C48A0232C43FF /* EmailPreviewTests.swift */; };
 		51BD6DAC467108079C465193 /* SearchResultGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F606D0624D23D47A171D26 /* SearchResultGroup.swift */; };
 		54863F3F6ECDD3BE00083582 /* Roster.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE543CB2E49335ADD02E8000 /* Roster.swift */; };
 		556BA960B3DFFACAB2F3DFA6 /* EnvironmentValues+Season.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6504EE31A645398C41BC2ED1 /* EnvironmentValues+Season.swift */; };
@@ -124,6 +125,7 @@
 		BDD14CA33B905F7A31910B1D /* SupabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10CD226D313FDD91E4037D8E /* SupabaseManager.swift */; };
 		BE71F196BAB7D9E78BE94A9D /* PlayerValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE87151F7F5AAB8F12F98B91 /* PlayerValue.swift */; };
 		BFAF90EB6F36235274ECB2DC /* HeadlineAIReportCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92075E680F858F8EB156001A /* HeadlineAIReportCard.swift */; };
+		C1B45AB2AF3DC33FE9B511AF /* EmailPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F22FF3CF671CAA9E80918C /* EmailPreview.swift */; };
 		C1D86EAE02F0D6EA70291876 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC70812B3E7E07BA6658A54 /* AvatarView.swift */; };
 		C21992E2FA476C65D8D23BA8 /* HexagonChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 501B8FD2B915B3BD6568F42C /* HexagonChartView.swift */; };
 		C381DCE8472D2F88B04FCBDA /* CareerStatsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CFD764A2BA7FF93B318A7F /* CareerStatsSection.swift */; };
@@ -145,6 +147,7 @@
 		E26F4617AAE9F2A917E951A6 /* LogsStubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B4330E790E5113D37E84B1 /* LogsStubView.swift */; };
 		E2E0551B857C17254E9B789B /* AdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E257076F7FE641947D1DC978 /* AdminView.swift */; };
 		E2EC532916CAA2FBB779DB35 /* UserStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62948D0A455E7CE99B15CB75 /* UserStore.swift */; };
+		E64E815819D87CED1DF5383F /* AIReviewPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6B846E697A235684C8EBA4 /* AIReviewPreviewView.swift */; };
 		EDDACB3FFB20E468D9D9D67D /* HeaderBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E7D0FD804723AC6A3E4298 /* HeaderBar.swift */; };
 		EE987501F73209179D5CEEB4 /* TestEmailStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E98CD5B3ECB6292B6D7637B /* TestEmailStore.swift */; };
 		F201A3A40D624F6AAA0C0CC1 /* PlayoffBracket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */; };
@@ -155,6 +158,7 @@
 		F7E0A8B9AECD0291527E0D0E /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F46A0AAE61A4E963BB15B0 /* SearchView.swift */; };
 		F9A37723FE37F4C30D46D6E1 /* PressableCardButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FB63BCA4BDD437FFE6D3A8 /* PressableCardButtonStyle.swift */; };
 		FAE7847413A293EF8CE9090C /* NFLTeamColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DF8F2FE857C55AFB1C1205 /* NFLTeamColors.swift */; };
+		FCC663F09AC754C35DF93A3D /* AdminStorePreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46FB9B5B4B8700EACD4A9CFD /* AdminStorePreviewTests.swift */; };
 		FCD03562C1879183A5DC02E2 /* PlayerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3F6B5022E8151683A45F4F /* PlayerStore.swift */; };
 /* End PBXBuildFile section */
 
@@ -197,12 +201,15 @@
 		43685B0C212A644C0EF202E5 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		43AC494E7D11CB94A2FD56EA /* LeaguePayouts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaguePayouts.swift; sourceTree = "<group>"; };
 		43E1C6D5A18697DE79586C1B /* WorldCupStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupStore.swift; sourceTree = "<group>"; };
+		44F22FF3CF671CAA9E80918C /* EmailPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailPreview.swift; sourceTree = "<group>"; };
 		44F83A5F997AF6E13C98660E /* WorldCupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupView.swift; sourceTree = "<group>"; };
 		45B52D5FD69B62417928B713 /* MatchupHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupHistory.swift; sourceTree = "<group>"; };
 		460030AF84E8D0E83D8F5896 /* Xomper.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Xomper.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4690614F644FE74115D0DAB6 /* ProposedTrade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProposedTrade.swift; sourceTree = "<group>"; };
 		46DB1025586B733C289B45A3 /* HistoricalStandingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoricalStandingsView.swift; sourceTree = "<group>"; };
+		46FB9B5B4B8700EACD4A9CFD /* AdminStorePreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStorePreviewTests.swift; sourceTree = "<group>"; };
 		47E50BF5631FC49F87923281 /* AuditStubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditStubView.swift; sourceTree = "<group>"; };
+		4D0F4D0BBA2C48A0232C43FF /* EmailPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailPreviewTests.swift; sourceTree = "<group>"; };
 		501B8FD2B915B3BD6568F42C /* HexagonChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HexagonChartView.swift; sourceTree = "<group>"; };
 		50D86A1E276C98E0A3D5070F /* MocksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MocksView.swift; sourceTree = "<group>"; };
 		536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthStore.swift; sourceTree = "<group>"; };
@@ -291,6 +298,7 @@
 		DBD0F6820960B354EAB3E89D /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		DC24A8748C940FC57B142AFF /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 		DE3B178733D5AF9EB7DA7189 /* XomperLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperLoader.swift; sourceTree = "<group>"; };
+		DE6B846E697A235684C8EBA4 /* AIReviewPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewPreviewView.swift; sourceTree = "<group>"; };
 		DF1A7B1219575171DA3ABAB7 /* StandingsScrollBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsScrollBar.swift; sourceTree = "<group>"; };
 		DF491605034E9F8C00BC0572 /* MatchupHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupHistoryView.swift; sourceTree = "<group>"; };
 		E0C5F37100E6EBB467EBFE1C /* SearchStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchStore.swift; sourceTree = "<group>"; };
@@ -443,6 +451,7 @@
 			isa = PBXGroup;
 			children = (
 				9AD03A165767A043D34A9499 /* AdminStorePreseasonTests.swift */,
+				46FB9B5B4B8700EACD4A9CFD /* AdminStorePreviewTests.swift */,
 				58ED7387DCA3E1DC5CDD7AFF /* AdminStoreTests.swift */,
 				6CFEC46AB65E6E7A90E0A695 /* AdminStoreWeeklyTests.swift */,
 				08BD215787E2BFC1C57E7E7E /* AIReviewStoreTests.swift */,
@@ -450,6 +459,7 @@
 				B3893B13276074EF6033CEA2 /* ClinchCalculatorTests.swift */,
 				2DB0B979B62A1CF6EB80417F /* DraftRecapResolverTests.swift */,
 				ED7456E9AFD3FA47DA3DA0F7 /* DraftSubTabSelectionTests.swift */,
+				4D0F4D0BBA2C48A0232C43FF /* EmailPreviewTests.swift */,
 				D7F3E6606D89CF3AEB320314 /* LandingViewTests.swift */,
 				7877A392F88F41B8D4979F23 /* MockDraftMetadataTests.swift */,
 				0BC1E989411B5FACF30C4B3A /* PastStandingsArchiveTests.swift */,
@@ -586,6 +596,7 @@
 				18383A0375F5728A9E3FE065 /* Championship.swift */,
 				7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */,
 				A789B8D49FA4430886626289 /* DraftHistory.swift */,
+				44F22FF3CF671CAA9E80918C /* EmailPreview.swift */,
 				765C03E7E4268373F28754DC /* HighestPossibleLineup.swift */,
 				FD88B55D96BD7C519B6B65B6 /* League.swift */,
 				43AC494E7D11CB94A2FD56EA /* LeaguePayouts.swift */,
@@ -668,6 +679,7 @@
 			isa = PBXGroup;
 			children = (
 				E257076F7FE641947D1DC978 /* AdminView.swift */,
+				DE6B846E697A235684C8EBA4 /* AIReviewPreviewView.swift */,
 				FB3748F7A26B406C00F1C546 /* AIReviewSubScreen.swift */,
 				47E50BF5631FC49F87923281 /* AuditStubView.swift */,
 				86B4330E790E5113D37E84B1 /* LogsStubView.swift */,
@@ -858,12 +870,14 @@
 			files = (
 				A0F4E9BCA7E5D757DE8BE5B3 /* AIReviewStoreTests.swift in Sources */,
 				A45E9B6A2A65059251FB3D76 /* AdminStorePreseasonTests.swift in Sources */,
+				FCC663F09AC754C35DF93A3D /* AdminStorePreviewTests.swift in Sources */,
 				37E600A31B5AA5DA5A766692 /* AdminStoreTests.swift in Sources */,
 				6D9C0E43C329D80ED8933AD2 /* AdminStoreWeeklyTests.swift in Sources */,
 				42F9C81AF6338A720FE0BC12 /* ArchiveNavigationTests.swift in Sources */,
 				02AC6FBAE68011749AA17644 /* ClinchCalculatorTests.swift in Sources */,
 				2BE0B9AB9BAEFD6AA714D2EF /* DraftRecapResolverTests.swift in Sources */,
 				E0951007574761D3F51B21B9 /* DraftSubTabSelectionTests.swift in Sources */,
+				50E9D9254D779960D0D2C5B1 /* EmailPreviewTests.swift in Sources */,
 				007B11207486956897981421 /* LandingViewTests.swift in Sources */,
 				3403B87830513963A9D86F8F /* MockDraftMetadataTests.swift in Sources */,
 				D9737CEB4C36AEFB5EC727D0 /* PastStandingsArchiveTests.swift in Sources */,
@@ -878,6 +892,7 @@
 				189F79187B5D4D5686909B2F /* AIReport.swift in Sources */,
 				42BF3DEE63074148F1DF0BD1 /* AIReviewDetailView.swift in Sources */,
 				04C5B75AA224E7ED8314FBA5 /* AIReviewHomeCard.swift in Sources */,
+				E64E815819D87CED1DF5383F /* AIReviewPreviewView.swift in Sources */,
 				73E3AB3D048A23D710376D09 /* AIReviewStore.swift in Sources */,
 				89E037BAB1BBE09EB642A101 /* AIReviewSubScreen.swift in Sources */,
 				68EE3E2F11A28AD898ABB03C /* AIReviewView.swift in Sources */,
@@ -907,6 +922,7 @@
 				6D833D6D3E53E0913363925C /* DraftSubTabBar.swift in Sources */,
 				3B1DDBCA7B19B8703FAF717E /* DrawerScrim.swift in Sources */,
 				817EEBDA82021E74A830E1B3 /* DrawerView.swift in Sources */,
+				C1B45AB2AF3DC33FE9B511AF /* EmailPreview.swift in Sources */,
 				72FF7B4516B2DCDAE4683B9D /* EmptyStateView.swift in Sources */,
 				556BA960B3DFFACAB2F3DFA6 /* EnvironmentValues+Season.swift in Sources */,
 				60FB3A9B54EAB11F015C1828 /* ErrorView.swift in Sources */,

--- a/Xomper/Core/Models/AIReport.swift
+++ b/Xomper/Core/Models/AIReport.swift
@@ -248,9 +248,15 @@ enum AIReportType: String, Codable, Sendable, CaseIterable, Hashable {
 ///   "delivery_count": 1,
 ///   "model": "claude-haiku-4-5",
 ///   "token_usage": { "input_tokens": 1234, "output_tokens": 567 },
-///   "report": { ...AIReport... }
+///   "report": { ...AIReport... },
+///   "previews": [ ...EmailPreview... ]  // F2: only present on dry_run=true
 /// }
 /// ```
+///
+/// `previews` is populated by the dry-run path only — broadcast
+/// (`dry_run=false`) responses leave it `nil`. See F2 plan for the
+/// cap rules and ordering guarantees (`docs/features/admin-portal/
+/// f2-preview/PLAN.md`).
 struct AIReviewTriggerResponse: Decodable, Sendable {
     let reportId: String
     let dryRun: Bool
@@ -258,6 +264,9 @@ struct AIReviewTriggerResponse: Decodable, Sendable {
     let model: String
     let tokenUsage: TokenUsage?
     let report: AIReport?
+    /// F2: rendered email previews, one per active whitelisted user.
+    /// Server pre-sorts by `display_name`. `nil` when `dry_run=false`.
+    let previews: [EmailPreview]?
 
     enum CodingKeys: String, CodingKey {
         case reportId = "report_id"
@@ -266,6 +275,7 @@ struct AIReviewTriggerResponse: Decodable, Sendable {
         case model
         case tokenUsage = "token_usage"
         case report
+        case previews
     }
 }
 

--- a/Xomper/Core/Models/EmailPreview.swift
+++ b/Xomper/Core/Models/EmailPreview.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// One rendered email preview returned by the three dry-run trigger
+/// endpoints (`/admin/ai-review-{postdraft,preseason,weekly}-trigger`).
+///
+/// Backend renders these via the same `build_email_payload` helper that
+/// the real broadcast path uses, so what the admin sees in the iOS
+/// preview list is exactly what would be delivered if they hit
+/// "Broadcast to all 12".
+///
+/// Wire shape (snake_case from the backend, server pre-sorts by
+/// `display_name` ascending):
+/// ```json
+/// {
+///   "recipient_user_id": "U123",
+///   "recipient_email": "user@example.com",
+///   "display_name": "Adam",
+///   "subject": "Week 4 Recap — 2026W04",
+///   "text_body": "..." // capped at 4096 chars server-side
+///   "html_body_excerpt": "..." // capped at 500 chars server-side
+/// }
+/// ```
+///
+/// Notes:
+/// - Server omits `html_body` entirely to keep payload <60KB for 12
+///   recipients. Only the excerpt comes over the wire.
+/// - `id` is derived from `recipientUserId` so SwiftUI `ForEach` /
+///   `.sheet(item:)` can use the struct directly.
+/// - F2 deliverable — see `docs/features/admin-portal/f2-preview/PLAN.md`.
+struct EmailPreview: Codable, Sendable, Identifiable, Hashable {
+    let recipientUserId: String
+    let recipientEmail: String
+    let displayName: String
+    let subject: String
+    let textBody: String
+    let htmlBodyExcerpt: String
+
+    var id: String { recipientUserId }
+
+    enum CodingKeys: String, CodingKey {
+        case recipientUserId = "recipient_user_id"
+        case recipientEmail = "recipient_email"
+        case displayName = "display_name"
+        case subject
+        case textBody = "text_body"
+        case htmlBodyExcerpt = "html_body_excerpt"
+    }
+}

--- a/Xomper/Core/Stores/AdminStore.swift
+++ b/Xomper/Core/Stores/AdminStore.swift
@@ -81,6 +81,16 @@ final class AdminStore {
     /// Driven by the override toggle + stepper on the weekly card.
     var weeklyWeekOverride: Int?
 
+    // MARK: - F2 Email Previews
+
+    /// In-memory store of rendered email previews per report type.
+    /// Populated after each successful dry-run trigger (when the
+    /// backend includes `previews` in the response). Broadcast
+    /// responses do NOT touch this — pre-broadcast previews remain
+    /// visible after a broadcast completes so the admin can compare.
+    /// Cleared on app restart (per F2 plan Q3 — no persistence).
+    private(set) var lastPreviewsByType: [AIReportType: [EmailPreview]] = [:]
+
     var filterKind: KindFilter = .all
     var filterStatus: StatusFilter = .all
 
@@ -186,6 +196,13 @@ final class AdminStore {
                 force: force
             )
             postDraftResult = response
+            // F2: capture rendered previews from the dry-run response.
+            // Broadcast responses leave `previews == nil`; we don't
+            // overwrite in that case so the admin can still see what
+            // was about to go out.
+            if let previews = response.previews {
+                lastPreviewsByType[.postDraft] = previews
+            }
             // Refresh latest so the card label updates from "Generate"
             // to "Regenerate (force)" on next render.
             await loadPostDraftLatest()
@@ -230,6 +247,10 @@ final class AdminStore {
                 force: force
             )
             preseasonResult = response
+            // F2: see notes on the post-draft equivalent above.
+            if let previews = response.previews {
+                lastPreviewsByType[.preseason] = previews
+            }
             // Refresh latest so the card label updates from "Generate"
             // to "Regenerate (force)" on next render.
             await loadPreseasonLatest()
@@ -283,6 +304,10 @@ final class AdminStore {
                 force: force
             )
             weeklyResult = response
+            // F2: see notes on the post-draft equivalent above.
+            if let previews = response.previews {
+                lastPreviewsByType[.weekly] = previews
+            }
             // Refresh latest so the card label updates from "Generate"
             // to "Regenerate (force)" on next render.
             await loadWeeklyLatest()
@@ -291,6 +316,15 @@ final class AdminStore {
             weeklyError = error
             throw error
         }
+    }
+
+    // MARK: - F2 Previews
+
+    /// Drops the in-memory preview set for one report type. Used by
+    /// tests + by the preview view after a successful broadcast so
+    /// stale previews don't linger past a successful send.
+    func clearPreviews(for reportType: AIReportType) {
+        lastPreviewsByType[reportType] = nil
     }
 
     func sendTest(

--- a/Xomper/Features/Admin/AIReviewPreviewView.swift
+++ b/Xomper/Features/Admin/AIReviewPreviewView.swift
@@ -1,0 +1,372 @@
+import SwiftUI
+
+/// F2 — pre-broadcast email preview list. Pushed from
+/// `AIReviewSubScreen` after a successful dry-run trigger via
+/// `router.navigate(to: .adminAIReviewPreview(reportType:))`.
+///
+/// Behavior:
+/// - Header: report type + the number of rendered previews.
+/// - "Broadcast to all" gold capsule at top. Tapping shows an
+///   `.alert(...)` confirm dialog (destructive role) so single-tap
+///   misfires can't happen.
+/// - Scrolling list of `EmailPreviewRow`s; tapping a row presents an
+///   `AIReviewPreviewDetailView` sheet with the full subject + body.
+/// - Server pre-sorts by `display_name`; iOS does **not** re-sort.
+///
+/// Previews live in `AdminStore.lastPreviewsByType[reportType]`, which
+/// is populated on each successful dry-run. The store is hoisted to
+/// `MainShell` so this view reads the same instance as the trigger
+/// card it was pushed from (F2 plan B5).
+struct AIReviewPreviewView: View {
+    let reportType: AIReportType
+    var adminStore: AdminStore
+    var router: AppRouter
+
+    @State private var selectedPreview: EmailPreview?
+    @State private var showBroadcastConfirm = false
+    @State private var broadcastError: String?
+
+    var body: some View {
+        content
+            .background(XomperColors.bgDark.ignoresSafeArea())
+            .navigationTitle("\(reportType.displayName) Previews")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .sheet(item: $selectedPreview) { preview in
+                AIReviewPreviewDetailView(preview: preview)
+            }
+            .alert(
+                "Broadcast \(reportType.displayName) to all \(previews.count)?",
+                isPresented: $showBroadcastConfirm
+            ) {
+                Button("Cancel", role: .cancel) { }
+                Button("Broadcast", role: .destructive) {
+                    Task { await broadcast() }
+                }
+            } message: {
+                Text("This cannot be undone. Every preview you see will be sent for real.")
+            }
+    }
+
+    // MARK: - Derived state
+
+    private var previews: [EmailPreview] {
+        adminStore.lastPreviewsByType[reportType] ?? []
+    }
+
+    private var isTriggerInFlight: Bool {
+        switch reportType {
+        case .postDraft: return adminStore.isTriggeringPostDraft
+        case .preseason: return adminStore.isTriggeringPreseason
+        case .weekly:    return adminStore.isTriggeringWeekly
+        case .mock:      return false
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        if previews.isEmpty {
+            EmptyStateView(
+                icon: "tray",
+                title: "No previews yet",
+                message: "Fire a dry-run from the AI Review screen first."
+            )
+        } else {
+            ScrollView {
+                VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
+                    headerCard
+
+                    broadcastButton
+
+                    if let broadcastError {
+                        Text("✗ \(broadcastError)")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(XomperColors.errorRed)
+                            .padding(.horizontal, XomperTheme.Spacing.md)
+                    }
+
+                    listHeader
+
+                    LazyVStack(spacing: XomperTheme.Spacing.sm) {
+                        ForEach(previews) { preview in
+                            EmailPreviewRow(preview: preview) {
+                                selectedPreview = preview
+                            }
+                        }
+                    }
+                    .padding(.horizontal, XomperTheme.Spacing.md)
+                }
+                .padding(.vertical, XomperTheme.Spacing.sm)
+                .padding(.bottom, XomperTheme.Spacing.xl)
+            }
+        }
+    }
+
+    // MARK: - Header card
+
+    private var headerCard: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                Image(systemName: reportType.systemImage)
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(reportType.accentColor)
+                Text(reportType.displayName)
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+            }
+            Text("\(previews.count) rendered \(previews.count == 1 ? "preview" : "previews"). Tap a row to read it in full.")
+                .font(.caption)
+                .foregroundStyle(XomperColors.textSecondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(reportType.accentColor.opacity(0.3), lineWidth: 1)
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    // MARK: - Broadcast button
+
+    private var broadcastButton: some View {
+        Button {
+            let generator = UIImpactFeedbackGenerator(style: .medium)
+            generator.impactOccurred()
+            showBroadcastConfirm = true
+        } label: {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                if isTriggerInFlight {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                        .tint(XomperColors.bgDark)
+                } else {
+                    Image(systemName: "paperplane.fill")
+                        .font(.caption2)
+                }
+                Text(isTriggerInFlight ? "Broadcasting…" : "Broadcast to all \(previews.count)")
+                    .font(.subheadline.weight(.bold))
+            }
+            .foregroundStyle(XomperColors.bgDark)
+            .padding(.horizontal, XomperTheme.Spacing.md)
+            .padding(.vertical, XomperTheme.Spacing.sm)
+            .frame(maxWidth: .infinity, minHeight: XomperTheme.minTouchTarget)
+            .background(isTriggerInFlight ? XomperColors.championGold.opacity(0.5) : XomperColors.championGold)
+            .clipShape(Capsule())
+        }
+        .buttonStyle(.pressableCard)
+        .disabled(isTriggerInFlight)
+        .padding(.horizontal, XomperTheme.Spacing.md)
+        .accessibilityLabel("Broadcast \(reportType.displayName) recap to all \(previews.count) recipients")
+        .accessibilityHint("Opens a confirmation dialog before sending.")
+    }
+
+    // MARK: - List header
+
+    private var listHeader: some View {
+        Text("Recipients")
+            .font(.caption.weight(.bold))
+            .textCase(.uppercase)
+            .tracking(0.5)
+            .foregroundStyle(XomperColors.textMuted)
+            .padding(.horizontal, XomperTheme.Spacing.md)
+            .padding(.top, XomperTheme.Spacing.sm)
+    }
+
+    // MARK: - Broadcast
+
+    /// Fires the same trigger endpoint with `dryRun=false, force=true`.
+    /// Clears local previews + pops back on success. On failure we leave
+    /// the previews intact and surface the error inline so the admin
+    /// can retry.
+    private func broadcast() async {
+        broadcastError = nil
+        do {
+            switch reportType {
+            case .postDraft:
+                _ = try await adminStore.triggerPostDraft(dryRun: false, force: true)
+            case .preseason:
+                _ = try await adminStore.triggerPreseason(dryRun: false, force: true)
+            case .weekly:
+                _ = try await adminStore.triggerWeekly(
+                    week: adminStore.weeklyWeekOverride,
+                    dryRun: false,
+                    force: true
+                )
+            case .mock:
+                broadcastError = "Mock drafts can't be broadcast from this screen."
+                return
+            }
+            adminStore.clearPreviews(for: reportType)
+            router.path.removeLast()
+        } catch {
+            broadcastError = error.localizedDescription
+        }
+    }
+}
+
+// MARK: - Row
+
+/// Single preview row. Surfaces display name + email + subject + a
+/// 3-line excerpt of the text body so the admin can scan without
+/// opening the sheet. Whole row is tappable.
+struct EmailPreviewRow: View {
+    let preview: EmailPreview
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(alignment: .top, spacing: XomperTheme.Spacing.sm) {
+                VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+                    HStack(spacing: XomperTheme.Spacing.xs) {
+                        Text(preview.displayName)
+                            .font(.subheadline.weight(.bold))
+                            .foregroundStyle(XomperColors.championGold)
+                            .lineLimit(1)
+                        Text(preview.recipientEmail)
+                            .font(.caption2)
+                            .foregroundStyle(XomperColors.textMuted)
+                            .lineLimit(1)
+                    }
+                    Text(preview.subject)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(XomperColors.textPrimary)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                    Text(snippet)
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textSecondary)
+                        .lineLimit(3)
+                        .multilineTextAlignment(.leading)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.bold))
+                    .foregroundStyle(XomperColors.textMuted)
+                    .accessibilityHidden(true)
+            }
+            .padding(XomperTheme.Spacing.md)
+            .frame(minHeight: XomperTheme.minTouchTarget)
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+            .overlay(
+                RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                    .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Preview for \(preview.displayName), subject \(preview.subject)")
+        .accessibilityHint("Double tap to read the full body.")
+    }
+
+    /// First non-blank line(s) of the text body, condensed for the row
+    /// excerpt. Falls back to the raw start of `textBody` when there
+    /// are no non-blank lines (defensive — shouldn't happen).
+    private var snippet: String {
+        let trimmed = preview.textBody
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .prefix(3)
+            .joined(separator: " ")
+        return trimmed.isEmpty
+            ? String(preview.textBody.prefix(120))
+            : trimmed
+    }
+}
+
+// MARK: - Detail sheet
+
+/// Detail sheet pushed via `.sheet(item:)` from the preview list.
+/// Renders the full subject + plain-text body. Body is interpreted
+/// as markdown via `AttributedString(markdown:)` (consistent with
+/// `AIReviewDetailView` + `DraftRecapView`) so headings and bold
+/// from the template render naturally.
+struct AIReviewPreviewDetailView: View {
+    let preview: EmailPreview
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
+                    headerCard
+                    bodyCard
+                }
+                .padding(XomperTheme.Spacing.md)
+                .padding(.bottom, XomperTheme.Spacing.xxl)
+            }
+            .background(XomperColors.bgDark.ignoresSafeArea())
+            .navigationTitle("Preview")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(XomperColors.championGold)
+                }
+            }
+        }
+    }
+
+    private var headerCard: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            Text(preview.displayName)
+                .font(.title3.weight(.bold))
+                .foregroundStyle(XomperColors.championGold)
+            Text(preview.recipientEmail)
+                .font(.caption)
+                .foregroundStyle(XomperColors.textMuted)
+                .textSelection(.enabled)
+            Text(preview.subject)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(XomperColors.textPrimary)
+                .padding(.top, XomperTheme.Spacing.xs)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    private var bodyCard: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            renderedBody
+                .font(.body)
+                .foregroundStyle(XomperColors.textPrimary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+    }
+
+    /// Best-effort markdown rendering. Falls back to the raw plain
+    /// text when the markdown parser rejects the input — the wire
+    /// `text_body` field is already plain text but happens to look
+    /// like markdown for templates that include headings and lists.
+    private var renderedBody: some View {
+        Group {
+            if let attributed = try? AttributedString(
+                markdown: preview.textBody,
+                options: AttributedString.MarkdownParsingOptions(
+                    interpretedSyntax: .full
+                )
+            ) {
+                Text(attributed)
+            } else {
+                Text(preview.textBody)
+            }
+        }
+    }
+}

--- a/Xomper/Features/Admin/AIReviewSubScreen.swift
+++ b/Xomper/Features/Admin/AIReviewSubScreen.swift
@@ -10,13 +10,25 @@ import SwiftUI
 /// look identical to the pre-refactor screen — reviewers should pixel-
 /// diff a recording against the previous AdminView.
 ///
-/// Owns its own `AdminStore` instance (same as the pre-refactor
-/// `AdminView` did). Re-runs `.task` whenever the caller's
-/// `callerSleeperId` changes so the activity feed re-scopes.
+/// `AdminStore` is **injected** from `MainShell` (F2 hoist) so the
+/// preview view route can read the same instance — without the hoist a
+/// pushed `AIReviewPreviewView` would see an empty `lastPreviewsByType`
+/// dictionary because `AIReviewSubScreen`'s `@State` doesn't survive
+/// the navigation push.
 struct AIReviewSubScreen: View {
     var authStore: AuthStore
     var leagueStore: LeagueStore
-    @State private var store = AdminStore()
+    /// F2: hoisted from `@State` to an injected dependency so the
+    /// pushed `AIReviewPreviewView` can read the same preview state.
+    /// Keeping the `store` label (rather than renaming to `adminStore`)
+    /// preserves every existing call site inside the view body. We
+    /// use `@Bindable` so the existing `$store.foo` binding sites
+    /// (toggles, pickers, stepper) keep compiling.
+    @Bindable var store: AdminStore
+    /// F2: needed so the trigger cards can navigate to the new
+    /// `adminAIReviewPreview(reportType:)` route after a successful
+    /// dry-run populates `store.lastPreviewsByType`.
+    var router: AppRouter
 
     var body: some View {
         content
@@ -175,6 +187,8 @@ struct AIReviewSubScreen: View {
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(XomperColors.errorRed)
             }
+
+            previewsButton(for: .postDraft)
         }
         .padding(XomperTheme.Spacing.md)
         .background(XomperColors.bgCard)
@@ -316,6 +330,8 @@ struct AIReviewSubScreen: View {
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(XomperColors.errorRed)
             }
+
+            previewsButton(for: .preseason)
         }
         .padding(XomperTheme.Spacing.md)
         .background(XomperColors.bgCard)
@@ -505,6 +521,8 @@ struct AIReviewSubScreen: View {
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(XomperColors.errorRed)
             }
+
+            previewsButton(for: .weekly)
         }
         .padding(XomperTheme.Spacing.md)
         .background(XomperColors.bgCard)
@@ -555,6 +573,42 @@ struct AIReviewSubScreen: View {
             )
         } catch {
             // Error already surfaced via store.weeklyError.
+        }
+    }
+
+    // MARK: - Preview entry point (F2)
+
+    /// Gold outline capsule shown under each trigger card when
+    /// `store.lastPreviewsByType[reportType]` is non-empty. Tapping
+    /// pushes the F2 preview screen onto the existing nav stack.
+    @ViewBuilder
+    private func previewsButton(for reportType: AIReportType) -> some View {
+        if let previews = store.lastPreviewsByType[reportType], !previews.isEmpty {
+            Button {
+                let generator = UIImpactFeedbackGenerator(style: .light)
+                generator.impactOccurred()
+                router.navigate(to: .adminAIReviewPreview(reportType: reportType))
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "eye.fill")
+                        .font(.caption2)
+                    Text("View \(previews.count) previews")
+                        .font(.caption.weight(.semibold))
+                    Image(systemName: "chevron.right")
+                        .font(.caption2.weight(.bold))
+                }
+                .foregroundStyle(XomperColors.championGold)
+                .padding(.horizontal, XomperTheme.Spacing.sm)
+                .padding(.vertical, XomperTheme.Spacing.xs)
+                .frame(minHeight: 32)
+                .overlay(
+                    Capsule()
+                        .strokeBorder(XomperColors.championGold.opacity(0.6), lineWidth: 1)
+                )
+            }
+            .buttonStyle(.pressableCard)
+            .accessibilityLabel("View \(previews.count) email previews for \(reportType.displayName)")
+            .accessibilityHint("Double tap to review what would be broadcast.")
         }
     }
 

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -31,6 +31,12 @@ struct MainShell: View {
     @State private var valuesStore = PlayerValuesStore()
     @State private var playerPointsStore = PlayerPointsStore()
     @State private var aiReviewStore = AIReviewStore()
+    /// F2 hoist: previously owned by `AIReviewSubScreen` as `@State`.
+    /// Lifted up so the new `AIReviewPreviewView` route can read the
+    /// same instance — without the hoist a fresh `AdminStore` would
+    /// spin up per push and `lastPreviewsByType` would be empty.
+    /// See `docs/features/admin-portal/f2-preview/PLAN.md` B5.
+    @State private var adminStore = AdminStore()
 
     // MARK: - Body
 
@@ -496,7 +502,9 @@ struct MainShell: View {
         case .adminAIReview:
             AIReviewSubScreen(
                 authStore: authStore,
-                leagueStore: leagueStore
+                leagueStore: leagueStore,
+                store: adminStore,
+                router: router
             )
 
         case .adminTestEmail:
@@ -513,6 +521,13 @@ struct MainShell: View {
 
         case .adminAudit:
             AuditStubView()
+
+        case .adminAIReviewPreview(let reportType):
+            AIReviewPreviewView(
+                reportType: reportType,
+                adminStore: adminStore,
+                router: router
+            )
         }
     }
 

--- a/Xomper/Navigation/AppRouter.swift
+++ b/Xomper/Navigation/AppRouter.swift
@@ -63,6 +63,14 @@ enum AppRoute: Hashable {
     /// Pushed from `AdminView`'s menu — stub destination for F4's
     /// Audit sub-feature (recent admin actions feed).
     case adminAudit
+
+    // MARK: - Admin Portal (F2)
+
+    /// Pushed from `AIReviewSubScreen` after a successful dry-run
+    /// trigger. Hosts the pre-broadcast email preview list — one row
+    /// per active whitelisted user. Source data lives in
+    /// `AdminStore.lastPreviewsByType[reportType]`. F2 deliverable.
+    case adminAIReviewPreview(reportType: AIReportType)
 }
 
 /// Owns the inner `NavigationStack` path inside `MainShell`. The drawer

--- a/XomperTests/AdminStorePreviewTests.swift
+++ b/XomperTests/AdminStorePreviewTests.swift
@@ -1,0 +1,198 @@
+import XCTest
+@testable import Xomper
+
+/// F2 — verifies `AdminStore.lastPreviewsByType` populates after each
+/// successful dry-run trigger, and that broadcast (non-dry-run)
+/// responses don't pollute the dictionary. Reuses
+/// `MockAdminAPIClient` from `AdminStoreTests.swift`.
+@MainActor
+final class AdminStorePreviewTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeTriggerResponse(
+        reportType: AIReportType,
+        dryRun: Bool,
+        previewNames: [String]?
+    ) -> AIReviewTriggerResponse {
+        let previewsJson: String
+        if let previewNames {
+            let rows = previewNames.enumerated().map { (idx, name) in
+                """
+                {
+                  "recipient_user_id": "U\(idx)",
+                  "recipient_email": "u\(idx)@x.com",
+                  "display_name": "\(name)",
+                  "subject": "Subject for \(name)",
+                  "text_body": "Body for \(name)",
+                  "html_body_excerpt": "<html>\(name)</html>"
+                }
+                """
+            }.joined(separator: ",")
+            previewsJson = ", \"previews\": [\(rows)]"
+        } else {
+            previewsJson = ""
+        }
+
+        let typeId: String
+        switch reportType {
+        case .postDraft: typeId = "postDraft#2026"
+        case .preseason: typeId = "preseason#2026-PRESEASON"
+        case .weekly:    typeId = "weekly#2026W04"
+        case .mock:      typeId = "mock#test"
+        }
+
+        let json = """
+        {
+          "report_id": "L1|REPORT#\(typeId)",
+          "dry_run": \(dryRun),
+          "delivery_count": \(previewNames?.count ?? 12),
+          "model": "claude-haiku-4-5",
+          "token_usage": { "input_tokens": 100, "output_tokens": 50 }\(previewsJson)
+        }
+        """
+        return try! JSONDecoder().decode(
+            AIReviewTriggerResponse.self,
+            from: Data(json.utf8)
+        )
+    }
+
+    // MARK: - Post-draft populates previews
+
+    func testTriggerPostDraft_populatesLastPreviewsByType() async throws {
+        let response = makeTriggerResponse(
+            reportType: .postDraft,
+            dryRun: true,
+            previewNames: ["Adam", "Beth", "Mike"]
+        )
+        let mock = MockAdminAPIClient(triggerResponse: response)
+        let store = AdminStore(apiClient: mock)
+
+        _ = try await store.triggerPostDraft(dryRun: true, force: false)
+
+        XCTAssertEqual(store.lastPreviewsByType[.postDraft]?.count, 3)
+        XCTAssertEqual(
+            store.lastPreviewsByType[.postDraft]?.map(\.displayName),
+            ["Adam", "Beth", "Mike"]
+        )
+        // Other types untouched.
+        XCTAssertNil(store.lastPreviewsByType[.preseason])
+        XCTAssertNil(store.lastPreviewsByType[.weekly])
+    }
+
+    /// Broadcast responses leave `previews == nil`. Critically, the
+    /// store must NOT overwrite a previously-populated preview set
+    /// with an empty one — that would erase what the admin scanned
+    /// just before hitting Broadcast.
+    func testTriggerPostDraft_broadcastDoesNotPollutePreviews() async throws {
+        // 1) Dry-run populates 12 previews.
+        let dryResponse = makeTriggerResponse(
+            reportType: .postDraft,
+            dryRun: true,
+            previewNames: (0..<12).map { "User\($0)" }
+        )
+        let mock = MockAdminAPIClient(triggerResponse: dryResponse)
+        let store = AdminStore(apiClient: mock)
+
+        _ = try await store.triggerPostDraft(dryRun: true, force: false)
+        XCTAssertEqual(store.lastPreviewsByType[.postDraft]?.count, 12)
+
+        // 2) Broadcast — same mock but swap in a response w/o previews.
+        let broadcastResponse = makeTriggerResponse(
+            reportType: .postDraft,
+            dryRun: false,
+            previewNames: nil
+        )
+        mock.triggerResponse = broadcastResponse
+
+        _ = try await store.triggerPostDraft(dryRun: false, force: true)
+
+        // Previews stay intact so the admin can still see what went out.
+        XCTAssertEqual(store.lastPreviewsByType[.postDraft]?.count, 12)
+    }
+
+    // MARK: - Preseason populates previews
+
+    func testTriggerPreseason_populatesLastPreviewsByType() async throws {
+        let response = makeTriggerResponse(
+            reportType: .preseason,
+            dryRun: true,
+            previewNames: ["Adam", "Beth"]
+        )
+        let mock = MockAdminAPIClient(preseasonTriggerResponse: response)
+        let store = AdminStore(apiClient: mock)
+
+        _ = try await store.triggerPreseason(dryRun: true, force: false)
+
+        XCTAssertEqual(store.lastPreviewsByType[.preseason]?.count, 2)
+        XCTAssertNil(store.lastPreviewsByType[.postDraft])
+    }
+
+    // MARK: - Weekly populates previews
+
+    func testTriggerWeekly_populatesLastPreviewsByType() async throws {
+        let response = makeTriggerResponse(
+            reportType: .weekly,
+            dryRun: true,
+            previewNames: ["Adam"]
+        )
+        let mock = MockAdminAPIClient(weeklyTriggerResponse: response)
+        let store = AdminStore(apiClient: mock)
+
+        _ = try await store.triggerWeekly(week: 4, dryRun: true, force: false)
+
+        XCTAssertEqual(store.lastPreviewsByType[.weekly]?.count, 1)
+        XCTAssertEqual(store.lastPreviewsByType[.weekly]?.first?.displayName, "Adam")
+    }
+
+    // MARK: - clearPreviews
+
+    func testClearPreviews_removesKey() async throws {
+        let response = makeTriggerResponse(
+            reportType: .postDraft,
+            dryRun: true,
+            previewNames: ["Adam"]
+        )
+        let mock = MockAdminAPIClient(triggerResponse: response)
+        let store = AdminStore(apiClient: mock)
+
+        _ = try await store.triggerPostDraft(dryRun: true, force: false)
+        XCTAssertNotNil(store.lastPreviewsByType[.postDraft])
+
+        store.clearPreviews(for: .postDraft)
+
+        XCTAssertNil(store.lastPreviewsByType[.postDraft])
+    }
+
+    // MARK: - Cross-type isolation
+
+    /// Trigger postDraft then preseason; both keys should exist and
+    /// neither should overwrite the other.
+    func testCrossTypeIsolation_keysCoexist() async throws {
+        let postDraftResponse = makeTriggerResponse(
+            reportType: .postDraft,
+            dryRun: true,
+            previewNames: ["Adam", "Beth"]
+        )
+        let preseasonResponse = makeTriggerResponse(
+            reportType: .preseason,
+            dryRun: true,
+            previewNames: ["Carlos"]
+        )
+        let mock = MockAdminAPIClient(
+            triggerResponse: postDraftResponse,
+            preseasonTriggerResponse: preseasonResponse
+        )
+        let store = AdminStore(apiClient: mock)
+
+        _ = try await store.triggerPostDraft(dryRun: true, force: false)
+        _ = try await store.triggerPreseason(dryRun: true, force: false)
+
+        XCTAssertEqual(store.lastPreviewsByType[.postDraft]?.count, 2)
+        XCTAssertEqual(store.lastPreviewsByType[.preseason]?.count, 1)
+        XCTAssertEqual(
+            store.lastPreviewsByType[.preseason]?.first?.displayName,
+            "Carlos"
+        )
+    }
+}

--- a/XomperTests/EmailPreviewTests.swift
+++ b/XomperTests/EmailPreviewTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+@testable import Xomper
+
+/// Decoder coverage for the new `EmailPreview` wire shape returned by
+/// the three AI Review dry-run trigger endpoints. The struct ships in
+/// F2 — see `docs/features/admin-portal/f2-preview/PLAN.md`.
+final class EmailPreviewTests: XCTestCase {
+
+    // MARK: - Happy path
+
+    func testDecode_mapsSnakeCaseKeys() throws {
+        let json = """
+        {
+          "recipient_user_id": "U123",
+          "recipient_email": "adam@example.com",
+          "display_name": "Adam",
+          "subject": "Week 4 Recap",
+          "text_body": "Adam,\\n\\nNice win.",
+          "html_body_excerpt": "<html>hi</html>"
+        }
+        """
+
+        let preview = try JSONDecoder().decode(
+            EmailPreview.self,
+            from: Data(json.utf8)
+        )
+
+        XCTAssertEqual(preview.recipientUserId, "U123")
+        XCTAssertEqual(preview.recipientEmail, "adam@example.com")
+        XCTAssertEqual(preview.displayName, "Adam")
+        XCTAssertEqual(preview.subject, "Week 4 Recap")
+        XCTAssertEqual(preview.textBody, "Adam,\n\nNice win.")
+        XCTAssertEqual(preview.htmlBodyExcerpt, "<html>hi</html>")
+    }
+
+    /// `id` is derived from `recipientUserId` so `ForEach` /
+    /// `.sheet(item:)` can use the struct directly without an
+    /// auxiliary identifier.
+    func testIdentifiable_idEqualsRecipientUserId() throws {
+        let json = """
+        {
+          "recipient_user_id": "ABC",
+          "recipient_email": "x@y.com",
+          "display_name": "X",
+          "subject": "s",
+          "text_body": "t",
+          "html_body_excerpt": ""
+        }
+        """
+        let preview = try JSONDecoder().decode(
+            EmailPreview.self,
+            from: Data(json.utf8)
+        )
+        XCTAssertEqual(preview.id, "ABC")
+        XCTAssertEqual(preview.id, preview.recipientUserId)
+    }
+
+    /// All fields are required — a missing key should fail to decode.
+    /// Locks the contract so the backend can't silently drop a field
+    /// without the iOS tests flagging it.
+    func testDecode_throwsOnMissingField() {
+        let json = """
+        {
+          "recipient_user_id": "U123",
+          "recipient_email": "adam@example.com",
+          "display_name": "Adam",
+          "subject": "Week 4 Recap"
+        }
+        """
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(EmailPreview.self, from: Data(json.utf8))
+        )
+    }
+
+    // MARK: - Trigger response coupling
+
+    /// `AIReviewTriggerResponse.previews` is the wire-level surface
+    /// that carries the array on `dry_run=true` responses. This test
+    /// asserts the optional decode picks up the array correctly.
+    func testTriggerResponse_decodesPreviewsArray() throws {
+        let json = """
+        {
+          "report_id": "L1|REPORT#postDraft#2026",
+          "dry_run": true,
+          "delivery_count": 1,
+          "model": "claude-haiku-4-5",
+          "token_usage": { "input_tokens": 100, "output_tokens": 50 },
+          "previews": [
+            {
+              "recipient_user_id": "U1",
+              "recipient_email": "a@x.com",
+              "display_name": "Adam",
+              "subject": "S1",
+              "text_body": "B1",
+              "html_body_excerpt": "H1"
+            },
+            {
+              "recipient_user_id": "U2",
+              "recipient_email": "b@x.com",
+              "display_name": "Beth",
+              "subject": "S2",
+              "text_body": "B2",
+              "html_body_excerpt": "H2"
+            }
+          ]
+        }
+        """
+
+        let response = try JSONDecoder().decode(
+            AIReviewTriggerResponse.self,
+            from: Data(json.utf8)
+        )
+
+        XCTAssertEqual(response.previews?.count, 2)
+        XCTAssertEqual(response.previews?.first?.displayName, "Adam")
+        XCTAssertEqual(response.previews?.last?.displayName, "Beth")
+    }
+
+    /// Broadcast responses don't include `previews` — it must remain
+    /// optional so existing decode paths (and the F1 broadcast surface)
+    /// keep working unchanged.
+    func testTriggerResponse_previewsOptional() throws {
+        let json = """
+        {
+          "report_id": "L1|REPORT#postDraft#2026",
+          "dry_run": false,
+          "delivery_count": 12,
+          "model": "claude-haiku-4-5",
+          "token_usage": { "input_tokens": 100, "output_tokens": 50 }
+        }
+        """
+
+        let response = try JSONDecoder().decode(
+            AIReviewTriggerResponse.self,
+            from: Data(json.utf8)
+        )
+
+        XCTAssertNil(response.previews)
+    }
+}


### PR DESCRIPTION
## Summary

iOS portion of Admin Portal F2 — the pre-broadcast 12-user email preview screen. After an admin fires a dry-run trigger, they get a "View N previews" button under that card. Tap it to scan the rendered emails recipient-by-recipient, then hit "Broadcast to all N" (with a destructive confirm dialog) to fire the real broadcast.

Backend contract (already deployed, see PR #66) attaches `previews: [EmailPreview]` to dry-run trigger responses. Broadcast responses leave it `nil`.

Closes #91

## Plan
- iOS plan: `docs/features/admin-portal/f2-preview/PLAN.md` (Phase B)
- Backend dep: PR #66 (`xomper-back-end`)

## Files

**New**
- `Xomper/Core/Models/EmailPreview.swift` — Codable + Sendable + Identifiable + Hashable struct, snake_case CodingKeys, `id` from `recipient_user_id`.
- `Xomper/Features/Admin/AIReviewPreviewView.swift` — preview list + `EmailPreviewRow` + `AIReviewPreviewDetailView` sheet (markdown body).
- `XomperTests/EmailPreviewTests.swift` — 5 tests covering wire-format decode + optional handling.
- `XomperTests/AdminStorePreviewTests.swift` — 6 tests covering store population, broadcast-doesn't-pollute, isolation, clear.

**Modified**
- `Xomper/Core/Models/AIReport.swift` — `AIReviewTriggerResponse` gains optional `previews: [EmailPreview]?`.
- `Xomper/Core/Stores/AdminStore.swift` — `lastPreviewsByType` dict + `clearPreviews(for:)`. Each trigger only sets the dict when `response.previews != nil` so broadcast can't erase a useful preview set.
- `Xomper/Features/Admin/AIReviewSubScreen.swift` — hoist `AdminStore` from `@State` to injected `@Bindable` param; accept `router: AppRouter`; add "View N previews" capsule under each trigger card when previews exist.
- `Xomper/Features/Shell/MainShell.swift` — own `adminStore` as `@State`, thread into `AIReviewSubScreen` + new preview destination.
- `Xomper/Navigation/AppRouter.swift` — `case adminAIReviewPreview(reportType: AIReportType)`.

## Key decisions

- **AdminStore hoist (the only refactor risk).** Previously owned by `AIReviewSubScreen` as `@State`; lifted up so the preview view route can read the same instance. Without the hoist a fresh store would spin up per push and `lastPreviewsByType` would be empty.
- **`@Bindable` annotation.** Existing `$store.postDraftDryRun` toggle / `$store.filterKind` picker / weekly stepper sites need the projected-value `$` syntax. Passing the store as a plain `var` would break those — `@Bindable` fixes it without touching the body.
- **Broadcast doesn't clear previews.** Per Q3, in-memory only. We deliberately keep the preview set populated post-broadcast so the admin can compare against what went out. `clearPreviews(for:)` runs after a successful in-screen broadcast and pops back.
- **Server pre-sorts.** iOS does NOT re-sort the `previews` array.
- **Destructive confirm dialog.** `.alert(...)` with `.destructive("Broadcast")` action on top of the gold capsule. Single-tap broadcast was deemed too easy to misfire.
- **Markdown rendering.** Detail sheet uses `AttributedString(markdown:)` (consistent with `AIReviewDetailView` + `DraftRecapView`) so heading + bold from templates render naturally. Falls back to plain `Text` if the parser rejects.

## Test plan

- [x] `xcodegen generate` clean
- [x] Build for iPhone 17 Pro simulator — clean (no new warnings)
- [x] All 97 tests pass (added 11 new tests; previous 86 unchanged)
- [x] F1 functionality survives the AdminStore hoist (trigger cards still bind `$store.postDraftDryRun` etc; activity feed task still runs)
- [ ] Manual QA on simulator: fire dry-run → view previews → broadcast confirm flow
- [ ] Manual QA: force-quit + relaunch drops previews (in-memory only)

## Out of scope

- HTML rendering in the detail sheet (V1 shows text_body interpreted as markdown).
- Persistence across app restarts (deliberate — see Q3).
- Audit-log integration (F4 deliverable).