### PR TITLE
feat(admin-portal F3): iOS — redact, DNB toggle, broadcast_at

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		1AFF6ACF05FD9FC1D186C5A8 /* StandingsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34E8D4C4B1A29FC412EBA41 /* StandingsListView.swift */; };
 		1C4049A62CC4A443AC38E464 /* Draft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */; };
 		1D279CC4379E6F068F2615DE /* RuleProposalFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B6C68E1131F2BBBE625DEAF /* RuleProposalFormView.swift */; };
+		1D67D0B027D9C2AA6E033E38 /* ReportFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DBFB7D900A09D0B904F5836 /* ReportFlag.swift */; };
 		1D74425C19EE5C00589214C3 /* TaxiSquadPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2DA1B65780757E6CC78CD61 /* TaxiSquadPlayer.swift */; };
 		2378DF41F2BB3933117897A7 /* MatchupHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B52D5FD69B62417928B713 /* MatchupHistory.swift */; };
 		284F17C4CD26363D19756E03 /* TrayProfileCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3FE7B1A468AA2569D95B20 /* TrayProfileCard.swift */; };
@@ -97,6 +98,7 @@
 		83E71E429B2F8B4B7AEBAB96 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD0F6820960B354EAB3E89D /* LoadingView.swift */; };
 		86412A35609319AF08D413D3 /* TaxiSquadStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6387E34B6FA70159F3F9D80A /* TaxiSquadStore.swift */; };
 		89E037BAB1BBE09EB642A101 /* AIReviewSubScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB3748F7A26B406C00F1C546 /* AIReviewSubScreen.swift */; };
+		8BADB9CC50C4CA7FAE7370AF /* AdminStoreFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98366CAC5A10DA7462A41E7B /* AdminStoreFlagTests.swift */; };
 		8C2ABA833D6AB1C5A3017BDA /* LeaguePayouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AC494E7D11CB94A2FD56EA /* LeaguePayouts.swift */; };
 		8C58AAB4103D2F8A473DAA4E /* MocksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D86A1E276C98E0A3D5070F /* MocksView.swift */; };
 		8C67D3AAFE5A0A124BDE5F1A /* AppRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EABD25CAB8BF973C4709720 /* AppRouter.swift */; };
@@ -110,6 +112,7 @@
 		9B5472B757330119136683F1 /* PastDraftPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806CFC3CC188242F06D8639C /* PastDraftPickerView.swift */; };
 		9D9E8D2C4A8A0C623AC1EF0D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E767CD5492176E84C2092B0F /* AppDelegate.swift */; };
 		9E5C71DAB504EDCDF2084DF3 /* MyProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558164667DF7D89C4DF2F32E /* MyProfileView.swift */; };
+		9FA30DE0724E90F9914ED3BA /* ReportFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D61FC118C0250CA87BDF647 /* ReportFlagTests.swift */; };
 		A0F4E9BCA7E5D757DE8BE5B3 /* AIReviewStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08BD215787E2BFC1C57E7E7E /* AIReviewStoreTests.swift */; };
 		A28A24923C27CF0929ED97E1 /* Double+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669A80C2A9F46A0C4612388C /* Double+Formatting.swift */; };
 		A379F9D71FE84EC4F3A2499C /* SearchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C5F37100E6EBB467EBFE1C /* SearchStore.swift */; };
@@ -180,6 +183,7 @@
 		10CD226D313FDD91E4037D8E /* SupabaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseManager.swift; sourceTree = "<group>"; };
 		18383A0375F5728A9E3FE065 /* Championship.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Championship.swift; sourceTree = "<group>"; };
 		1AD376EFB7AD4A192FAB3E8F /* RecordBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordBadge.swift; sourceTree = "<group>"; };
+		1D61FC118C0250CA87BDF647 /* ReportFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportFlagTests.swift; sourceTree = "<group>"; };
 		1D6C6489A04EC9CA00FFBD0F /* StandingsOffseasonCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsOffseasonCard.swift; sourceTree = "<group>"; };
 		1FBB5433786555EDDBC896C7 /* XomperTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperTheme.swift; sourceTree = "<group>"; };
 		22A99CAA9B57C1A0144DCA22 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
@@ -256,8 +260,10 @@
 		94E125AD2AA5212D0EB4C13A /* NflStateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NflStateStore.swift; sourceTree = "<group>"; };
 		957EE31D25CFE325633622D4 /* StandingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsStore.swift; sourceTree = "<group>"; };
 		967DCE922FE090CE4F067587 /* AIReviewDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewDetailView.swift; sourceTree = "<group>"; };
+		98366CAC5A10DA7462A41E7B /* AdminStoreFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStoreFlagTests.swift; sourceTree = "<group>"; };
 		9AD03A165767A043D34A9499 /* AdminStorePreseasonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStorePreseasonTests.swift; sourceTree = "<group>"; };
 		9B7C85CB880ABD7D373E49A6 /* RuleProposal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleProposal.swift; sourceTree = "<group>"; };
+		9DBFB7D900A09D0B904F5836 /* ReportFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportFlag.swift; sourceTree = "<group>"; };
 		9E94170F987E8EFE5C566B9B /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		9F49969EE42BDE6462664021 /* TradedPick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradedPick.swift; sourceTree = "<group>"; };
 		A2AA9304E883FF9B1D42EB60 /* ArchiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveView.swift; sourceTree = "<group>"; };
@@ -450,6 +456,7 @@
 		391A14F36D43146CBE38D666 /* XomperTests */ = {
 			isa = PBXGroup;
 			children = (
+				98366CAC5A10DA7462A41E7B /* AdminStoreFlagTests.swift */,
 				9AD03A165767A043D34A9499 /* AdminStorePreseasonTests.swift */,
 				46FB9B5B4B8700EACD4A9CFD /* AdminStorePreviewTests.swift */,
 				58ED7387DCA3E1DC5CDD7AFF /* AdminStoreTests.swift */,
@@ -463,6 +470,7 @@
 				D7F3E6606D89CF3AEB320314 /* LandingViewTests.swift */,
 				7877A392F88F41B8D4979F23 /* MockDraftMetadataTests.swift */,
 				0BC1E989411B5FACF30C4B3A /* PastStandingsArchiveTests.swift */,
+				1D61FC118C0250CA87BDF647 /* ReportFlagTests.swift */,
 				BB79AE4EA78D33BDCD8565A8 /* TestEmailStoreTests.swift */,
 			);
 			path = XomperTests;
@@ -611,6 +619,7 @@
 				6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */,
 				42C8A3FA617E9FEB48852C45 /* Profile.swift */,
 				4690614F644FE74115D0DAB6 /* ProposedTrade.swift */,
+				9DBFB7D900A09D0B904F5836 /* ReportFlag.swift */,
 				AE543CB2E49335ADD02E8000 /* Roster.swift */,
 				9B7C85CB880ABD7D373E49A6 /* RuleProposal.swift */,
 				B29D510D87CD290AE7F76FBF /* StandingsTeam.swift */,
@@ -869,6 +878,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A0F4E9BCA7E5D757DE8BE5B3 /* AIReviewStoreTests.swift in Sources */,
+				8BADB9CC50C4CA7FAE7370AF /* AdminStoreFlagTests.swift in Sources */,
 				A45E9B6A2A65059251FB3D76 /* AdminStorePreseasonTests.swift in Sources */,
 				FCC663F09AC754C35DF93A3D /* AdminStorePreviewTests.swift in Sources */,
 				37E600A31B5AA5DA5A766692 /* AdminStoreTests.swift in Sources */,
@@ -881,6 +891,7 @@
 				007B11207486956897981421 /* LandingViewTests.swift in Sources */,
 				3403B87830513963A9D86F8F /* MockDraftMetadataTests.swift in Sources */,
 				D9737CEB4C36AEFB5EC727D0 /* PastStandingsArchiveTests.swift in Sources */,
+				9FA30DE0724E90F9914ED3BA /* ReportFlagTests.swift in Sources */,
 				57E9FA9D90F0BF708A014023 /* TestEmailStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -975,6 +986,7 @@
 				42E7DDAD3454512247E1AFA6 /* ProposedTrade.swift in Sources */,
 				7D94ADAC136455C3056D5867 /* PushNotificationManager.swift in Sources */,
 				76260F26A40213A62E5F22FB /* RecordBadge.swift in Sources */,
+				1D67D0B027D9C2AA6E033E38 /* ReportFlag.swift in Sources */,
 				54863F3F6ECDD3BE00083582 /* Roster.swift in Sources */,
 				CFE915FD4020FDEB923157C2 /* RuleProposal.swift in Sources */,
 				1D279CC4379E6F068F2615DE /* RuleProposalFormView.swift in Sources */,

--- a/Xomper/Core/Models/AIReport.swift
+++ b/Xomper/Core/Models/AIReport.swift
@@ -155,6 +155,35 @@ struct AIReport: Decodable, Identifiable, Sendable, Hashable {
         "\(reportType.displayName) — \(period)"
     }
 
+    // MARK: - F3 Metadata flags
+
+    /// True when the admin has marked the report `is_redacted=true`
+    /// in the metadata blob. Non-admin clients are filtered server-
+    /// side; this accessor exists so admin surfaces can render the
+    /// "REDACTED" badge and gate context-menu actions when the
+    /// `showRedacted` toggle on `AIReviewStore` is on.
+    var isRedacted: Bool {
+        metadata["is_redacted"] == "true"
+    }
+
+    /// True when the admin has marked the report `do_not_broadcast=true`.
+    /// Pre-broadcast lock — the backend re-reads metadata immediately
+    /// before SES fan-out and aborts with 409 when this is set. iOS
+    /// surfaces this on the preview view's Broadcast button so the
+    /// admin sees the lock before attempting the round-trip.
+    var doNotBroadcast: Bool {
+        metadata["do_not_broadcast"] == "true"
+    }
+
+    /// When the report was last broadcast to all whitelisted users.
+    /// Stamped by the backend immediately AFTER successful SES fan-out
+    /// (postdraft / preseason / weekly all share the same helper).
+    /// `nil` for dry-run-only reports or before the first broadcast.
+    var broadcastAt: Date? {
+        guard let raw = metadata["broadcast_at"] else { return nil }
+        return AIReport.parseISO(raw)
+    }
+
     /// First ~80 chars of the markdown body, stripped of leading
     /// markdown markers. Used by the archive list + Home card.
     var previewSnippet: String {
@@ -175,7 +204,7 @@ struct AIReport: Decodable, Identifiable, Sendable, Hashable {
         return String(stripped[..<idx]) + "…"
     }
 
-    private static func parseISO(_ raw: String) -> Date? {
+    static func parseISO(_ raw: String) -> Date? {
         guard !raw.isEmpty else { return nil }
         let iso = ISO8601DateFormatter()
         iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]

--- a/Xomper/Core/Models/ReportFlag.swift
+++ b/Xomper/Core/Models/ReportFlag.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Typed input for the F3 `POST /admin/reports-flag` endpoint. The
+/// backend accepts exactly these two metadata keys; passing anything
+/// else returns 400. Raw values match the wire format so the API
+/// client can serialize the enum directly into the request body.
+///
+/// See `docs/features/admin-portal/f3-redact/PLAN.md` for the full
+/// flag semantics:
+/// - `isRedacted` (`metadata.is_redacted=true`) — hides the report
+///   from non-admin app surfaces (`/ai-reports/latest` returns 404,
+///   `/ai-reports/list` filters the row out). Admin still sees
+///   everything.
+/// - `doNotBroadcast` (`metadata.do_not_broadcast=true`) — locks the
+///   broadcast path. All three orchestrators re-read metadata right
+///   before SES fan-out and abort with 409 when set.
+enum ReportFlag: String, Codable, Sendable, CaseIterable {
+    case isRedacted = "is_redacted"
+    case doNotBroadcast = "do_not_broadcast"
+}
+
+/// Wire shape for the `POST /admin/reports-flag` response. Backend
+/// returns the full updated `metadata` map after the write so the
+/// client can mutate the local cached `AIReport` in place without
+/// a second fetch — useful for the archive view's "Hide from app"
+/// flow where the row needs to reflect the new flag immediately.
+///
+/// The keys mirror the Python handler (`api_admin_reports_flag`):
+/// ```json
+/// {
+///   "Success": true,
+///   "league_id": "1181789700187090944",
+///   "report_type": "weekly",
+///   "period": "2026W04",
+///   "flag": "is_redacted",
+///   "value": true,
+///   "metadata": { "is_redacted": "true", "broadcast_at": "..." }
+/// }
+/// ```
+struct ReportFlagResponse: Decodable, Sendable {
+    let success: Bool
+    let leagueId: String
+    let reportType: String
+    let period: String
+    let flag: String
+    let value: Bool
+    /// Full updated metadata map. Dynamo collapses BOOL → string and
+    /// numbers → string upstream so this is safely `[String: String]`.
+    let metadata: [String: String]
+
+    enum CodingKeys: String, CodingKey {
+        case success = "Success"
+        case leagueId = "league_id"
+        case reportType = "report_type"
+        case period
+        case flag
+        case value
+        case metadata
+    }
+}

--- a/Xomper/Core/Networking/XomperAPIClient.swift
+++ b/Xomper/Core/Networking/XomperAPIClient.swift
@@ -24,6 +24,15 @@ protocol XomperAPIClientProtocol: Sendable {
     func triggerPostDraftAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse
     func triggerPreseasonAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse
     func triggerWeeklyAIReview(week: Int?, dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse
+
+    // Admin: report metadata flags (F3)
+    func setReportFlag(
+        leagueId: String,
+        reportType: AIReportType,
+        period: String,
+        flag: ReportFlag,
+        value: Bool
+    ) async throws -> ReportFlagResponse
 }
 
 // MARK: - Request Payloads
@@ -639,6 +648,33 @@ final class XomperAPIClient: XomperAPIClientProtocol {
             "/admin/ai-review-weekly-trigger",
             body: payload
         )
+    }
+
+    // MARK: - Admin Report Flags (F3)
+
+    /// Admin-only: toggle `is_redacted` or `do_not_broadcast` on a
+    /// single report row. Backend path is `/admin/reports-flag` —
+    /// flat (not nested under report id) so the same handler can
+    /// service any of the three report types without re-routing.
+    ///
+    /// Returns the full updated metadata map so callers can mutate
+    /// the local cached `AIReport` in place without a follow-up
+    /// `/ai-reports/latest` round-trip.
+    func setReportFlag(
+        leagueId: String,
+        reportType: AIReportType,
+        period: String,
+        flag: ReportFlag,
+        value: Bool
+    ) async throws -> ReportFlagResponse {
+        let body: [String: Any] = [
+            "league_id": leagueId,
+            "report_type": reportType.rawValue,
+            "period": period,
+            "flag": flag.rawValue,
+            "value": value,
+        ]
+        return try await postDecoding("/admin/reports-flag", body: body)
     }
 
     // MARK: - Private

--- a/Xomper/Core/Stores/AIReviewStore.swift
+++ b/Xomper/Core/Stores/AIReviewStore.swift
@@ -52,6 +52,14 @@ final class AIReviewStore {
     private(set) var error: Error?
     private(set) var lastLoadedAt: Date?
 
+    /// Admin-only opt-in to see redacted rows in the archive. Defaults
+    /// off so admins see the same view as everyone else by default. The
+    /// archive view gates the toolbar toggle behind `authStore.isAdmin`,
+    /// and the server already filters redacted rows for non-admin
+    /// callers — this flag is only meaningful when the caller is admin.
+    /// Client-side filter is defense-in-depth on top of the server.
+    var showRedacted: Bool = false
+
     // MARK: - Dependencies
 
     private let apiClient: XomperAPIClientProtocol
@@ -198,6 +206,54 @@ final class AIReviewStore {
         } catch {
             self.error = error
         }
+    }
+
+    // MARK: - F3 Report Flags
+
+    /// Toggle `is_redacted` / `do_not_broadcast` on a single archive
+    /// row. On API success, the matching row in `archive` (and
+    /// `latestByType` when present) is replaced with a fresh copy that
+    /// carries the updated metadata so the UI reflects the new state
+    /// instantly — no follow-up `/ai-reports/list` round-trip.
+    ///
+    /// Mirrors `AdminStore.setReportFlag` but mutates archive entries
+    /// instead of triggering a `*Latest` re-fetch. Both stores route
+    /// through the same `XomperAPIClientProtocol.setReportFlag` call.
+    @discardableResult
+    func setReportFlag(
+        report: AIReport,
+        flag: ReportFlag,
+        value: Bool
+    ) async throws -> [String: String] {
+        let response = try await apiClient.setReportFlag(
+            leagueId: report.leagueId,
+            reportType: report.reportType,
+            period: report.period,
+            flag: flag,
+            value: value
+        )
+        // Rebuild the report with the backend's authoritative metadata
+        // map so any other metadata keys (broadcast_at, model, etc.)
+        // round-trip cleanly. Then apply the mutation in place.
+        let updated = AIReport(
+            id: report.id,
+            leagueId: report.leagueId,
+            reportType: report.reportType,
+            period: report.period,
+            bodyMarkdown: report.bodyMarkdown,
+            metadata: response.metadata,
+            metadataRawJSON: nil,
+            createdAt: report.createdAt,
+            model: report.model,
+            promptVersion: report.promptVersion
+        )
+        if let idx = archive.firstIndex(where: { $0.id == report.id }) {
+            archive[idx] = updated
+        }
+        if latestByType[report.reportType]?.id == report.id {
+            latestByType[report.reportType] = updated
+        }
+        return response.metadata
     }
 
     /// Format a `(season, week)` pair into the wire period string the

--- a/Xomper/Core/Stores/AdminStore.swift
+++ b/Xomper/Core/Stores/AdminStore.swift
@@ -327,6 +327,54 @@ final class AdminStore {
         lastPreviewsByType[reportType] = nil
     }
 
+    // MARK: - F3 Report Flags
+
+    /// Convenience accessor for the latest report of a given type.
+    /// Used by `AIReviewPreviewView` to read the current DNB state
+    /// for the active report type without switching on the type at
+    /// the call site.
+    func latest(for reportType: AIReportType) -> AIReport? {
+        switch reportType {
+        case .postDraft: return postDraftLatest
+        case .preseason: return preseasonLatest
+        case .weekly:    return weeklyLatest
+        case .mock:      return nil
+        }
+    }
+
+    /// Toggle a metadata flag (F3) on a report row. Calls the backend
+    /// then re-fetches the affected `*Latest` so the trigger card +
+    /// preview view both reflect the new state. Throws so the caller
+    /// can surface the error inline (the preview view shows it in the
+    /// existing `broadcastError` block).
+    ///
+    /// Returns the full updated metadata map for callers that want to
+    /// apply it locally instead of re-fetching (the archive flow
+    /// does this via `AIReviewStore.setReportFlag`).
+    @discardableResult
+    func setReportFlag(
+        report: AIReport,
+        flag: ReportFlag,
+        value: Bool
+    ) async throws -> [String: String] {
+        let response = try await apiClient.setReportFlag(
+            leagueId: report.leagueId,
+            reportType: report.reportType,
+            period: report.period,
+            flag: flag,
+            value: value
+        )
+        // Refresh the affected latest so trigger card + preview view
+        // pick up the flag change without a manual re-fetch.
+        switch report.reportType {
+        case .postDraft: await loadPostDraftLatest()
+        case .preseason: await loadPreseasonLatest()
+        case .weekly:    await loadWeeklyLatest()
+        case .mock:      break
+        }
+        return response.metadata
+    }
+
     func sendTest(
         kind: AdminTestKind,
         sleeperUserId: String,

--- a/Xomper/Features/AIReview/AIReviewView.swift
+++ b/Xomper/Features/AIReview/AIReviewView.swift
@@ -8,13 +8,48 @@ import SwiftUI
 /// Until the backend's `/ai-reports/list` endpoint is live the call
 /// errors out — the view renders the error inline. Once the route
 /// returns an empty array the empty state appears instead.
+///
+/// F3 additions:
+/// - Admin-only "Show redacted" toolbar toggle that includes hidden
+///   reports in the listing (server already filters for non-admin).
+/// - `.contextMenu` on each row with "Hide from app" / "Show in app"
+///   actions backed by `store.setReportFlag(...)`. Hide presents a
+///   destructive confirm dialog.
+/// - REDACTED badge + 50% opacity on redacted rows when visible.
 struct AIReviewView: View {
     let store: AIReviewStore
+    let authStore: AuthStore
     let router: AppRouter
+
+    /// Pending hide target — set when the admin taps "Hide from app"
+    /// on a row context menu. Triggers the destructive `.alert` below.
+    @State private var pendingHide: AIReport?
+    /// Surfaces any flag-write failure (hide or unhide) inline at the
+    /// top of the list so the admin can retry without losing context.
+    @State private var flagError: String?
+
+    private var isAdmin: Bool {
+        authStore.whitelistedUser?.isAdmin == true
+    }
+
+    /// Client-side defense-in-depth filter — the server already strips
+    /// `is_redacted == true` rows for non-admin callers. Admins see
+    /// the full list when `showRedacted` is on, otherwise they get
+    /// the same view as everyone else.
+    private var visibleArchive: [AIReport] {
+        store.archive.filter { !$0.isRedacted || store.showRedacted }
+    }
 
     var body: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+                if let flagError {
+                    Text("✗ \(flagError)")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(XomperColors.errorRed)
+                        .padding(.horizontal, XomperTheme.Spacing.md)
+                }
+
                 if store.isLoading && store.archive.isEmpty {
                     LoadingView(message: "Loading reports…")
                         .padding(.top, XomperTheme.Spacing.xl)
@@ -23,7 +58,7 @@ struct AIReviewView: View {
                         Task { await store.loadArchive(force: true) }
                     }
                     .padding(.top, XomperTheme.Spacing.lg)
-                } else if store.archive.isEmpty {
+                } else if visibleArchive.isEmpty {
                     EmptyStateView(
                         icon: "sparkles",
                         title: "No reports yet",
@@ -31,16 +66,26 @@ struct AIReviewView: View {
                     )
                     .padding(.top, XomperTheme.Spacing.xl)
                 } else {
-                    ForEach(Array(store.archive.enumerated()), id: \.element.id) { idx, report in
-                        AIReportCardRow(report: report) {
-                            router.navigate(to: .aiReportDetail(reportId: report.id))
-                        }
+                    ForEach(Array(visibleArchive.enumerated()), id: \.element.id) { idx, report in
+                        AIReportCardRow(
+                            report: report,
+                            isAdmin: isAdmin,
+                            onTap: {
+                                router.navigate(to: .aiReportDetail(reportId: report.id))
+                            },
+                            onHide: {
+                                pendingHide = report
+                            },
+                            onUnhide: {
+                                Task { await applyFlag(report: report, value: false) }
+                            }
+                        )
                         .padding(.horizontal, XomperTheme.Spacing.md)
                         .onAppear {
                             // Infinite scroll: when the last visible
                             // row mounts, request the next page.
                             // No-op when the cursor is nil.
-                            if idx == store.archive.count - 1 {
+                            if idx == visibleArchive.count - 1 {
                                 Task { await store.loadMore() }
                             }
                         }
@@ -61,6 +106,40 @@ struct AIReviewView: View {
             .padding(.bottom, XomperTheme.Spacing.xl)
         }
         .background(XomperColors.bgDark.ignoresSafeArea())
+        .toolbar {
+            // Admin-only "Show redacted" toggle — non-admin users
+            // never see this control. The server-side filter strips
+            // redacted rows for them regardless of the toggle state.
+            if isAdmin {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Toggle(isOn: Binding(
+                        get: { store.showRedacted },
+                        set: { store.showRedacted = $0 }
+                    )) {
+                        Label("Show redacted", systemImage: "eye.slash")
+                    }
+                    .toggleStyle(.button)
+                    .tint(XomperColors.championGold)
+                }
+            }
+        }
+        .alert(
+            "Hide \(pendingHide?.displayTitle ?? "report")?",
+            isPresented: Binding(
+                get: { pendingHide != nil },
+                set: { if !$0 { pendingHide = nil } }
+            )
+        ) {
+            Button("Cancel", role: .cancel) { pendingHide = nil }
+            Button("Hide", role: .destructive) {
+                if let target = pendingHide {
+                    pendingHide = nil
+                    Task { await applyFlag(report: target, value: true) }
+                }
+            }
+        } message: {
+            Text("Hides the report from the league archive. Admins can still see it and un-hide it later. Already-delivered emails are unaffected.")
+        }
         .task {
             await store.loadArchive()
         }
@@ -68,15 +147,37 @@ struct AIReviewView: View {
             await store.refresh()
         }
     }
+
+    /// Toggle `is_redacted` on a report. Wraps any error in `flagError`
+    /// so the admin sees what went wrong without losing the rest of
+    /// the archive state. On success the store updates the row in
+    /// place, so no manual refresh is needed.
+    private func applyFlag(report: AIReport, value: Bool) async {
+        flagError = nil
+        do {
+            try await store.setReportFlag(
+                report: report,
+                flag: .isRedacted,
+                value: value
+            )
+        } catch {
+            flagError = error.localizedDescription
+        }
+    }
 }
 
 // MARK: - Row
 
 /// Compact archive row — type chip, period, snippet, relative date.
-/// Tappable card with the standard pressable feedback.
+/// Tappable card with the standard pressable feedback. F3: when
+/// `report.isRedacted == true`, renders the REDACTED badge + dim
+/// opacity; admin context menu exposes Hide / Show actions.
 private struct AIReportCardRow: View {
     let report: AIReport
+    let isAdmin: Bool
     let onTap: () -> Void
+    let onHide: () -> Void
+    let onUnhide: () -> Void
 
     var body: some View {
         Button(action: {
@@ -89,6 +190,9 @@ private struct AIReportCardRow: View {
                     Text(report.period)
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(XomperColors.textSecondary)
+                    if report.isRedacted {
+                        redactedBadge
+                    }
                     Spacer()
                     Text(relativeDate(report.createdAt))
                         .font(.caption2)
@@ -121,8 +225,29 @@ private struct AIReportCardRow: View {
             )
         }
         .buttonStyle(.pressableCard)
+        .opacity(report.isRedacted ? 0.5 : 1.0)
+        .contextMenu {
+            // F3 admin-only context actions. Non-admin users never see
+            // a redacted row in the first place (server filter), so
+            // hiding the menu behind `isAdmin` is belt + suspenders.
+            if isAdmin {
+                if report.isRedacted {
+                    Button {
+                        onUnhide()
+                    } label: {
+                        Label("Show in app", systemImage: "eye")
+                    }
+                } else {
+                    Button(role: .destructive) {
+                        onHide()
+                    } label: {
+                        Label("Hide from app", systemImage: "eye.slash")
+                    }
+                }
+            }
+        }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(report.reportType.displayName) report, \(report.period)")
+        .accessibilityLabel(accessibilityLabel)
         .accessibilityHint("Double tap to read full report")
     }
 
@@ -139,6 +264,29 @@ private struct AIReportCardRow: View {
         .padding(.vertical, 4)
         .background(report.reportType.accentColor)
         .clipShape(Capsule())
+    }
+
+    /// Small all-caps badge surfaced next to the period when a report
+    /// is hidden from non-admin surfaces. Only ever renders when the
+    /// admin has toggled `showRedacted` on (the row is filtered out
+    /// otherwise) so the badge is purely an admin signal.
+    private var redactedBadge: some View {
+        Text("REDACTED")
+            .font(.caption2.weight(.heavy))
+            .tracking(0.8)
+            .foregroundStyle(XomperColors.errorRed)
+            .padding(.horizontal, XomperTheme.Spacing.xs)
+            .padding(.vertical, 2)
+            .overlay(
+                RoundedRectangle(cornerRadius: 4)
+                    .strokeBorder(XomperColors.errorRed.opacity(0.6), lineWidth: 1)
+            )
+            .accessibilityLabel("Redacted")
+    }
+
+    private var accessibilityLabel: String {
+        let base = "\(report.reportType.displayName) report, \(report.period)"
+        return report.isRedacted ? "\(base), redacted" : base
     }
 
     private func relativeDate(_ date: Date) -> String {

--- a/Xomper/Features/Admin/AIReviewPreviewView.swift
+++ b/Xomper/Features/Admin/AIReviewPreviewView.swift
@@ -25,6 +25,12 @@ struct AIReviewPreviewView: View {
     @State private var selectedPreview: EmailPreview?
     @State private var showBroadcastConfirm = false
     @State private var broadcastError: String?
+    /// True while the DNB flag write is in-flight. Disables the
+    /// toggle to prevent double-tap races against the round-trip.
+    @State private var dnbInFlight = false
+    /// Surfaces any failure from the DNB flag write inline below the
+    /// lock row so the admin sees why their tap didn't stick.
+    @State private var dnbError: String?
 
     var body: some View {
         content
@@ -63,6 +69,21 @@ struct AIReviewPreviewView: View {
         }
     }
 
+    /// Latest report for the active type. Source of truth for the
+    /// DNB metadata flag — `currentReport?.doNotBroadcast` drives the
+    /// lock row toggle + the disabled state on the Broadcast button.
+    /// `nil` when the trigger card hasn't yet loaded `*Latest` (rare —
+    /// the parent calls `loadXLatest()` on appear).
+    private var currentReport: AIReport? {
+        adminStore.latest(for: reportType)
+    }
+
+    /// Whether the broadcast path is locked by the DNB flag. Pulled
+    /// out so the button + label switch can share one source.
+    private var isDNBLocked: Bool {
+        currentReport?.doNotBroadcast == true
+    }
+
     // MARK: - Content
 
     @ViewBuilder
@@ -77,6 +98,8 @@ struct AIReviewPreviewView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
                     headerCard
+
+                    dnbLockRow
 
                     broadcastButton
 
@@ -131,6 +154,74 @@ struct AIReviewPreviewView: View {
         .padding(.horizontal, XomperTheme.Spacing.md)
     }
 
+    // MARK: - DNB lock row (F3)
+
+    /// Lock toggle above the Broadcast button. When checked, the
+    /// backend rejects broadcast attempts with 409 and the Broadcast
+    /// button below visibly locks (red tint + "Locked — DNB flag set"
+    /// label) so the admin sees the gate before tapping.
+    ///
+    /// Reads its current state from `currentReport?.doNotBroadcast` so
+    /// re-entering the view always reflects the persisted metadata
+    /// rather than a stale local toggle. The toggle binding fires the
+    /// API write asynchronously; `dnbInFlight` disables the toggle for
+    /// the duration of the round-trip to prevent double-tap races.
+    @ViewBuilder
+    private var dnbLockRow: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            HStack(spacing: XomperTheme.Spacing.sm) {
+                Image(systemName: isDNBLocked ? "lock.fill" : "lock.open")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(isDNBLocked ? XomperColors.errorRed : XomperColors.textMuted)
+                    .frame(width: 20)
+
+                Toggle(
+                    "Do not broadcast",
+                    isOn: Binding(
+                        get: { isDNBLocked },
+                        set: { newValue in
+                            Task { await applyDNB(newValue) }
+                        }
+                    )
+                )
+                .toggleStyle(SwitchToggleStyle(tint: XomperColors.errorRed))
+                .foregroundStyle(XomperColors.textPrimary)
+                .disabled(dnbInFlight || currentReport == nil)
+
+                if dnbInFlight {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                        .tint(XomperColors.championGold)
+                }
+            }
+
+            Text("When checked, this report cannot be sent to all 12 managers.")
+                .font(.caption2)
+                .foregroundStyle(XomperColors.textMuted)
+
+            if let dnbError {
+                Text("✗ \(dnbError)")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(XomperColors.errorRed)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(
+                    (isDNBLocked ? XomperColors.errorRed : XomperColors.textMuted).opacity(0.3),
+                    lineWidth: 1
+                )
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Do not broadcast lock for \(reportType.displayName) report")
+        .accessibilityHint("Toggle on to prevent this report from being broadcast.")
+    }
+
     // MARK: - Broadcast button
 
     private var broadcastButton: some View {
@@ -144,25 +235,55 @@ struct AIReviewPreviewView: View {
                     ProgressView()
                         .scaleEffect(0.7)
                         .tint(XomperColors.bgDark)
+                } else if isDNBLocked {
+                    Image(systemName: "lock.fill")
+                        .font(.caption2)
                 } else {
                     Image(systemName: "paperplane.fill")
                         .font(.caption2)
                 }
-                Text(isTriggerInFlight ? "Broadcasting…" : "Broadcast to all \(previews.count)")
+                Text(broadcastButtonLabel)
                     .font(.subheadline.weight(.bold))
             }
             .foregroundStyle(XomperColors.bgDark)
             .padding(.horizontal, XomperTheme.Spacing.md)
             .padding(.vertical, XomperTheme.Spacing.sm)
             .frame(maxWidth: .infinity, minHeight: XomperTheme.minTouchTarget)
-            .background(isTriggerInFlight ? XomperColors.championGold.opacity(0.5) : XomperColors.championGold)
+            .background(broadcastButtonBackground)
             .clipShape(Capsule())
         }
         .buttonStyle(.pressableCard)
-        .disabled(isTriggerInFlight)
+        .disabled(isTriggerInFlight || isDNBLocked)
         .padding(.horizontal, XomperTheme.Spacing.md)
-        .accessibilityLabel("Broadcast \(reportType.displayName) recap to all \(previews.count) recipients")
-        .accessibilityHint("Opens a confirmation dialog before sending.")
+        .accessibilityLabel(broadcastButtonAccessibilityLabel)
+        .accessibilityHint(
+            isDNBLocked
+                ? "Broadcast is locked by the do-not-broadcast flag. Toggle it off above to re-enable."
+                : "Opens a confirmation dialog before sending."
+        )
+    }
+
+    /// Label for the Broadcast button — switches between in-flight,
+    /// locked-by-DNB, and the normal "Broadcast to all N" state.
+    private var broadcastButtonLabel: String {
+        if isTriggerInFlight { return "Broadcasting…" }
+        if isDNBLocked { return "Locked — DNB flag set" }
+        return "Broadcast to all \(previews.count)"
+    }
+
+    /// Background tint for the Broadcast button. Red when locked,
+    /// dimmed gold while in-flight, full gold otherwise.
+    private var broadcastButtonBackground: Color {
+        if isDNBLocked { return XomperColors.errorRed.opacity(0.5) }
+        if isTriggerInFlight { return XomperColors.championGold.opacity(0.5) }
+        return XomperColors.championGold
+    }
+
+    private var broadcastButtonAccessibilityLabel: String {
+        if isDNBLocked {
+            return "Broadcast locked. Do-not-broadcast flag is set on this \(reportType.displayName) report."
+        }
+        return "Broadcast \(reportType.displayName) recap to all \(previews.count) recipients"
     }
 
     // MARK: - List header
@@ -205,6 +326,26 @@ struct AIReviewPreviewView: View {
             router.path.removeLast()
         } catch {
             broadcastError = error.localizedDescription
+        }
+    }
+
+    /// Write the DNB flag to the backend then re-read `*Latest` so the
+    /// toggle + Broadcast button state reflect the persisted value.
+    /// No-op when the report hasn't loaded yet (toggle is disabled in
+    /// that case so this is defensive).
+    private func applyDNB(_ newValue: Bool) async {
+        guard let report = currentReport else { return }
+        dnbError = nil
+        dnbInFlight = true
+        defer { dnbInFlight = false }
+        do {
+            try await adminStore.setReportFlag(
+                report: report,
+                flag: .doNotBroadcast,
+                value: newValue
+            )
+        } catch {
+            dnbError = error.localizedDescription
         }
     }
 }

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -232,6 +232,7 @@ struct MainShell: View {
             case .aiReview:
                 AIReviewView(
                     store: aiReviewStore,
+                    authStore: authStore,
                     router: router
                 )
 

--- a/XomperTests/AIReviewStoreTests.swift
+++ b/XomperTests/AIReviewStoreTests.swift
@@ -332,6 +332,29 @@ final class MockXomperAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
     func triggerPreseasonAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw Unsupported.method }
     func triggerWeeklyAIReview(week: Int?, dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw Unsupported.method }
 
+    // MARK: F3 Report Flags
+
+    /// Captured args + configurable response for `setReportFlag`. Used
+    /// by `AIReviewStoreRedactTests` to assert the API client is hit
+    /// with the right `(leagueId, reportType, period, flag, value)`
+    /// tuple and that error paths leave the archive untouched.
+    var setReportFlagResponse: ReportFlagResponse?
+    var setReportFlagError: Error?
+    private(set) var setReportFlagCalls: [(leagueId: String, reportType: AIReportType, period: String, flag: ReportFlag, value: Bool)] = []
+
+    func setReportFlag(
+        leagueId: String,
+        reportType: AIReportType,
+        period: String,
+        flag: ReportFlag,
+        value: Bool
+    ) async throws -> ReportFlagResponse {
+        setReportFlagCalls.append((leagueId, reportType, period, flag, value))
+        if let err = setReportFlagError { throw err }
+        guard let response = setReportFlagResponse else { throw Unsupported.method }
+        return response
+    }
+
     enum Unsupported: Error { case method }
 }
 

--- a/XomperTests/AdminStoreFlagTests.swift
+++ b/XomperTests/AdminStoreFlagTests.swift
@@ -1,0 +1,233 @@
+import XCTest
+@testable import Xomper
+
+/// F3 — verifies `AdminStore.setReportFlag` round-trips through the
+/// API client with the right arguments, re-loads the affected
+/// `*Latest` so the UI reflects the new metadata, and surfaces
+/// errors via `throws`. Also covers `AIReviewStore.setReportFlag`
+/// mutation-in-place behavior on the archive cache.
+@MainActor
+final class AdminStoreFlagTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeWeeklyReport(metadata: [String: String] = [:]) -> AIReport {
+        AIReport(
+            id: "L1|REPORT#weekly#2026W04",
+            leagueId: "L1",
+            reportType: .weekly,
+            period: "2026W04",
+            bodyMarkdown: "## Week 4",
+            metadata: metadata,
+            createdAt: Date(timeIntervalSince1970: 0),
+            model: "claude-haiku-4-5",
+            promptVersion: "f0-2026-05-21"
+        )
+    }
+
+    private func makeFlagResponse(
+        flag: ReportFlag,
+        value: Bool,
+        metadata: [String: String]
+    ) -> ReportFlagResponse {
+        // Render via JSON so we exercise the same Decodable path the
+        // real network client takes.
+        let metaJson = metadata.map { "\"\($0.key)\": \"\($0.value)\"" }
+            .joined(separator: ", ")
+        let json = """
+        {
+          "Success": true,
+          "league_id": "L1",
+          "report_type": "weekly",
+          "period": "2026W04",
+          "flag": "\(flag.rawValue)",
+          "value": \(value),
+          "metadata": { \(metaJson) }
+        }
+        """
+        return try! JSONDecoder().decode(
+            ReportFlagResponse.self,
+            from: Data(json.utf8)
+        )
+    }
+
+    // MARK: - AdminStore.setReportFlag
+
+    /// Happy path: setReportFlag calls the API client with the right
+    /// args, returns the updated metadata, and re-loads the affected
+    /// `*Latest` so trigger card + preview view reflect the new state.
+    func test_adminSetReportFlag_callsAPIWithRightArgs() async throws {
+        let report = makeWeeklyReport()
+        let response = makeFlagResponse(
+            flag: .doNotBroadcast,
+            value: true,
+            metadata: ["do_not_broadcast": "true"]
+        )
+        let updatedLatest = makeWeeklyReport(metadata: ["do_not_broadcast": "true"])
+        let mock = MockAdminAPIClient(weeklyLatest: updatedLatest)
+        mock.setReportFlagResponse = response
+        let store = AdminStore(apiClient: mock)
+
+        let returnedMetadata = try await store.setReportFlag(
+            report: report,
+            flag: .doNotBroadcast,
+            value: true
+        )
+
+        // API client called exactly once with the report's (leagueId,
+        // reportType, period) + the flag + value the caller passed in.
+        XCTAssertEqual(mock.setReportFlagCalls.count, 1)
+        let call = mock.setReportFlagCalls[0]
+        XCTAssertEqual(call.leagueId, "L1")
+        XCTAssertEqual(call.reportType, .weekly)
+        XCTAssertEqual(call.period, "2026W04")
+        XCTAssertEqual(call.flag, .doNotBroadcast)
+        XCTAssertTrue(call.value)
+
+        // Returns the backend's updated metadata so the caller can
+        // apply it locally (mirrors the wire response).
+        XCTAssertEqual(returnedMetadata["do_not_broadcast"], "true")
+
+        // Re-fetched weekly latest so the trigger card / preview view
+        // pick up the new DNB state without manual refresh.
+        XCTAssertEqual(mock.fetchLatestCalls, [.weekly])
+        XCTAssertEqual(store.weeklyLatest?.doNotBroadcast, true)
+    }
+
+    /// Error path: API throws, AdminStore re-throws, and `*Latest`
+    /// is NOT re-fetched (no point — nothing changed server-side).
+    func test_adminSetReportFlag_errorRethrowsAndSkipsReload() async {
+        let report = makeWeeklyReport()
+        let mock = MockAdminAPIClient()
+        mock.setReportFlagError = MockError.boom
+        let store = AdminStore(apiClient: mock)
+
+        do {
+            _ = try await store.setReportFlag(
+                report: report,
+                flag: .doNotBroadcast,
+                value: true
+            )
+            XCTFail("Expected throw")
+        } catch {
+            // Expected.
+        }
+
+        XCTAssertEqual(mock.setReportFlagCalls.count, 1)
+        XCTAssertTrue(mock.fetchLatestCalls.isEmpty, "Should not re-fetch latest on error")
+    }
+
+    /// Latest accessor: returns the right cached report for each type
+    /// (or nil for mock). Used by the preview view to read the
+    /// current DNB state without switching on the type at the call
+    /// site.
+    func test_adminStore_latestAccessorReturnsByType() async {
+        let weekly = makeWeeklyReport(metadata: ["do_not_broadcast": "true"])
+        let mock = MockAdminAPIClient(weeklyLatest: weekly)
+        let store = AdminStore(apiClient: mock)
+
+        await store.loadWeeklyLatest()
+
+        XCTAssertEqual(store.latest(for: .weekly)?.id, weekly.id)
+        XCTAssertNil(store.latest(for: .postDraft))
+        XCTAssertNil(store.latest(for: .preseason))
+        XCTAssertNil(store.latest(for: .mock))
+    }
+
+    // MARK: - AIReviewStore.setReportFlag (archive mutation)
+
+    /// `setReportFlag` mutates the matching `archive` entry in place
+    /// using the backend's authoritative metadata map — no need for
+    /// a follow-up `/ai-reports/list` round-trip.
+    func test_aiReviewStore_setReportFlagMutatesArchiveInPlace() async throws {
+        let original = AIReport(
+            id: "L1|REPORT#weekly#2026W04",
+            leagueId: "L1",
+            reportType: .weekly,
+            period: "2026W04",
+            bodyMarkdown: "## Week 4",
+            metadata: [:],
+            createdAt: Date(timeIntervalSince1970: 0),
+            model: "claude-haiku-4-5",
+            promptVersion: "f0-2026-05-21"
+        )
+        let other = AIReport(
+            id: "L1|REPORT#weekly#2026W03",
+            leagueId: "L1",
+            reportType: .weekly,
+            period: "2026W03",
+            bodyMarkdown: "## Week 3",
+            metadata: [:],
+            createdAt: Date(timeIntervalSince1970: 0),
+            model: "claude-haiku-4-5",
+            promptVersion: "f0-2026-05-21"
+        )
+        let mock = MockXomperAPIClient(listPages: [(rows: [original, other], cursor: nil)])
+        let json = """
+        {
+          "Success": true,
+          "league_id": "L1",
+          "report_type": "weekly",
+          "period": "2026W04",
+          "flag": "is_redacted",
+          "value": true,
+          "metadata": { "is_redacted": "true" }
+        }
+        """
+        mock.setReportFlagResponse = try JSONDecoder().decode(
+            ReportFlagResponse.self,
+            from: Data(json.utf8)
+        )
+        let store = AIReviewStore(apiClient: mock)
+        await store.loadArchive()
+        XCTAssertEqual(store.archive.count, 2)
+
+        try await store.setReportFlag(
+            report: original,
+            flag: .isRedacted,
+            value: true
+        )
+
+        // Target row is now flagged; sibling is untouched.
+        XCTAssertEqual(store.archive.count, 2)
+        let mutated = store.archive.first(where: { $0.id == original.id })
+        XCTAssertNotNil(mutated)
+        XCTAssertTrue(mutated?.isRedacted == true)
+        let sibling = store.archive.first(where: { $0.id == other.id })
+        XCTAssertEqual(sibling?.isRedacted, false)
+    }
+
+    /// API failure leaves the archive untouched — instant-feedback
+    /// mutation is gated on a successful round-trip.
+    func test_aiReviewStore_setReportFlagErrorLeavesArchiveUntouched() async {
+        let original = AIReport(
+            id: "L1|REPORT#weekly#2026W04",
+            leagueId: "L1",
+            reportType: .weekly,
+            period: "2026W04",
+            bodyMarkdown: "## Week 4",
+            metadata: [:],
+            createdAt: Date(timeIntervalSince1970: 0),
+            model: "claude-haiku-4-5",
+            promptVersion: "f0-2026-05-21"
+        )
+        let mock = MockXomperAPIClient(listPages: [(rows: [original], cursor: nil)])
+        mock.setReportFlagError = MockXomperAPIClient.Unsupported.method
+        let store = AIReviewStore(apiClient: mock)
+        await store.loadArchive()
+
+        do {
+            _ = try await store.setReportFlag(
+                report: original,
+                flag: .isRedacted,
+                value: true
+            )
+            XCTFail("Expected throw")
+        } catch {
+            // Expected.
+        }
+
+        // Row unchanged — no mutation on failure.
+        XCTAssertEqual(store.archive.first?.isRedacted, false)
+    }
+}

--- a/XomperTests/AdminStoreTests.swift
+++ b/XomperTests/AdminStoreTests.swift
@@ -262,6 +262,28 @@ final class MockAdminAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
         return response
     }
 
+    // MARK: F3 Report Flags
+
+    /// Captured invocations so tests can assert the right path was
+    /// hit with the right args. `setReportFlagResponse` drives the
+    /// happy path; `setReportFlagError` short-circuits with an error.
+    var setReportFlagResponse: ReportFlagResponse?
+    var setReportFlagError: Error?
+    private(set) var setReportFlagCalls: [(leagueId: String, reportType: AIReportType, period: String, flag: ReportFlag, value: Bool)] = []
+
+    func setReportFlag(
+        leagueId: String,
+        reportType: AIReportType,
+        period: String,
+        flag: ReportFlag,
+        value: Bool
+    ) async throws -> ReportFlagResponse {
+        setReportFlagCalls.append((leagueId, reportType, period, flag, value))
+        if let err = setReportFlagError { throw err }
+        guard let response = setReportFlagResponse else { throw MockError.notConfigured }
+        return response
+    }
+
     // MARK: Unused protocol surface
 
     func sendRuleProposalEmail(proposal: RuleProposalEmailPayload, recipients: [String], userIds: [String]) async throws { throw MockError.unsupported }

--- a/XomperTests/ReportFlagTests.swift
+++ b/XomperTests/ReportFlagTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+@testable import Xomper
+
+/// F3 — verifies the three metadata accessors added to `AIReport`
+/// (`isRedacted`, `doNotBroadcast`, `broadcastAt`) read off the same
+/// flat-map source of truth that `metadata` already exposes. Also
+/// exercises `ReportFlag` raw values + `ReportFlagResponse` decoding
+/// since the API client wires them together.
+@MainActor
+final class ReportFlagTests: XCTestCase {
+
+    // MARK: - Fixture helper
+
+    private func makeReport(metadata: [String: String]) -> AIReport {
+        AIReport(
+            id: "L1|REPORT#weekly#2026W04",
+            leagueId: "L1",
+            reportType: .weekly,
+            period: "2026W04",
+            bodyMarkdown: "## Week 4",
+            metadata: metadata,
+            createdAt: Date(timeIntervalSince1970: 0),
+            model: "claude-haiku-4-5",
+            promptVersion: "f0-2026-05-21"
+        )
+    }
+
+    // MARK: - isRedacted
+
+    func test_isRedacted_trueWhenMetadataString() {
+        let report = makeReport(metadata: ["is_redacted": "true"])
+        XCTAssertTrue(report.isRedacted)
+    }
+
+    func test_isRedacted_falseWhenAbsent() {
+        let report = makeReport(metadata: [:])
+        XCTAssertFalse(report.isRedacted)
+    }
+
+    func test_isRedacted_falseWhenExplicitlyFalse() {
+        let report = makeReport(metadata: ["is_redacted": "false"])
+        XCTAssertFalse(report.isRedacted)
+    }
+
+    // MARK: - doNotBroadcast
+
+    func test_doNotBroadcast_trueWhenMetadataString() {
+        let report = makeReport(metadata: ["do_not_broadcast": "true"])
+        XCTAssertTrue(report.doNotBroadcast)
+    }
+
+    func test_doNotBroadcast_falseWhenAbsent() {
+        let report = makeReport(metadata: [:])
+        XCTAssertFalse(report.doNotBroadcast)
+    }
+
+    func test_flagsAreIndependent() {
+        let redacted = makeReport(metadata: ["is_redacted": "true"])
+        XCTAssertTrue(redacted.isRedacted)
+        XCTAssertFalse(redacted.doNotBroadcast)
+
+        let dnb = makeReport(metadata: ["do_not_broadcast": "true"])
+        XCTAssertFalse(dnb.isRedacted)
+        XCTAssertTrue(dnb.doNotBroadcast)
+    }
+
+    // MARK: - broadcastAt
+
+    func test_broadcastAt_nilWhenAbsent() {
+        let report = makeReport(metadata: [:])
+        XCTAssertNil(report.broadcastAt)
+    }
+
+    func test_broadcastAt_parsesISO8601WithoutFractional() {
+        let report = makeReport(metadata: ["broadcast_at": "2026-09-30T15:42:11Z"])
+        XCTAssertNotNil(report.broadcastAt)
+    }
+
+    func test_broadcastAt_parsesISO8601WithFractional() {
+        let report = makeReport(metadata: ["broadcast_at": "2026-09-30T15:42:11.123Z"])
+        XCTAssertNotNil(report.broadcastAt)
+    }
+
+    func test_broadcastAt_nilOnInvalidString() {
+        let report = makeReport(metadata: ["broadcast_at": "not-a-date"])
+        XCTAssertNil(report.broadcastAt)
+    }
+
+    // MARK: - ReportFlag wire values
+
+    func test_reportFlag_rawValuesMatchBackend() {
+        XCTAssertEqual(ReportFlag.isRedacted.rawValue, "is_redacted")
+        XCTAssertEqual(ReportFlag.doNotBroadcast.rawValue, "do_not_broadcast")
+    }
+
+    func test_reportFlag_decodesFromRawString() throws {
+        let json = "\"do_not_broadcast\""
+        let decoded = try JSONDecoder().decode(
+            ReportFlag.self,
+            from: Data(json.utf8)
+        )
+        XCTAssertEqual(decoded, .doNotBroadcast)
+    }
+
+    // MARK: - ReportFlagResponse decoding
+
+    func test_reportFlagResponse_decodesFullPayload() throws {
+        let json = """
+        {
+          "Success": true,
+          "league_id": "L1",
+          "report_type": "weekly",
+          "period": "2026W04",
+          "flag": "is_redacted",
+          "value": true,
+          "metadata": {
+            "is_redacted": "true",
+            "broadcast_at": "2026-09-30T15:42:11Z"
+          }
+        }
+        """
+        let response = try JSONDecoder().decode(
+            ReportFlagResponse.self,
+            from: Data(json.utf8)
+        )
+        XCTAssertTrue(response.success)
+        XCTAssertEqual(response.leagueId, "L1")
+        XCTAssertEqual(response.reportType, "weekly")
+        XCTAssertEqual(response.period, "2026W04")
+        XCTAssertEqual(response.flag, "is_redacted")
+        XCTAssertTrue(response.value)
+        XCTAssertEqual(response.metadata["is_redacted"], "true")
+        XCTAssertEqual(response.metadata["broadcast_at"], "2026-09-30T15:42:11Z")
+    }
+}

--- a/XomperTests/TestEmailStoreTests.swift
+++ b/XomperTests/TestEmailStoreTests.swift
@@ -280,6 +280,7 @@ final class MockTestEmailAPIClient: XomperAPIClientProtocol, @unchecked Sendable
     func triggerPostDraftAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw TestEmailMockError.unsupported }
     func triggerPreseasonAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw TestEmailMockError.unsupported }
     func triggerWeeklyAIReview(week: Int?, dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw TestEmailMockError.unsupported }
+    func setReportFlag(leagueId: String, reportType: AIReportType, period: String, flag: ReportFlag, value: Bool) async throws -> ReportFlagResponse { throw TestEmailMockError.unsupported }
 }
 
 enum TestEmailMockError: Error, LocalizedError {

--- a/docs/features/admin-portal/f3-redact/PLAN.md
+++ b/docs/features/admin-portal/f3-redact/PLAN.md
@@ -3,22 +3,361 @@
 **Epic**: admin-portal
 **Sub-feature ID**: F3
 **Phase**: Phase 3 — Broadcast Safety Loop
-**Status**: Draft
+**Status**: Ready
 **Created**: 2026-05-26
-**Depends on**: F2 (DNB checkbox lives in F2's preview surface)
+**Last updated**: 2026-05-27
+**Depends on**: F2 (DNB checkbox lives on `AIReviewPreviewView`)
+**Related**: `docs/features/admin-portal/EPIC_PLAN.md`, `docs/features/admin-portal/BRAINSTORM.md` (Q5), `docs/features/admin-portal/f1-test-email/PLAN.md`, `docs/features/admin-portal/f2-preview/PLAN.md`
+
+---
 
 ## Summary
-Two new metadata flags (`is_redacted`, `do_not_broadcast`) plus universal stamping of `broadcast_at` on every successful real broadcast (already done for post-draft; replicate for preseason + weekly). New flag endpoint. Broadcast path re-reads metadata post-generation and aborts 409 if `do_not_broadcast`. Read paths filter `is_redacted == true` for non-admin callers.
 
-## Repos Touched
-- `xomper-infrastructure` — API GW route `POST /admin/reports/{league_id}/{report_type}/{period}/flag`
-- `xomper-back-end` — `lambdas/api_admin_reports_flag/`, broadcast path DNB check, read-path redact filter
-- `xomper-ios` — "Hide from app" button on report rows; "Do not broadcast" checkbox on preview screen
+F3 closes the broadcast-safety loop with three coordinated capabilities, shipped behind one PR triplet:
 
-## Open Questions (this sub-feature)
-- [ ] Reports list screen scope: "most recent of each type" (recommended for F3) vs full paginated archive (defer to F4)?
-- [ ] Button label confirmation — "Hide from app" not "Unsend" (cannot recall already-delivered email).
+1. **Two new metadata flags on AI report rows.** `is_redacted` hides a report from non-admin app surfaces (post-broadcast cleanup). `do_not_broadcast` blocks the broadcast path from sending it (pre-broadcast lock). Both live in the existing `metadata` map on the `xomper-ai-reports` Dynamo row — no schema change, reuses the existing `update_metadata` helper.
+2. **Universal `broadcast_at` stamping.** Every successful real broadcast writes `metadata.broadcast_at = <iso8601>`. Post-draft already does this; F3 verifies and replicates for preseason + weekly so all three orchestrators are uniform.
+3. **One new flag endpoint + read-side redact filter.** `POST /admin/reports/{league_id}/{report_type}/{period}/flag` toggles either flag (admin-gated). `api_ai_reports_latest` + `api_ai_reports_list` filter out `is_redacted == true` rows for non-admin callers.
 
-## TODO
-- [ ] Flesh out this stub via `/plan admin-portal/f3-redact` before executing
-- [ ] Flip Status to Ready
+iOS surfaces: a "Do not broadcast" checkbox at the top of `AIReviewPreviewView` (locks the Broadcast button when checked); a "Hide from app" kebab action on each row in `AIReviewView` (the archive). Admin-only "Show redacted" toggle in the archive so admins can still see + un-redact rows.
+
+Success: admin can hide any sent report from non-admin surfaces; admin can lock a dry-run report so it cannot be broadcast; every broadcast lands with a `broadcast_at` timestamp; the broadcast path aborts 409 on the second send attempt of a DNB-locked report.
+
+---
+
+## Approach
+
+Locked in from `BRAINSTORM.md` Q5 (Option A) and the epic plan's F3 section:
+
+- **Endpoint shape**: one flag endpoint, body carries `{flag, value}`. Easier to extend (F4 will reuse this exact endpoint for the Reports row of the table editor — no new lambda needed there).
+- **Storage**: `metadata.is_redacted = "true"` / `metadata.do_not_broadcast = "true"` via `ai_reports_store.update_metadata`. Booleans persist as strings because the existing flat-map accessor (`AIReport.metadata: [String: String]`) collapses Dynamo `BOOL` to `"true"`/`"false"` already (see `AIReport.swift:46-58`).
+- **DNB enforcement point**: re-read the report metadata immediately **before** the SES fan-out, not before Anthropic generation. Reasons: (a) cheap — one `get_item` — and (b) catches the race where an admin checks DNB after generation but before broadcast. Generation is wasteful only when the report is regenerated (`force=true`); the dry-run path doesn't broadcast at all, so DNB doesn't apply there.
+- **`broadcast_at` ordering**: stamp **after** `send_emails_concurrently` returns, not before. Matches the epic risk row "race condition on `broadcast_at` write" — partial fan-out failures must not leave the report marked broadcast.
+- **Admin detection in read paths**: pass the caller's `is_admin` claim through to `api_ai_reports_latest` / `api_ai_reports_list`. These endpoints don't currently require admin (they're read-only for any authed user), but they do have access to the JWT claims via API GW. Use `admin_gate.is_admin(event)` — a non-raising sibling of `require_admin` — to branch the filter. If the helper doesn't exist yet, add it in `lambdas/common/admin_gate.py` as a 5-line function that returns `bool`.
+- **Audit retrofit**: F4 ships the `admin_audit` Supabase table. F3 leaves a `# TODO(F4): admin_audit row` comment block at every mutation point in `api_admin_reports_flag/handler.py`. F4's plan already calls out the retrofit (see EPIC_PLAN.md row "Audit log gaps").
+- **iOS routing**: no new routes. The DNB checkbox lives inside the existing `AIReviewPreviewView` (already pushed via `.adminAIReviewPreview(reportType:)`). The Hide-from-app action lives inline on existing `AIReviewView` rows via `Menu`/`.contextMenu`.
+- **Store ownership**: extend the existing `AdminStore` (which already owns the preview state) with `setReportFlag(...)`. Also add a `showRedacted: Bool = false` admin toggle on `AIReviewStore` so admins can opt-in to seeing redacted rows. New `ReportFlag` enum is a small `Sendable` type colocated with the API client.
+
+---
+
+## Design Questions — Resolved
+
+| # | Question | Resolution |
+|---|----------|------------|
+| 1 | Endpoint shape | **Single endpoint, body `{flag, value}`**. Extensible for future flags + reused by F4's reports row of the table editor with zero new code. |
+| 2 | Admin detection in read endpoints | **Add `admin_gate.is_admin(event) -> bool`** (non-raising). `api_ai_reports_latest` + `api_ai_reports_list` call it and branch the filter. Avoids passing an explicit `?include_redacted` query param (clients can't be trusted to set it; security through JWT claim is the safer surface). |
+| 3 | Confirm dialog wording (iOS Hide action) | **Alert title**: `"Hide \(report.displayTitle)?"` **Message**: `"This removes the report from the league archive. Admins can still see it and un-hide it later. Already-delivered emails are unaffected."` **Primary**: `"Hide"` (destructive). **Secondary**: `"Cancel"`. |
+| 4 | DNB checkbox visual treatment | **Checkbox + explanation block at top of `AIReviewPreviewView`, above the Broadcast button.** Row: `Image(systemName: "lock.fill")` (red when checked, muted when unchecked) + Toggle bound to `report.doNotBroadcast` + caption "Locks this report from broadcast. Toggle off to re-enable." When checked the Broadcast button becomes disabled with label `"Locked — DNB flag set"` and a red accent. Destructive-adjacent so we err on the side of "user knows what they did". |
+| 5 | Admin view of redacted reports | **Yes — `showRedacted: Bool = false` toggle on `AIReviewView`.** Visible only to admins (gated by `authStore.isAdmin`). When on, redacted rows render with a "REDACTED" badge + 50% opacity + disabled tap (no detail push). Un-redact action is the same kebab → "Show in app". |
+| 6 | Audit retrofit | **Stub now, retrofit in F4.** F3 lambda writes a TODO comment at every mutation point and uses the existing `notification_log` table with `kind="admin_action"` as a poor-man's audit trail. F4's backend PR replaces the `notification_log` writes with proper `admin_audit` rows. |
+| 7 | `broadcast_at` parity across orchestrators | **Verify post-draft (already implements per F1 epic notes), add to preseason + weekly orchestrators if missing.** Single helper in `lambdas/common/ai_reports_store.py` — `stamp_broadcast_at(league_id, report_type, period)` — called from all three orchestrators after `send_emails_concurrently` returns success. |
+| 8 | Read-path filter shape | **Filter in lambda, not Dynamo.** Both `api_ai_reports_latest` and `api_ai_reports_list` already pull the row(s) into Python before serializing. Post-filter list-comprehension `[r for r in rows if is_admin or r["metadata"].get("is_redacted") != "true"]` is one line per endpoint. Dynamo-side filter expression would require a GSI rebuild — not worth it for ~52 rows/year. |
+
+---
+
+## Affected Files / Components
+
+### Infrastructure (`xomper-infrastructure`)
+
+| File | Change | Why |
+|------|--------|-----|
+| `terraform/lambdas_api.tf` | Add 1 entry to `local.api_lambdas`: `admin-reports-flag` (POST) at path `admin/reports/{league_id}/{report_type}/{period}/flag` | Routes the new flag endpoint via existing `aws_lambda_function.api` for-each. No IAM change — existing exec role already has Dynamo R/W on `xomper-ai-reports`. |
+
+### Backend (`xomper-back-end`)
+
+| File | Change | Why |
+|------|--------|-----|
+| `lambdas/api_admin_reports_flag/__init__.py` | **New** empty module init | Standard layout. |
+| `lambdas/api_admin_reports_flag/handler.py` | **New** `POST` handler. ~90 lines. | The flag endpoint. Validates `flag in {"is_redacted","do_not_broadcast"}` + `value: bool`, calls `update_metadata`, returns the new metadata blob. |
+| `lambdas/common/admin_gate.py` | Add `def is_admin(event) -> bool` non-raising helper | Read-path filter needs to branch on caller admin status without raising. |
+| `lambdas/common/ai_reports_store.py` | Add `stamp_broadcast_at(league_id, report_type, period)` helper that calls `update_metadata` with `{"broadcast_at": now_iso()}` | Single canonical place to write the stamp. Used by all three orchestrators. |
+| `lambdas/api_admin_ai_review_postdraft_trigger/orchestrator.py` | **Verify** DNB check exists immediately before `send_emails_concurrently`. **Verify** `stamp_broadcast_at` is called after a successful broadcast. Refactor to use the new helper if it inlines the metadata write today. | Per session notes post-draft already stamps; confirm + normalize. |
+| `lambdas/api_admin_ai_review_preseason_trigger/orchestrator.py` | **Add** DNB pre-fan-out check (409 abort). **Add** `stamp_broadcast_at` call after success. | Replicate post-draft pattern. |
+| `lambdas/common/weekly_orchestrator.py` | **Add** DNB pre-fan-out check (409 abort). **Add** `stamp_broadcast_at` call after success. | Replicate post-draft pattern. |
+| `lambdas/api_ai_reports_latest/handler.py` | After fetching the row, return `None`/empty when `metadata.is_redacted == "true"` AND caller is **not** admin (use `admin_gate.is_admin`). | Hide redacted from non-admin clients. |
+| `lambdas/api_ai_reports_list/handler.py` | After fetching the page, filter out `is_redacted == "true"` rows for non-admin callers. Keep pagination cursor stable — filter is post-query (acceptable for our row counts). | Same as latest. |
+| `tests/test_api_admin_reports_flag.py` | **New** pytest module | Non-admin 403; happy path for both flags; rejects unknown flag; rejects missing report; round-trips through `update_metadata`. |
+| `tests/test_orchestrator_dnb_abort.py` | **New** pytest module | Each of the three orchestrators aborts with 409 when `metadata.do_not_broadcast == "true"` AND `dry_run=false`. Dry-run path is unaffected. |
+| `tests/test_orchestrator_broadcast_at_stamp.py` | **New** pytest module | Each of the three orchestrators calls `stamp_broadcast_at` after `send_emails_concurrently` returns success. Partial-failure case does **not** stamp. |
+| `tests/test_api_ai_reports_redact_filter.py` | **New** pytest module | `api_ai_reports_latest` returns the row for admin + omits/returns 404 for non-admin when redacted. `api_ai_reports_list` filters redacted rows for non-admin + includes them for admin. |
+
+### iOS (`xomper-ios`)
+
+| File | Change | Why |
+|------|--------|-----|
+| `Xomper/Core/Models/AIReport.swift` | Add three computed accessors: `var isRedacted: Bool { metadata["is_redacted"] == "true" }`, `var doNotBroadcast: Bool { metadata["do_not_broadcast"] == "true" }`, `var broadcastAt: Date? { metadata["broadcast_at"].flatMap { Self.parseISO($0) } }`. Expose `parseISO` as `static` (currently `private static`). | The flat-map already collapses Dynamo BOOL to string per `metadata` computed property (lines 46–58) — these are one-liners over the same source of truth. |
+| `Xomper/Core/Models/ReportFlag.swift` | **New** — small `enum ReportFlag: String, Sendable { case isRedacted = "is_redacted"; case doNotBroadcast = "do_not_broadcast" }` | Typed input for the API call. |
+| `Xomper/Core/Networking/XomperAPIClient.swift` | Add `func setReportFlag(report: AIReport, flag: ReportFlag, value: Bool) async throws -> ReportFlagResponse` to `XomperAPIClientProtocol` + concrete impl. POST to `/admin/reports/<league_id>/<report_type>/<period>/flag` with body `{ "flag": ..., "value": ... }`. Add `ReportFlagResponse: Decodable` with the returned metadata. | The store calls this. |
+| `Xomper/Core/Stores/AdminStore.swift` | Add `func setReportFlag(report: AIReport, flag: ReportFlag, value: Bool) async throws`. On success, mutate `lastPreviewsByType` IS NOT applicable (previews aren't the source of truth) — instead, re-fetch the affected `*Latest` report so the trigger card reflects the new flag state. | The store is already the broadcast surface owner; the flag write is broadcast-adjacent. |
+| `Xomper/Core/Stores/AIReviewStore.swift` | Add `var showRedacted: Bool = false` (admin-only toggle source of truth) + `func setReportFlag(report:flag:value:) async throws` that delegates to the API client and mutates `archive` in place so the row reflects the change without a full refetch. Re-fetch on flag change is also fine — single-call latency is fast and avoids stale state. | Archive view needs to mutate rows on hide/show. |
+| `Xomper/Features/Admin/AIReviewPreviewView.swift` | Add a "Do not broadcast" lock row above `broadcastButton`. When checked, Broadcast button disables with label "Locked — DNB flag set" + `XomperColors.errorRed` accent. Tapping the toggle calls `adminStore.setReportFlag(report: latestReportForType, flag: .doNotBroadcast, value: newValue)`. Source the report via `adminStore.<type>Latest` (the store already loads this). | F3 deliverable; F2's preview surface is the right home per epic plan. |
+| `Xomper/Features/AIReview/AIReviewView.swift` | Add `.contextMenu` on each `AIReportCardRow` with two actions: "Hide from app" (when not redacted) / "Show in app" (when redacted). Confirm via `.alert(...)`. Calls `store.setReportFlag(report: report, flag: .isRedacted, value: ...)`. Render redacted rows with a "REDACTED" badge + 50% opacity + disabled `Button(action:)` when `!authStore.isAdmin`. Add a top toolbar toggle "Show redacted" gated by `authStore.isAdmin` — bound to `store.showRedacted`. Filter `store.archive` client-side by `showRedacted` (defense-in-depth — server already filters for non-admin). | F3 deliverable. |
+| `Xomper/Features/AIReview/AIReviewView.swift` (continued) | Inject `authStore` + `adminStore` (the latter is optional — only the archive's own `AIReviewStore.setReportFlag` is needed). | Need admin status to gate the toggle + the hide action. |
+| `Xomper/Features/Shell/MainShell.swift` | Pass `authStore` into `AIReviewView` initializer (the call site already exists; just thread one more parameter). | Hookup. |
+| `XomperTests/AIReportFlagsTests.swift` | **New** — unit tests for the three computed accessors on `AIReport`. | Correctness of the metadata accessor surface. |
+| `XomperTests/AdminStoreReportFlagTests.swift` | **New** — mock `XomperAPIClientProtocol`. Asserts: happy path POSTs the right body, error surfaces in `lastError`, no state mutation on failure. | Store correctness. |
+| `XomperTests/AIReviewStoreRedactTests.swift` | **New** — asserts `showRedacted` toggle filters `archive` correctly; `setReportFlag` mutates the row in place. | Store correctness. |
+
+---
+
+## Implementation Steps
+
+Dependency-ordered. **Infra PR merges first**, then backend, then iOS. Within each PR, commits follow the order below.
+
+### Phase A — Infrastructure (PR #1, `xomper-infrastructure`)
+
+- [ ] **A1**. Add 1 entry to `local.api_lambdas` in `terraform/lambdas_api.tf`:
+  ```hcl
+  { name = "admin-reports-flag",
+    description = "Admin: toggle is_redacted / do_not_broadcast on an AI report row",
+    path_part = "reports/{league_id}/{report_type}/{period}/flag",
+    http_method = "POST" },
+  ```
+  Note: path is nested under `admin/`; confirm the existing for-each handles multi-segment paths (the F1 entries used flat paths, so a small adjustment to the path module may be needed).
+- [ ] **A2**. Run `terraform plan` locally — expect 1 new `aws_lambda_function`, 1 new API GW resource chain (`/admin/reports`, `/admin/reports/{league_id}`, etc.), 1 new method, 1 new permission.
+- [ ] **A3**. Open PR titled `infra(admin-portal F3): add POST /admin/reports/{...}/flag`. Body links epic plan + F3 plan.
+- [ ] **A4**. After CI green: apply via GitHub Actions (Terraform-only infra rule — no local apply).
+- [ ] **A5**. Verify via `aws apigateway get-resources` that the four nested path resources exist and the POST method is wired.
+
+### Phase B — Backend (PR #2, `xomper-back-end`)
+
+- [ ] **B1**. Add `lambdas/common/admin_gate.py::is_admin(event) -> bool` non-raising helper. Mirrors `require_admin` minus the raise. Returns `False` when the claim is missing.
+- [ ] **B2**. Add `lambdas/common/ai_reports_store.py::stamp_broadcast_at(league_id, report_type, period)` that calls `update_metadata(... {"broadcast_at": datetime.now(timezone.utc).isoformat()})`.
+- [ ] **B3**. Audit post-draft orchestrator (`api_admin_ai_review_postdraft_trigger/orchestrator.py`):
+  - Confirm there's a DNB metadata check between `build_email_payload(...)` and `send_emails_concurrently(...)`. If missing, add one — abort with 409 + `{"Success": false, "Message": "Report is marked do_not_broadcast. Toggle the flag off to broadcast."}`.
+  - Confirm `broadcast_at` is stamped after the SES fan-out returns. If inline today, refactor to call `stamp_broadcast_at(...)`.
+  - Add a dry-run guard around the DNB check + stamp — both only apply when `dry_run == False`.
+- [ ] **B4**. Repeat B3 for `api_admin_ai_review_preseason_trigger/orchestrator.py`. Replicate the post-draft pattern (probably missing today per the input notes).
+- [ ] **B5**. Repeat B3 for `lambdas/common/weekly_orchestrator.py`. Same pattern.
+- [ ] **B6**. Create `lambdas/api_admin_reports_flag/handler.py`:
+  - Imports: `parse_body`, `success_response`, `error_response`, `require_admin`, `NotAdmin`, `get_report`, `update_metadata`, plus `log_email` (or a new `log_admin_action`) from `notification_log`.
+  - Flow:
+    1. `require_admin(event)` → raises NotAdmin (caught → 403).
+    2. Parse path params: `league_id`, `report_type`, `period`.
+    3. Parse body: `flag` (must be `"is_redacted"` or `"do_not_broadcast"`), `value` (must be bool). Reject 400 on anything else.
+    4. `get_report(league_id, report_type, period)` → 404 if missing.
+    5. `update_metadata(league_id, report_type, period, {flag: "true" if value else "false"})`.
+    6. `# TODO(F4): admin_audit row` (or call the placeholder `log_admin_action` helper if cheap).
+    7. Return `success_response({"Success": true, "flag": flag, "value": value, "metadata": <full updated map>})`.
+- [ ] **B7**. Modify `lambdas/api_ai_reports_latest/handler.py`:
+  - After fetching the row, if `metadata.get("is_redacted") == "true"` AND `not is_admin(event)` → return 404 (treat as "not found" so non-admin clients don't even learn the row exists).
+- [ ] **B8**. Modify `lambdas/api_ai_reports_list/handler.py`:
+  - After fetching the page, filter rows: `rows = [r for r in rows if is_admin(event) or r.get("metadata", {}).get("is_redacted") != "true"]`.
+  - **Cursor caveat**: filter is post-query. Page size can shrink below the requested limit. Acceptable — iOS infinite scroll already handles short pages.
+- [ ] **B9**. Write `tests/test_api_admin_reports_flag.py`:
+  - **T1**: non-admin → 403.
+  - **T2**: invalid `flag` → 400.
+  - **T3**: missing `value` → 400.
+  - **T4**: unknown report → 404.
+  - **T5**: happy path `is_redacted=true` → returns metadata with flag set, `update_metadata` called once.
+  - **T6**: happy path `do_not_broadcast=true` → same.
+  - **T7**: round-trip — set then unset (idempotency).
+- [ ] **B10**. Write `tests/test_orchestrator_dnb_abort.py`:
+  - For each of the three orchestrators:
+    - **T1**: report has `do_not_broadcast=true`, `dry_run=false` → 409 + clear message; `send_emails_concurrently` NOT called.
+    - **T2**: report has `do_not_broadcast=true`, `dry_run=true` → dry-run path unaffected (no abort).
+    - **T3**: report has `do_not_broadcast=false`, `dry_run=false` → normal send path runs.
+- [ ] **B11**. Write `tests/test_orchestrator_broadcast_at_stamp.py`:
+  - For each orchestrator:
+    - **T1**: `dry_run=false` + successful SES → `stamp_broadcast_at` called once.
+    - **T2**: `dry_run=false` + partial failure (SES raises) → `stamp_broadcast_at` NOT called.
+    - **T3**: `dry_run=true` → `stamp_broadcast_at` NOT called.
+- [ ] **B12**. Write `tests/test_api_ai_reports_redact_filter.py`:
+  - **T1**: `latest` returns row for admin caller when `is_redacted=true`.
+  - **T2**: `latest` returns 404 for non-admin caller when `is_redacted=true`.
+  - **T3**: `list` includes redacted rows for admin caller.
+  - **T4**: `list` filters out redacted rows for non-admin caller.
+- [ ] **B13**. Run `pytest lambdas/` + `pytest tests/` → green.
+- [ ] **B14**. Open PR titled `feat(admin-portal F3): reports flag endpoint + DNB enforcement + broadcast_at stamp`. Body links F3 plan; calls out the three orchestrators + the two read-path changes.
+- [ ] **B15**. After merge, backend deploy lambda push. Hit `POST /admin/reports/.../flag` via `curl` with a known admin JWT + a known report; verify metadata via Dynamo console.
+
+### Phase C — iOS (PR #3, `xomper-ios`)
+
+- [ ] **C1**. Extend `AIReport.swift`:
+  - Make `parseISO` `internal static` (currently `private static`) so the new accessor can use it. Alternatively keep private and call it through a wrapper computed property — pick the lighter touch.
+  - Add `var isRedacted: Bool { metadata["is_redacted"] == "true" }`.
+  - Add `var doNotBroadcast: Bool { metadata["do_not_broadcast"] == "true" }`.
+  - Add `var broadcastAt: Date? { metadata["broadcast_at"].flatMap { AIReport.parseISO($0) } }`.
+- [ ] **C2**. Create `Xomper/Core/Models/ReportFlag.swift`:
+  ```swift
+  enum ReportFlag: String, Sendable {
+      case isRedacted = "is_redacted"
+      case doNotBroadcast = "do_not_broadcast"
+  }
+  ```
+- [ ] **C3**. Extend `XomperAPIClient`:
+  - Add `ReportFlagResponse: Decodable` with `success: Bool`, `flag: String`, `value: Bool`, `metadata: [String: JSONValue]?` (raw map; iOS doesn't need to consume it but it's there for forward compat).
+  - Add `func setReportFlag(report: AIReport, flag: ReportFlag, value: Bool) async throws -> ReportFlagResponse` to `XomperAPIClientProtocol`. Concrete impl parses `report.id` (composite `LEAGUE#<id>|REPORT#<type>#<period>`) to derive path params, then POSTs to `/admin/reports/<league_id>/<report_type>/<period>/flag` with body `{ "flag": flag.rawValue, "value": value }`.
+- [ ] **C4**. Extend `AdminStore.swift`:
+  - Add `func setReportFlag(report: AIReport, flag: ReportFlag, value: Bool) async throws`. On success: re-load the affected `*Latest` (`postDraftLatest`, `preseasonLatest`, or `weeklyLatest`) so the trigger card / preview view reflects the new state.
+- [ ] **C5**. Extend `AIReviewStore.swift`:
+  - Add `var showRedacted: Bool = false` (admin opt-in to see redacted rows in the archive).
+  - Add `func setReportFlag(report: AIReport, flag: ReportFlag, value: Bool) async throws`. On success: mutate the matching entry in `archive` in place (find by `report.id`, replace with a re-fetched copy or apply the flag locally — pick local mutation via a memberwise rebuild for instant UI feedback).
+- [ ] **C6**. Modify `AIReviewPreviewView.swift`:
+  - Resolve `currentReport: AIReport?` from `adminStore.<type>Latest` (switch on `reportType`).
+  - Above `broadcastButton`, render a `dnbLockRow`:
+    - `HStack(spacing: XomperTheme.Spacing.sm) { Image(systemName: doNotBroadcast ? "lock.fill" : "lock.open"); Toggle("Do not broadcast", isOn: dnbBinding); Spacer() }`
+    - Caption below: `Text("Locks this report from being broadcast. Toggle off to re-enable.")`.
+    - Toggle binding fires `Task { try? await adminStore.setReportFlag(report: currentReport, flag: .doNotBroadcast, value: $0) }`.
+  - `broadcastButton.disabled(...)` now also disables when `currentReport?.doNotBroadcast == true`. When disabled for DNB reason, change the label to `"Locked — DNB flag set"` and tint the background `XomperColors.errorRed.opacity(0.5)`.
+  - Add a small `@State private var dnbInFlight = false` so the toggle disables itself during the round-trip.
+- [ ] **C7**. Modify `AIReviewView.swift`:
+  - Pass `authStore: AuthStore` as a new init param.
+  - Add `@State private var pendingHide: AIReport?` for the confirm dialog state.
+  - Wrap each `AIReportCardRow` with a `.contextMenu` (long-press) that exposes:
+    - **Hide from app** (when `!report.isRedacted`, admin only) → sets `pendingHide = report`.
+    - **Show in app** (when `report.isRedacted`, admin only) → calls `store.setReportFlag(... .isRedacted, value: false)` directly (less destructive — no confirm).
+  - Add `.alert("Hide \(pendingHide?.displayTitle ?? "")?", isPresented: pendingHideBinding) { Button("Cancel", role: .cancel) {}; Button("Hide", role: .destructive) { Task { ... } } } message: { Text("This removes the report from the league archive. Admins can still see it and un-hide it later. Already-delivered emails are unaffected.") }`.
+  - Add a top toolbar `Toggle("Show redacted", isOn: $store.showRedacted)` gated by `authStore.isAdmin`.
+  - Render redacted rows with a "REDACTED" badge (red caps text, top-right corner) + `.opacity(0.5)` + `.disabled(!authStore.isAdmin)` on the underlying Button so non-admins can't tap.
+  - Client-side filter (defense-in-depth): `let visible = store.archive.filter { !$0.isRedacted || store.showRedacted }`. Replace `store.archive` with `visible` in the existing `ForEach`.
+- [ ] **C8**. Modify `MainShell.swift`:
+  - Pass `authStore` into the `AIReviewView` call site.
+- [ ] **C9**. Run `xcodegen generate` + iOS build:
+  ```bash
+  DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild \
+    -scheme Xomper -sdk iphonesimulator \
+    -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build
+  ```
+- [ ] **C10**. Write `XomperTests/AIReportFlagsTests.swift`:
+  - **T1**: `isRedacted` true when `metadata["is_redacted"] == "true"`.
+  - **T2**: `doNotBroadcast` true when `metadata["do_not_broadcast"] == "true"`.
+  - **T3**: `broadcastAt` parses ISO8601 with and without fractional seconds.
+  - **T4**: all three default to false/nil when metadata absent.
+- [ ] **C11**. Write `XomperTests/AdminStoreReportFlagTests.swift`:
+  - Mock `XomperAPIClientProtocol`.
+  - **T1**: `setReportFlag` happy path → mock client called with right args; latest re-fetched.
+  - **T2**: API error → throws, latest not mutated.
+- [ ] **C12**. Write `XomperTests/AIReviewStoreRedactTests.swift`:
+  - **T1**: `showRedacted=false` filters out redacted entries (caller view derivation).
+  - **T2**: `setReportFlag(... .isRedacted, value: true)` mutates the entry in place after API success.
+  - **T3**: API failure leaves the entry unchanged.
+- [ ] **C13**. Manual QA pass on iPhone 17 Pro simulator (admin acct):
+  - Fire dry-run for any report type → preview opens. Toggle "Do not broadcast" on → Broadcast button greys out + label changes. Toggle off → button restored. Sleeper-DB inspection: `metadata.do_not_broadcast` round-trips.
+  - Attempt broadcast on a DNB-locked report (toggle off → broadcast → back → toggle on → broadcast) → 409 surfaces inline in the preview view (existing `broadcastError` path).
+  - Open AI Review archive. Long-press a row → "Hide from app" → confirm. Row disappears from non-admin view (toggle showRedacted off). Toggle showRedacted on → row reappears with REDACTED badge + dim. Long-press → "Show in app" → row reverts.
+  - Non-admin acct: archive does not show the toggle; redacted rows never appear at all (server filter).
+- [ ] **C14**. Open PR titled `feat(admin-portal F3): redact + DNB + broadcast_at stamping`. Body links epic plan + F3 plan; tags PRs #1 (infra) + #2 (backend) as merged; screen recordings of both the preview DNB lock + the archive hide action.
+
+### Phase D — Coordination + Sign-off
+
+- [ ] **D1**. After all three PRs merge: `/end-session` to log learnings into `.claude/memory/session-log.md`.
+- [ ] **D2**. Update `EPIC_PLAN.md` orchestration block — flip F3 from Draft to Done; flag F4 as ready to start (F4 retrofits audit writes into F1 + F3 lambdas).
+- [ ] **D3**. Flip this plan's Status to `Done`. Update `Last updated` field.
+
+---
+
+## Test Plan
+
+### Backend (`xomper-back-end/tests/`)
+
+| Test | File | Asserts |
+|------|------|---------|
+| Non-admin 403 | `test_api_admin_reports_flag.py::test_non_admin_403` | 403 + `Success=False` |
+| Invalid flag rejected | `test_api_admin_reports_flag.py::test_invalid_flag_400` | 400 on `flag="bogus"` |
+| Missing value rejected | `test_api_admin_reports_flag.py::test_missing_value_400` | 400 when body lacks `value` |
+| Unknown report | `test_api_admin_reports_flag.py::test_unknown_report_404` | 404 |
+| Set is_redacted | `test_api_admin_reports_flag.py::test_set_is_redacted` | `update_metadata` called with `{"is_redacted": "true"}` |
+| Set do_not_broadcast | `test_api_admin_reports_flag.py::test_set_do_not_broadcast` | same for DNB |
+| Idempotent unset | `test_api_admin_reports_flag.py::test_round_trip` | set+unset = original metadata |
+| DNB aborts broadcast (postdraft) | `test_orchestrator_dnb_abort.py::test_postdraft_dnb_abort` | 409, no SES call |
+| DNB aborts broadcast (preseason) | `test_orchestrator_dnb_abort.py::test_preseason_dnb_abort` | 409, no SES call |
+| DNB aborts broadcast (weekly) | `test_orchestrator_dnb_abort.py::test_weekly_dnb_abort` | 409, no SES call |
+| DNB does NOT abort dry-run | `test_orchestrator_dnb_abort.py::test_dry_run_unaffected` | dry-run path runs |
+| broadcast_at stamped on success (×3 orchestrators) | `test_orchestrator_broadcast_at_stamp.py::test_*_stamps_on_success` | `stamp_broadcast_at` called once |
+| broadcast_at NOT stamped on SES failure | `test_orchestrator_broadcast_at_stamp.py::test_*_no_stamp_on_failure` | helper not called |
+| Redact filter: latest hides for non-admin | `test_api_ai_reports_redact_filter.py::test_latest_hides_for_non_admin` | 404 returned |
+| Redact filter: latest visible for admin | `test_api_ai_reports_redact_filter.py::test_latest_visible_for_admin` | row returned |
+| Redact filter: list filters for non-admin | `test_api_ai_reports_redact_filter.py::test_list_filters_for_non_admin` | redacted rows absent |
+| Redact filter: list includes for admin | `test_api_ai_reports_redact_filter.py::test_list_includes_for_admin` | redacted rows present |
+
+### iOS (`XomperTests/`)
+
+| Test | File | Asserts |
+|------|------|---------|
+| `isRedacted` accessor | `AIReportFlagsTests.swift::test_isRedacted_true_when_metadata` | true/false branches |
+| `doNotBroadcast` accessor | `AIReportFlagsTests.swift::test_doNotBroadcast_true_when_metadata` | true/false branches |
+| `broadcastAt` parses ISO | `AIReportFlagsTests.swift::test_broadcastAt_parses_iso` | with + without fractional seconds |
+| `AdminStore.setReportFlag` happy | `AdminStoreReportFlagTests.swift::test_setReportFlag_happy` | mock client called; latest re-fetched |
+| `AdminStore.setReportFlag` error | `AdminStoreReportFlagTests.swift::test_setReportFlag_error` | throws, latest not mutated |
+| `AIReviewStore.showRedacted` filter | `AIReviewStoreRedactTests.swift::test_showRedacted_filters` | derived view respects toggle |
+| `AIReviewStore.setReportFlag` mutates | `AIReviewStoreRedactTests.swift::test_setReportFlag_mutates_in_place` | matching row replaced |
+| `AIReviewStore.setReportFlag` error | `AIReviewStoreRedactTests.swift::test_setReportFlag_error_no_mutation` | archive untouched |
+
+### Manual QA Checklist
+
+- [ ] Dry-run a report → open preview → toggle DNB on → Broadcast button shows "Locked — DNB flag set" + red tint + disabled.
+- [ ] Toggle DNB off → Broadcast button restored.
+- [ ] DNB state survives app restart (Dynamo persistence).
+- [ ] Force a real broadcast on a DNB-locked report by toggling off, broadcasting, then locking — second broadcast attempt 409s with clear message in `broadcastError`.
+- [ ] After successful broadcast (any of the 3 types) → Dynamo row has `metadata.broadcast_at` populated.
+- [ ] Long-press archive row → "Hide from app" → confirm dialog → row disappears from non-admin view.
+- [ ] Admin toggle "Show redacted" on → redacted row visible with REDACTED badge + dim.
+- [ ] Long-press redacted row → "Show in app" → row reverts to normal.
+- [ ] Non-admin acct: archive never shows redacted rows AND no "Show redacted" toggle.
+- [ ] Non-admin acct: `/ai-reports/latest` returns 404 for a redacted report; `/ai-reports/list` omits it.
+
+---
+
+## Acceptance Checklist
+
+- [ ] `POST /admin/reports/{league_id}/{report_type}/{period}/flag` returns `{Success: true, flag, value, metadata}` for happy-path admin call.
+- [ ] Endpoint returns 403 for non-admin callers.
+- [ ] Endpoint returns 400 for unknown flag names or non-bool values.
+- [ ] All three orchestrators abort with 409 when `metadata.do_not_broadcast == "true"` AND `dry_run=false`.
+- [ ] All three orchestrators stamp `metadata.broadcast_at` after successful SES fan-out (and only after).
+- [ ] `api_ai_reports_latest` returns 404 for non-admin callers when the row is redacted.
+- [ ] `api_ai_reports_list` filters redacted rows for non-admin callers.
+- [ ] `AIReport` exposes `isRedacted`, `doNotBroadcast`, `broadcastAt` computed properties.
+- [ ] `AIReviewPreviewView` has a DNB lock row; Broadcast button locks when checked.
+- [ ] `AIReviewView` has a context-menu hide/show action with confirm dialog.
+- [ ] `AIReviewView` admin "Show redacted" toggle works; redacted rows render with badge + dim when visible.
+- [ ] All backend + iOS tests pass.
+- [ ] Three PRs merged in order: infra → backend → iOS.
+- [ ] Epic plan's F3 row flipped to Done.
+
+---
+
+## Out of Scope (deferred to F4 or polish)
+
+- `admin_audit` Supabase table + row writes (F4 ships the table and retrofits audit writes into F3's flag endpoint).
+- Bulk redact / un-redact actions (e.g. "Hide all preseason reports"). Single-row only for V1.
+- "Redacted by X on Y" badge metadata (would require capturing `actor_sleeper_id` + `redacted_at` in metadata; deferred since the audit table covers this in F4).
+- Paginated archive picker for setting DNB pre-emptively on rows that aren't the latest (V1 only locks the latest report per type — that's the only one the preview surface ever shows).
+- Push notification when a report is redacted (no use case yet).
+- Recall already-delivered email (impossible — the dialog wording is "Hide from app" for this exact reason).
+- iOS detail-view UX for redacted reports (V1: detail still opens for admin tap on a redacted row in `showRedacted=true` mode; non-admin can never reach the detail anyway because the row is filtered).
+
+---
+
+## Risks / Tradeoffs
+
+| Risk | Mitigation |
+|------|------------|
+| DNB check runs after Anthropic generation (wasteful when admin sets DNB between dry-run and broadcast) | Accepted: the alternative (check before generation) misses the race where DNB is set between generation and broadcast. Generation cost is bounded (≤1 Claude call per broadcast attempt). |
+| `broadcast_at` race: stamping fires before SES fan-out completes, partial failure leaves report marked broadcast | Stamp AFTER `send_emails_concurrently` returns success. Unit test `test_*_no_stamp_on_failure` enforces. |
+| Audit gap between F3 ship and F4 retrofit | `# TODO(F4): admin_audit row` comments at every mutation point + grep gate in F4's PR review. Acceptable risk for a 12-person league with one admin. |
+| Redact filter applied post-query → pages can shrink below requested limit | Acceptable — infinite scroll already handles short pages. Documented in B8 step. |
+| `parseISO` visibility change ripples | Either make it `internal static` (small surface change) or add a thin wrapper accessor — pick lighter touch in C1. |
+| `metadata` Dynamo Map writes overwrite vs merge | `update_metadata` merges by design (used by every other path already). Test T7 round-trips to confirm. |
+| iOS `setReportFlag` race when admin double-taps the toggle | `@State dnbInFlight` disables the toggle during the round-trip. |
+| Non-admin learns redacted reports exist (timing attack on 404 vs 200) | Acceptable for a closed-league app. The 404 is identical to a missing report so no info leak. |
+| Existing post-draft orchestrator already stamps but in a different shape than the new helper | B3 explicitly refactors to use `stamp_broadcast_at` so all three orchestrators write the same key with the same format. |
+
+---
+
+## Open Questions
+
+- [ ] Verify post-draft orchestrator's current `broadcast_at` write — if it stamps a non-ISO format or a different key, B3 normalizes. Confirm at start of Phase B.
+- [ ] Should the DNB toggle on the preview view also clear the local previews so the admin re-runs dry-run to confirm? **Recommendation**: no — DNB is reversible and previews are still useful for inspection. The Broadcast button being locked is enough signal.
+- [ ] Should `AIReviewStore.setReportFlag` re-fetch the row from the backend after success, or mutate locally? **Recommendation**: mutate locally for instant UI feedback; the backend's `update_metadata` is the source of truth, but the flag is the only thing changing so the local mutation is safe. Documented in C5.
+- [ ] Do we want a "broadcast at" timestamp surfaced anywhere in the iOS UI in F3, or defer to F4? **Recommendation**: defer — `AIReport.broadcastAt` is exposed on the model but no view consumes it in F3. F4's table editor naturally shows it as a row column.
+
+---
+
+## Skills / Agents to Use
+
+- **`backend-engineer` agent** for Phase B (lambda + helpers + orchestrator updates + tests).
+- **`ios-engineer` agent** for Phase C (model accessors, store extensions, preview + archive view edits).
+- **Terraform skill** for Phase A (single `lambdas_api.tf` edit + GitHub Actions apply per the Terraform-only infra rule).
+- **`/execute admin-portal/f3-redact`** kicks off the three-phase delegation preview after Status flips to Ready.


### PR DESCRIPTION
## Summary

Closes the F3 broadcast-safety loop on iOS. Adds three coordinated surfaces:

- **DNB toggle** on `AIReviewPreviewView` — lock-icon row above the Broadcast button. When checked, the Broadcast button disables, label flips to "Locked — DNB flag set", and the background tints `errorRed`.
- **Redact actions** on `AIReviewView` archive rows — `.contextMenu` exposes "Hide from app" (destructive confirm alert) / "Show in app". Hidden rows render with a REDACTED badge + 50% opacity when visible.
- **Admin-only "Show redacted" toolbar toggle** on `AIReviewView`. Non-admin users never see the toggle (and the server already filters redacted rows for them).
- **`broadcast_at` accessor** on `AIReport`. No UI consumes it in F3 — exposed for F4's table editor.

## What changed

**New:**
- `Xomper/Core/Models/ReportFlag.swift` — `ReportFlag` enum + `ReportFlagResponse` decode shape.
- `XomperTests/ReportFlagTests.swift` — 13 tests covering all three metadata accessors + enum + response decode.
- `XomperTests/AdminStoreFlagTests.swift` — 5 tests covering both stores' setReportFlag orchestrators.

**Modified:**
- `Xomper/Core/Models/AIReport.swift` — three computed metadata accessors (`isRedacted`, `doNotBroadcast`, `broadcastAt`). Flipped `parseISO` from `private static` to `static`.
- `Xomper/Core/Networking/XomperAPIClient.swift` — `setReportFlag` method + protocol entry.
- `Xomper/Core/Stores/AdminStore.swift` — `setReportFlag` orchestrator + `latest(for:)` accessor. Re-fetches the affected `*Latest` after a successful write.
- `Xomper/Core/Stores/AIReviewStore.swift` — `setReportFlag` orchestrator (mutates archive in place) + `showRedacted: Bool` admin opt-in.
- `Xomper/Features/Admin/AIReviewPreviewView.swift` — `dnbLockRow` + lockable Broadcast button.
- `Xomper/Features/AIReview/AIReviewView.swift` — context menu, confirm alert, REDACTED badge, admin show-redacted toolbar toggle.
- `Xomper/Features/Shell/MainShell.swift` — passes `authStore` into `AIReviewView`.
- `XomperTests/AdminStoreTests.swift` / `AIReviewStoreTests.swift` / `TestEmailStoreTests.swift` — added `setReportFlag` mock impls to keep the protocol mocks conforming.

## Dependencies

- Backend: `xomper-back-end` PR #67 — flag endpoint + DNB enforcement + broadcast_at stamping.
- Infra: `xomper-infrastructure` PR #109 — `POST /admin/reports-flag` route registration.
- Plan: `docs/features/admin-portal/f3-redact/PLAN.md` (Status: Ready).
- Epic: `docs/features/admin-portal/EPIC_PLAN.md` — F3 row.

Closes #91.

## Test plan

- [x] Unit: 13 `ReportFlagTests` — all pass.
- [x] Unit: 5 `AdminStoreFlagTests` — all pass.
- [x] Full suite: 115 tests, all pass.
- [x] Build: clean, no warnings.
- [ ] Manual (sim): Fire a weekly dry-run → preview opens. Toggle DNB on → Broadcast greys + label changes. Toggle off → Broadcast restored.
- [ ] Manual (sim): Archive long-press → "Hide from app" → confirm alert → row disappears.
- [ ] Manual (sim): Toggle "Show redacted" on (admin only) → row reappears with REDACTED badge.
- [ ] Manual (sim): Long-press redacted row → "Show in app" → row returns to normal.
- [ ] Manual (sim, non-admin): toolbar toggle absent, redacted rows never appear.