### PR TITLE
feat(mock-draft): client-side rookie mock engine

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		0905D6C3E336782530E5F4B4 /* LogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99981051F598B42534DE81CB /* LogLevel.swift */; };
 		0A87A5226863819FF3884F6C /* AnnouncementsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCF4387BA57375E04A8940B /* AnnouncementsCard.swift */; };
 		0C2B77E0A46ECE55AE8CE46F /* DivisionBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B670A3A0762D22FB3202E1E /* DivisionBadge.swift */; };
+		10F252D05E75C513A5780FD8 /* EngineMockedPick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CD7928EAED8A9ADA1C683B /* EngineMockedPick.swift */; };
 		114998283E6705D075ED2CA7 /* League.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD88B55D96BD7C519B6B65B6 /* League.swift */; };
 		11EFE5DD5C1D6DE5056597BB /* PlayerPointsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36829F2AD0FD089788B9CE1 /* PlayerPointsStore.swift */; };
 		133F58C70F4FA02676079E9A /* RulesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FDC8A9B02A2BFD83398D04F /* RulesStore.swift */; };
@@ -35,6 +36,7 @@
 		284F17C4CD26363D19756E03 /* TrayProfileCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3FE7B1A468AA2569D95B20 /* TrayProfileCard.swift */; };
 		2A6A3B695891A9925C663FB4 /* AuditEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E231D553037403D68EB216 /* AuditEntry.swift */; };
 		2BE0B9AB9BAEFD6AA714D2EF /* DraftRecapResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB0B979B62A1CF6EB80417F /* DraftRecapResolverTests.swift */; };
+		2ECED2F6ACF5F762D1E1462F /* MockDraftEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A951936FD34F712A8D8E66C0 /* MockDraftEngineTests.swift */; };
 		2F09FBAE23D8109C931D63A9 /* XomperTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBB5433786555EDDBC896C7 /* XomperTheme.swift */; };
 		2F50FD9BC26550139DAD2E96 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F510E2F428E107F1AD75CD /* Config.swift */; };
 		2F60B09D13BABD5E49B3DCBF /* MainShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A254D17EF062523E09C9D4 /* MainShell.swift */; };
@@ -46,7 +48,9 @@
 		37E600A31B5AA5DA5A766692 /* AdminStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ED7387DCA3E1DC5CDD7AFF /* AdminStoreTests.swift */; };
 		3B1DDBCA7B19B8703FAF717E /* DrawerScrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D921732971689E8096F9549 /* DrawerScrim.swift */; };
 		3B67875F822BE9AA9BD052EF /* DraftHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6060C3A4F2B355757F1E3A2 /* DraftHistoryView.swift */; };
+		3B72E4DFCC9CB503A8EB4BD0 /* MockDraftStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C33587E13342D4234DD55FA /* MockDraftStore.swift */; };
 		3E5A98150356BEB75FD87145 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = 72178EB48829A7D249085476 /* Supabase */; };
+		3E78C9E4D65745EF23FACBBA /* MockDraftResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C1490E2B5B3B9C4FAB735 /* MockDraftResult.swift */; };
 		40C507B6FB2EF2A7E647AA3C /* TeamStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36A01820FD0F6643BBF8511D /* TeamStore.swift */; };
 		427F23653F78A52108C55692 /* XomperLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3B178733D5AF9EB7DA7189 /* XomperLoader.swift */; };
 		42BF3DEE63074148F1DF0BD1 /* AIReviewDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967DCE922FE090CE4F067587 /* AIReviewDetailView.swift */; };
@@ -58,6 +62,7 @@
 		4DB9374CF45A69E97C02FC94 /* PlayerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC44D14381C74E97D8AF868F /* PlayerDetailView.swift */; };
 		4E0CAC9964BF3F2B59EDD844 /* DraftHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A789B8D49FA4430886626289 /* DraftHistory.swift */; };
 		4E975CC9716AFD855A964A53 /* LeagueEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8B04D9DD0B2952BBABAB46 /* LeagueEditView.swift */; };
+		509666F6EDC374F217AC1071 /* EngineMockedPickRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89328BA5BCB3605A986E57D3 /* EngineMockedPickRow.swift */; };
 		50E9D9254D779960D0D2C5B1 /* EmailPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D0F4D0BBA2C48A0232C43FF /* EmailPreviewTests.swift */; };
 		51BD6DAC467108079C465193 /* SearchResultGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F606D0624D23D47A171D26 /* SearchResultGroup.swift */; };
 		54863F3F6ECDD3BE00083582 /* Roster.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE543CB2E49335ADD02E8000 /* Roster.swift */; };
@@ -96,6 +101,7 @@
 		77A0EFCEE4340D3A7853BF08 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43685B0C212A644C0EF202E5 /* ProfileView.swift */; };
 		77CFB7F9C5E4975E6350662B /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AFC2ADE424F95E3121BF22 /* SettingsView.swift */; };
 		78094B6DF90F54E0FA59898A /* TrayDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70E04168BDBA7D3372BB605 /* TrayDestination.swift */; };
+		79083ADBA183714E71D3DC36 /* MockDraftCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6608DF8A0DC5E1EF5A36A39 /* MockDraftCard.swift */; };
 		7956271EA17998F79679D970 /* AuditFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1358E97D2A18E9A5440D8CC /* AuditFeedView.swift */; };
 		7D94ADAC136455C3056D5867 /* PushNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAEC7A4917990425085AE71 /* PushNotificationManager.swift */; };
 		7E34464209AAF9EC6801191A /* NflState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E5A60EE78F668F02CF63C0 /* NflState.swift */; };
@@ -113,6 +119,7 @@
 		8C67D3AAFE5A0A124BDE5F1A /* AppRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EABD25CAB8BF973C4709720 /* AppRouter.swift */; };
 		8E8B3EC17A43676ACA176FC3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6F2D6E80C100927C4C20FAD7 /* Assets.xcassets */; };
 		901F54CB41785D269CC63160 /* WorldCupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E1C6D5A18697DE79586C1B /* WorldCupStore.swift */; };
+		90B62C24495752B9C03F5CE8 /* HighestPossibleCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6D698BC8816DA02019846C /* HighestPossibleCalculatorTests.swift */; };
 		9134D2C8A8737083C9FB8F7F /* ClinchCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3728C5F6BEF61FE509A3EA32 /* ClinchCalculator.swift */; };
 		93D8C8E352B60752D37FD0FF /* PlayerSeasonStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C24A12080AD428D5A40A7E /* PlayerSeasonStats.swift */; };
 		95DE1C46E20BF6910D4E5447 /* TrayItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E4EC7FDB93C47A9EE601BA3 /* TrayItem.swift */; };
@@ -127,9 +134,11 @@
 		A379F9D71FE84EC4F3A2499C /* SearchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C5F37100E6EBB467EBFE1C /* SearchStore.swift */; };
 		A45E9B6A2A65059251FB3D76 /* AdminStorePreseasonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD03A165767A043D34A9499 /* AdminStorePreseasonTests.swift */; };
 		A4D93DF4C02A8DE6C695CE4D /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E94170F987E8EFE5C566B9B /* LoginView.swift */; };
+		AB72973CE762675E8087A1C2 /* MockDraftEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5EA1D700C954EFB08B185F2 /* MockDraftEngine.swift */; };
 		AFE044848CB195AC6BC3CA62 /* DraftRecapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5DA384F46CEDA38C9898C14 /* DraftRecapView.swift */; };
 		B24D5DBDDF4C163FCAB52689 /* TeamAnalysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC09DFF48D9AAFEF0A286BAD /* TeamAnalysis.swift */; };
 		B309CAE3F00F954918C09554 /* PlayerValuesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE99E9B095120FB6636FC8A /* PlayerValuesStore.swift */; };
+		B3826B5CCBF64A347CCF75D0 /* DraftPersonality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E909175D4E989F36E6A4B9B /* DraftPersonality.swift */; };
 		B48B9F6061A67CFC74A096CC /* StandingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957EE31D25CFE325633622D4 /* StandingsStore.swift */; };
 		B7EB06298BFBF6AC76ABF53E /* TeamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51CC9357B13AB7ADD9C8586 /* TeamView.swift */; };
 		BB91E92DC29E6ECA5E1F0DEC /* SeasonStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F3F1A18F4EEC5A3F81FD28 /* SeasonStore.swift */; };
@@ -143,6 +152,7 @@
 		C381DCE8472D2F88B04FCBDA /* CareerStatsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CFD764A2BA7FF93B318A7F /* CareerStatsSection.swift */; };
 		C9D656F4702A3483BB8E970C /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A99CAA9B57C1A0144DCA22 /* Player.swift */; };
 		CB47F51AA46AEBC59183C449 /* PlayoffBracketView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581D4F6F3EB8FC0547F49927 /* PlayoffBracketView.swift */; };
+		CC44774FC6B17057810140CF /* SeededRNGTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F82C66C92981F7F8AB58CE /* SeededRNGTests.swift */; };
 		CD0DD0769D59E9688C719322 /* LogEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C57E1F397386BF980992CF7 /* LogEvent.swift */; };
 		CDA1A124C81E1FF5127BEE2C /* TraySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A497DF9DD9066BD24A1E19 /* TraySection.swift */; };
 		CEC2B1D5D34F80BFB3444C6F /* LeagueOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A84518A312FF0F96719AF1E8 /* LeagueOverviewView.swift */; };
@@ -161,6 +171,8 @@
 		DD07BFD2B8150BC2E8256BE1 /* LogGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A099DEE55FFF98FE95185F /* LogGroup.swift */; };
 		E0951007574761D3F51B21B9 /* DraftSubTabSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7456E9AFD3FA47DA3DA0F7 /* DraftSubTabSelectionTests.swift */; };
 		E1D933F9B0C3E87F9C1C907A /* XomperAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89FC018282A1F1D8B2FD1B60 /* XomperAPIClient.swift */; };
+		E1E44482FBD2CBBA9ED6E829 /* TeamContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747BA75CF4BABB8C5748469D /* TeamContext.swift */; };
+		E1EA65A3788E9D5F4B2D45B8 /* SeededRNG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7697158FD11D7CF6F9045B /* SeededRNG.swift */; };
 		E2E0551B857C17254E9B789B /* AdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E257076F7FE641947D1DC978 /* AdminView.swift */; };
 		E2EC532916CAA2FBB779DB35 /* UserStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62948D0A455E7CE99B15CB75 /* UserStore.swift */; };
 		E64E815819D87CED1DF5383F /* AIReviewPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6B846E697A235684C8EBA4 /* AIReviewPreviewView.swift */; };
@@ -198,6 +210,7 @@
 		0BC1E989411B5FACF30C4B3A /* PastStandingsArchiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastStandingsArchiveTests.swift; sourceTree = "<group>"; };
 		10CD226D313FDD91E4037D8E /* SupabaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseManager.swift; sourceTree = "<group>"; };
 		1687307C5353DC42503BD721 /* AuditDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditDetailView.swift; sourceTree = "<group>"; };
+		16CD7928EAED8A9ADA1C683B /* EngineMockedPick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineMockedPick.swift; sourceTree = "<group>"; };
 		18383A0375F5728A9E3FE065 /* Championship.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Championship.swift; sourceTree = "<group>"; };
 		1AD376EFB7AD4A192FAB3E8F /* RecordBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordBadge.swift; sourceTree = "<group>"; };
 		1D61FC118C0250CA87BDF647 /* ReportFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportFlagTests.swift; sourceTree = "<group>"; };
@@ -231,10 +244,12 @@
 		4690614F644FE74115D0DAB6 /* ProposedTrade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProposedTrade.swift; sourceTree = "<group>"; };
 		46DB1025586B733C289B45A3 /* HistoricalStandingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoricalStandingsView.swift; sourceTree = "<group>"; };
 		46FB9B5B4B8700EACD4A9CFD /* AdminStorePreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStorePreviewTests.swift; sourceTree = "<group>"; };
+		48F82C66C92981F7F8AB58CE /* SeededRNGTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeededRNGTests.swift; sourceTree = "<group>"; };
 		4D0F4D0BBA2C48A0232C43FF /* EmailPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailPreviewTests.swift; sourceTree = "<group>"; };
 		501B8FD2B915B3BD6568F42C /* HexagonChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HexagonChartView.swift; sourceTree = "<group>"; };
 		50D86A1E276C98E0A3D5070F /* MocksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MocksView.swift; sourceTree = "<group>"; };
 		536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthStore.swift; sourceTree = "<group>"; };
+		539C1490E2B5B3B9C4FAB735 /* MockDraftResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftResult.swift; sourceTree = "<group>"; };
 		558164667DF7D89C4DF2F32E /* MyProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyProfileView.swift; sourceTree = "<group>"; };
 		56BB91320E3D5EBE1F777838 /* LeagueStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeagueStore.swift; sourceTree = "<group>"; };
 		57940AEB84889A20016648F2 /* TaxiSquadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiSquadView.swift; sourceTree = "<group>"; };
@@ -242,6 +257,7 @@
 		5800235C3D61B73FE57C7308 /* UsersListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsersListView.swift; sourceTree = "<group>"; };
 		581D4F6F3EB8FC0547F49927 /* PlayoffBracketView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayoffBracketView.swift; sourceTree = "<group>"; };
 		58ED7387DCA3E1DC5CDD7AFF /* AdminStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStoreTests.swift; sourceTree = "<group>"; };
+		5A6D698BC8816DA02019846C /* HighestPossibleCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighestPossibleCalculatorTests.swift; sourceTree = "<group>"; };
 		5CE99E9B095120FB6636FC8A /* PlayerValuesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerValuesStore.swift; sourceTree = "<group>"; };
 		5E2B7884F65B1BD0E9B82AA9 /* PastStandingsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastStandingsListView.swift; sourceTree = "<group>"; };
 		5E7AC7756D5F973D69491BC5 /* TablesSubScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TablesSubScreenView.swift; sourceTree = "<group>"; };
@@ -263,9 +279,12 @@
 		6F2D6E80C100927C4C20FAD7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		71FB63BCA4BDD437FFE6D3A8 /* PressableCardButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PressableCardButtonStyle.swift; sourceTree = "<group>"; };
 		72CFD764A2BA7FF93B318A7F /* CareerStatsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareerStatsSection.swift; sourceTree = "<group>"; };
+		747BA75CF4BABB8C5748469D /* TeamContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamContext.swift; sourceTree = "<group>"; };
 		765C03E7E4268373F28754DC /* HighestPossibleLineup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighestPossibleLineup.swift; sourceTree = "<group>"; };
 		7839DD9CF0968986F91A58DB /* AdminStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStore.swift; sourceTree = "<group>"; };
 		7877A392F88F41B8D4979F23 /* MockDraftMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftMetadataTests.swift; sourceTree = "<group>"; };
+		7C33587E13342D4234DD55FA /* MockDraftStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftStore.swift; sourceTree = "<group>"; };
+		7E909175D4E989F36E6A4B9B /* DraftPersonality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftPersonality.swift; sourceTree = "<group>"; };
 		7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Draft.swift; sourceTree = "<group>"; };
 		806CFC3CC188242F06D8639C /* PastDraftPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastDraftPickerView.swift; sourceTree = "<group>"; };
 		8098F78566BB324ACC70FB94 /* TeamAnalyzerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamAnalyzerView.swift; sourceTree = "<group>"; };
@@ -273,8 +292,10 @@
 		831DFA7D391F8415451D6479 /* DraftSubTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftSubTabBar.swift; sourceTree = "<group>"; };
 		840D50097382434B0D123ACB /* NavigationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStore.swift; sourceTree = "<group>"; };
 		8521885A7FF4C6910DFBF549 /* MatchupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupsView.swift; sourceTree = "<group>"; };
+		89328BA5BCB3605A986E57D3 /* EngineMockedPickRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineMockedPickRow.swift; sourceTree = "<group>"; };
 		89FC018282A1F1D8B2FD1B60 /* XomperAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperAPIClient.swift; sourceTree = "<group>"; };
 		8A95FE8DD123C85CA39DAE13 /* AIReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReport.swift; sourceTree = "<group>"; };
+		8B7697158FD11D7CF6F9045B /* SeededRNG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeededRNG.swift; sourceTree = "<group>"; };
 		8D921732971689E8096F9549 /* DrawerScrim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerScrim.swift; sourceTree = "<group>"; };
 		92075E680F858F8EB156001A /* HeadlineAIReportCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadlineAIReportCard.swift; sourceTree = "<group>"; };
 		94DF42654C9F48EE60C040F7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -298,6 +319,7 @@
 		A83A8FEFFD8FA91F498D03A0 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		A84518A312FF0F96719AF1E8 /* LeagueOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeagueOverviewView.swift; sourceTree = "<group>"; };
 		A8BD31456E25771C8D7D39C9 /* XomperApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperApp.swift; sourceTree = "<group>"; };
+		A951936FD34F712A8D8E66C0 /* MockDraftEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftEngineTests.swift; sourceTree = "<group>"; };
 		ACCFF9888476668EBE7AA0CC /* XomperTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = XomperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD43D54AB620DABD559F8A40 /* CareerStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareerStats.swift; sourceTree = "<group>"; };
 		AE543CB2E49335ADD02E8000 /* Roster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Roster.swift; sourceTree = "<group>"; };
@@ -306,6 +328,7 @@
 		B29D510D87CD290AE7F76FBF /* StandingsTeam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsTeam.swift; sourceTree = "<group>"; };
 		B3893B13276074EF6033CEA2 /* ClinchCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClinchCalculatorTests.swift; sourceTree = "<group>"; };
 		B6060C3A4F2B355757F1E3A2 /* DraftHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftHistoryView.swift; sourceTree = "<group>"; };
+		B6608DF8A0DC5E1EF5A36A39 /* MockDraftCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftCard.swift; sourceTree = "<group>"; };
 		B66A2C896FE4C62CF9719D7A /* TaxiStealConfirmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiStealConfirmView.swift; sourceTree = "<group>"; };
 		B67C55260D2B14215D920245 /* LogsRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsRowView.swift; sourceTree = "<group>"; };
 		B94B6AD01FF1F85D81B5A5DE /* TrophyCaseSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrophyCaseSection.swift; sourceTree = "<group>"; };
@@ -360,6 +383,7 @@
 		F3443191E5EED3E2888F8757 /* PayoutsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayoutsView.swift; sourceTree = "<group>"; };
 		F4A254D17EF062523E09C9D4 /* MainShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainShell.swift; sourceTree = "<group>"; };
 		F51CC9357B13AB7ADD9C8586 /* TeamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamView.swift; sourceTree = "<group>"; };
+		F5EA1D700C954EFB08B185F2 /* MockDraftEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftEngine.swift; sourceTree = "<group>"; };
 		F6F606D0624D23D47A171D26 /* SearchResultGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultGroup.swift; sourceTree = "<group>"; };
 		F7048EDD875E2582C792BE47 /* LandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingView.swift; sourceTree = "<group>"; };
 		FB3748F7A26B406C00F1C546 /* AIReviewSubScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewSubScreen.swift; sourceTree = "<group>"; };
@@ -381,6 +405,21 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		12A52E3EF0B0C87306FE9171 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				7E909175D4E989F36E6A4B9B /* DraftPersonality.swift */,
+				16CD7928EAED8A9ADA1C683B /* EngineMockedPick.swift */,
+				89328BA5BCB3605A986E57D3 /* EngineMockedPickRow.swift */,
+				B6608DF8A0DC5E1EF5A36A39 /* MockDraftCard.swift */,
+				F5EA1D700C954EFB08B185F2 /* MockDraftEngine.swift */,
+				539C1490E2B5B3B9C4FAB735 /* MockDraftResult.swift */,
+				8B7697158FD11D7CF6F9045B /* SeededRNG.swift */,
+				747BA75CF4BABB8C5748469D /* TeamContext.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
 		17EC53AFD40D386BDC28634C /* Navigation */ = {
 			isa = PBXGroup;
 			children = (
@@ -501,12 +540,15 @@
 				2DB0B979B62A1CF6EB80417F /* DraftRecapResolverTests.swift */,
 				ED7456E9AFD3FA47DA3DA0F7 /* DraftSubTabSelectionTests.swift */,
 				4D0F4D0BBA2C48A0232C43FF /* EmailPreviewTests.swift */,
+				5A6D698BC8816DA02019846C /* HighestPossibleCalculatorTests.swift */,
 				D7F3E6606D89CF3AEB320314 /* LandingViewTests.swift */,
 				82A98546D2F68452085EEC9C /* LogEventTests.swift */,
 				ED8C8F9BD9880370D65EDF0B /* LogsStoreTests.swift */,
+				A951936FD34F712A8D8E66C0 /* MockDraftEngineTests.swift */,
 				7877A392F88F41B8D4979F23 /* MockDraftMetadataTests.swift */,
 				0BC1E989411B5FACF30C4B3A /* PastStandingsArchiveTests.swift */,
 				1D61FC118C0250CA87BDF647 /* ReportFlagTests.swift */,
+				48F82C66C92981F7F8AB58CE /* SeededRNGTests.swift */,
 				BB79AE4EA78D33BDCD8565A8 /* TestEmailStoreTests.swift */,
 			);
 			path = XomperTests;
@@ -562,6 +604,7 @@
 			isa = PBXGroup;
 			children = (
 				E9ED150F995299D37368EDC3 /* DraftOrderView.swift */,
+				12A52E3EF0B0C87306FE9171 /* Mocks */,
 			);
 			path = DraftOrder;
 			sourceTree = "<group>";
@@ -755,6 +798,7 @@
 				F013CD37874EFB0FA1CB4261 /* HistoryStore.swift */,
 				56BB91320E3D5EBE1F777838 /* LeagueStore.swift */,
 				A3AF6560D898E487AD13DA35 /* LogsStore.swift */,
+				7C33587E13342D4234DD55FA /* MockDraftStore.swift */,
 				94E125AD2AA5212D0EB4C13A /* NflStateStore.swift */,
 				D36829F2AD0FD089788B9CE1 /* PlayerPointsStore.swift */,
 				CC3F6B5022E8151683A45F4F /* PlayerStore.swift */,
@@ -938,12 +982,15 @@
 				2BE0B9AB9BAEFD6AA714D2EF /* DraftRecapResolverTests.swift in Sources */,
 				E0951007574761D3F51B21B9 /* DraftSubTabSelectionTests.swift in Sources */,
 				50E9D9254D779960D0D2C5B1 /* EmailPreviewTests.swift in Sources */,
+				90B62C24495752B9C03F5CE8 /* HighestPossibleCalculatorTests.swift in Sources */,
 				007B11207486956897981421 /* LandingViewTests.swift in Sources */,
 				31527A4E320270A464DBADDB /* LogEventTests.swift in Sources */,
 				7794B2E1BA5055ACFF150166 /* LogsStoreTests.swift in Sources */,
+				2ECED2F6ACF5F762D1E1462F /* MockDraftEngineTests.swift in Sources */,
 				3403B87830513963A9D86F8F /* MockDraftMetadataTests.swift in Sources */,
 				D9737CEB4C36AEFB5EC727D0 /* PastStandingsArchiveTests.swift in Sources */,
 				9FA30DE0724E90F9914ED3BA /* ReportFlagTests.swift in Sources */,
+				CC44774FC6B17057810140CF /* SeededRNGTests.swift in Sources */,
 				57E9FA9D90F0BF708A014023 /* TestEmailStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -984,12 +1031,15 @@
 				4E0CAC9964BF3F2B59EDD844 /* DraftHistory.swift in Sources */,
 				3B67875F822BE9AA9BD052EF /* DraftHistoryView.swift in Sources */,
 				6BC002C5DD7EF547F82CA860 /* DraftOrderView.swift in Sources */,
+				B3826B5CCBF64A347CCF75D0 /* DraftPersonality.swift in Sources */,
 				AFE044848CB195AC6BC3CA62 /* DraftRecapView.swift in Sources */,
 				6D833D6D3E53E0913363925C /* DraftSubTabBar.swift in Sources */,
 				3B1DDBCA7B19B8703FAF717E /* DrawerScrim.swift in Sources */,
 				817EEBDA82021E74A830E1B3 /* DrawerView.swift in Sources */,
 				C1B45AB2AF3DC33FE9B511AF /* EmailPreview.swift in Sources */,
 				72FF7B4516B2DCDAE4683B9D /* EmptyStateView.swift in Sources */,
+				10F252D05E75C513A5780FD8 /* EngineMockedPick.swift in Sources */,
+				509666F6EDC374F217AC1071 /* EngineMockedPickRow.swift in Sources */,
 				556BA960B3DFFACAB2F3DFA6 /* EnvironmentValues+Season.swift in Sources */,
 				60FB3A9B54EAB11F015C1828 /* ErrorView.swift in Sources */,
 				EDDACB3FFB20E468D9D9D67D /* HeaderBar.swift in Sources */,
@@ -1022,7 +1072,11 @@
 				368D96609CAF02430F340657 /* MatchupHistoryBrowserView.swift in Sources */,
 				7EA8F8FCEFFE3C165655208C /* MatchupHistoryView.swift in Sources */,
 				16F47DD114B2470F88D007A5 /* MatchupsView.swift in Sources */,
+				79083ADBA183714E71D3DC36 /* MockDraftCard.swift in Sources */,
+				AB72973CE762675E8087A1C2 /* MockDraftEngine.swift in Sources */,
 				75837F1ECFAFDA457B558FBC /* MockDraftModels.swift in Sources */,
+				3E78C9E4D65745EF23FACBBA /* MockDraftResult.swift in Sources */,
+				3B72E4DFCC9CB503A8EB4BD0 /* MockDraftStore.swift in Sources */,
 				8C58AAB4103D2F8A473DAA4E /* MocksView.swift in Sources */,
 				9E5C71DAB504EDCDF2084DF3 /* MyProfileView.swift in Sources */,
 				FAE7847413A293EF8CE9090C /* NFLTeamColors.swift in Sources */,
@@ -1060,6 +1114,7 @@
 				F7E0A8B9AECD0291527E0D0E /* SearchView.swift in Sources */,
 				143F0C4F56D88430BDC07B2A /* SeasonPickerBar.swift in Sources */,
 				BB91E92DC29E6ECA5E1F0DEC /* SeasonStore.swift in Sources */,
+				E1EA65A3788E9D5F4B2D45B8 /* SeededRNG.swift in Sources */,
 				77CFB7F9C5E4975E6350662B /* SettingsView.swift in Sources */,
 				65DC95B6907B22347616C3D7 /* SleeperAPIClient.swift in Sources */,
 				1AFF6ACF05FD9FC1D186C5A8 /* StandingsListView.swift in Sources */,
@@ -1076,6 +1131,7 @@
 				D7A95C32621E03E2AAB37327 /* TaxiStealConfirmView.swift in Sources */,
 				B24D5DBDDF4C163FCAB52689 /* TeamAnalysis.swift in Sources */,
 				58FD67DB9B137F1A8BE50521 /* TeamAnalyzerView.swift in Sources */,
+				E1E44482FBD2CBBA9ED6E829 /* TeamContext.swift in Sources */,
 				40C507B6FB2EF2A7E647AA3C /* TeamStore.swift in Sources */,
 				B7EB06298BFBF6AC76ABF53E /* TeamView.swift in Sources */,
 				EE987501F73209179D5CEEB4 /* TestEmailStore.swift in Sources */,

--- a/Xomper/Core/Models/HighestPossibleLineup.swift
+++ b/Xomper/Core/Models/HighestPossibleLineup.swift
@@ -77,9 +77,31 @@ enum HighestPossibleCalculator {
         rosterPositions: [String],
         playerStore: PlayerStore
     ) -> Double {
+        optimalLineupPointsByPosition(
+            playerPoints: playerPoints,
+            rosterPositions: rosterPositions,
+            playerStore: playerStore
+        ).values.reduce(0, +)
+    }
+
+    /// Per-position breakdown of the optimal-lineup points for a single
+    /// week. Returns a `[positionLabel: totalPointsCreditedAtThatPosition]`
+    /// map — keys are the chosen player's *position* (QB / RB / WR /
+    /// TE / K / DEF / IDP labels), NOT the slot they filled. So a WR
+    /// chosen at FLEX is credited to `"WR"`.
+    ///
+    /// Drives Team Fit's `needBoost`: summing this map's WR/RB/TE/QB
+    /// entries across regular-season weeks gives `teamPosHPP` per
+    /// position. Greedy + slot-restrictiveness ordering identical to
+    /// `optimalLineupPoints` so the totals match exactly.
+    static func optimalLineupPointsByPosition(
+        playerPoints: [String: Double],
+        rosterPositions: [String],
+        playerStore: PlayerStore
+    ) -> [String: Double] {
         // 1. Filter to active starting slots
         let activeSlots = rosterPositions.filter { !nonStartingSlots.contains($0) }
-        guard !activeSlots.isEmpty else { return 0 }
+        guard !activeSlots.isEmpty else { return [:] }
 
         // 2. Resolve each slot's eligibility set
         let slots: [(slot: String, eligible: Set<String>)] = activeSlots.map { slot in
@@ -103,18 +125,19 @@ enum HighestPossibleCalculator {
         let orderedSlots = slots.sorted { $0.eligible.count < $1.eligible.count }
 
         // 5. Greedy: each slot grabs the highest-scoring eligible
-        //    unassigned candidate.
+        //    unassigned candidate; credit it to the chosen player's
+        //    position bucket.
         var used: Set<String> = []
-        var total: Double = 0
+        var byPos: [String: Double] = [:]
         for slotEntry in orderedSlots {
             let pick = candidates
                 .filter { !used.contains($0.id) && slotEntry.eligible.contains($0.pos) }
                 .max(by: { $0.pts < $1.pts })
             if let pick {
                 used.insert(pick.id)
-                total += pick.pts
+                byPos[pick.pos, default: 0] += pick.pts
             }
         }
-        return total
+        return byPos
     }
 }

--- a/Xomper/Core/Stores/MockDraftStore.swift
+++ b/Xomper/Core/Stores/MockDraftStore.swift
@@ -1,0 +1,353 @@
+import Foundation
+
+/// Orchestrates the client-side mock-draft engine. Owns the rookie
+/// pool derivation, the `TeamContext` snapshot, and the cached Pure +
+/// Mixed results for the current session.
+///
+/// View flow:
+/// 1. `MocksView` calls `ensureLoaded(...)` on appear (idempotent).
+/// 2. Store builds `TeamContext`, derives the rookie pool, and runs
+///    the engine once per personality (Pure) and three times with
+///    random per-team assignments (Mixed). Both modes pre-baked so
+///    toggling between them is instant.
+/// 3. `reshuffle()` bumps `currentSeed` and regenerates all stochastic
+///    results. Deterministic mocks (BPA / Team Fit / Win-Now) are
+///    untouched — same seed, same input, same output.
+@Observable
+@MainActor
+final class MockDraftStore {
+
+    // MARK: - State
+
+    enum Status: Sendable, Equatable {
+        case idle
+        case pending
+        case ready
+        case noUpcomingDraft
+        case noRookiePool
+        case error(String)
+    }
+
+    private(set) var status: Status = .idle
+
+    /// Personality → Pure mock result. One entry per personality the
+    /// engine knows about (5 entries when fully populated).
+    private(set) var pureMocks: [DraftPersonality: MockDraftResult] = [:]
+
+    /// 3 Mixed mocks. Each has a distinct seed and a random per-team
+    /// personality assignment.
+    private(set) var mixedMocks: [MockDraftResult] = []
+
+    /// Resolved slot order from `historyStore.upcomingDraft.draft_order`.
+    /// `slot → SlotTeam` so the view can render the team next to each
+    /// pick.
+    private(set) var slotOrder: [Int: SlotTeam] = [:]
+
+    /// The rookie pool used to generate the current results. Surfaced
+    /// for tests + a debug footer in dev builds.
+    private(set) var rookiePool: [RookieCandidate] = []
+
+    /// Whether the pool was widened from `yearsExp == 0` to
+    /// `yearsExp ∈ {0, 1}` because the strict intersection was too
+    /// small. View surfaces a header warning when true.
+    private(set) var didFallbackPool: Bool = false
+
+    /// `TeamContext.isFallback` for the current run — surfaced so the
+    /// view can warn when Team Fit degrades to BPA.
+    private(set) var didFallbackTeamContext: Bool = false
+
+    /// Active viewing mode. Defaults to Pure on first appear per the
+    /// plan.
+    private(set) var mode: MockDraftResult.Mode = .pure
+
+    /// Current RNG seed. Bumped by `reshuffle()` so stochastic mocks
+    /// re-roll while deterministic mocks stay stable.
+    private(set) var currentSeed: UInt64 = 0xC0FFEE_5EED
+
+    // MARK: - Config (defaults match the plan)
+
+    /// Rookie draft rounds. 5 rounds × 12 teams = 60 picks in the
+    /// happy path.
+    static let defaultRounds: Int = 5
+
+    /// Minimum pool size before triggering the fallback widen to
+    /// `yearsExp ∈ {0, 1}`.
+    static let minPoolSize: Int = 60
+
+    /// Cache identity: bumps when the underlying draft / values
+    /// snapshots change so `ensureLoaded` knows to regenerate.
+    private var lastBuildKey: String?
+
+    // MARK: - Public API
+
+    /// Idempotent loader. Builds `TeamContext`, derives the rookie
+    /// pool, and generates Pure + Mixed mocks for the current
+    /// session. No-op when the relevant snapshots haven't changed.
+    func ensureLoaded(
+        leagueStore: LeagueStore,
+        historyStore: HistoryStore,
+        playerStore: PlayerStore,
+        playerValuesStore: PlayerValuesStore,
+        playerPointsStore: PlayerPointsStore,
+        regularSeasonLastWeek: Int
+    ) {
+        // Gate on the dependencies the engine needs.
+        guard let upcomingDraft = historyStore.upcomingDraft else {
+            status = .noUpcomingDraft
+            return
+        }
+        guard playerValuesStore.hasValues else {
+            status = .pending
+            return
+        }
+        guard !playerStore.players.isEmpty else {
+            status = .pending
+            return
+        }
+
+        // Snake-draft warning per PLAN.md step 18. v1 ships linear-only;
+        // we render the mocks anyway under linear assumptions.
+        if let type = upcomingDraft.type?.lowercased(),
+           type == "snake" {
+            // Just log — the view surfaces a banner. (No print(); use
+            // os_log later if needed.)
+            _ = type
+        }
+
+        let buildKey = makeBuildKey(
+            draftId: upcomingDraft.draftId,
+            valuesLoadedAt: playerValuesStore.lastLoadedAt,
+            seed: currentSeed
+        )
+        if buildKey == lastBuildKey { return }
+
+        // Resolve slot order from `draft_order` + upcoming users +
+        // rosters.
+        let slots = resolveSlotOrder(
+            draft: upcomingDraft,
+            historyStore: historyStore
+        )
+        guard !slots.isEmpty else {
+            status = .noUpcomingDraft
+            return
+        }
+        slotOrder = slots
+
+        // Build the rookie pool.
+        let (pool, didFallback) = buildRookiePool(
+            playerStore: playerStore,
+            playerValuesStore: playerValuesStore
+        )
+        guard !pool.isEmpty else {
+            status = .noRookiePool
+            return
+        }
+        rookiePool = pool
+        didFallbackPool = didFallback
+
+        // Per-roster per-position HPP snapshot.
+        let rosterIds = Array(Set(slots.values.map { $0.rosterId })).sorted()
+        let context = TeamContext.build(
+            rosterIds: rosterIds,
+            leagueStore: leagueStore,
+            playerStore: playerStore,
+            playerPointsStore: playerPointsStore,
+            regularSeasonLastWeek: regularSeasonLastWeek
+        )
+        didFallbackTeamContext = context.isFallback
+
+        // Generate Pure + Mixed.
+        regenerateAll(teamContext: context)
+
+        lastBuildKey = buildKey
+        status = .ready
+    }
+
+    /// Bumps the seed and regenerates stochastic mocks. BPA, Team Fit,
+    /// and Win-Now are deterministic so their entries don't change —
+    /// but we re-run them anyway for symmetry (cheap; 60 picks × 458
+    /// rookies × 5 personalities is sub-millisecond).
+    func reshuffle(
+        leagueStore: LeagueStore,
+        historyStore: HistoryStore,
+        playerStore: PlayerStore,
+        playerValuesStore: PlayerValuesStore,
+        playerPointsStore: PlayerPointsStore,
+        regularSeasonLastWeek: Int
+    ) {
+        currentSeed = currentSeed &* 0x9E37_79B9_7F4A_7C15 &+ 0x1234_5678_9ABC_DEF1
+        lastBuildKey = nil
+        ensureLoaded(
+            leagueStore: leagueStore,
+            historyStore: historyStore,
+            playerStore: playerStore,
+            playerValuesStore: playerValuesStore,
+            playerPointsStore: playerPointsStore,
+            regularSeasonLastWeek: regularSeasonLastWeek
+        )
+    }
+
+    func setMode(_ newMode: MockDraftResult.Mode) {
+        mode = newMode
+    }
+
+    // MARK: - Generation
+
+    private func regenerateAll(teamContext: TeamContext) {
+        var newPure: [DraftPersonality: MockDraftResult] = [:]
+
+        // Pure: one mock per personality. Each personality draws from
+        // its own RNG slice so reshuffle's seed change propagates to
+        // both stochastic personalities, not just whichever was
+        // generated first.
+        for (i, p) in DraftPersonality.displayOrder.enumerated() {
+            var rng = SeededRNG(seed: currentSeed &+ UInt64(i))
+            let (picks, didExhaust) = MockDraftEngine.run(
+                rookies: rookiePool,
+                slotOrder: slotOrder,
+                rounds: Self.defaultRounds,
+                teamContext: teamContext,
+                personality: { _, _ in p },
+                rng: &rng
+            )
+            newPure[p] = MockDraftResult(
+                id: "pure-\(p.rawValue)",
+                mode: .pure,
+                purePersonality: p,
+                picks: picks,
+                personalityByRosterId: nil,
+                seed: currentSeed &+ UInt64(i),
+                didExhaustPool: didExhaust
+            )
+        }
+        pureMocks = newPure
+
+        // Mixed: 3 mocks, each with random per-team personality
+        // assignments. Use the seed to drive the assignment too so
+        // reshuffle changes the team→personality map AND the
+        // stochastic picks.
+        let rosterIds = Array(Set(slotOrder.values.map { $0.rosterId })).sorted()
+        var newMixed: [MockDraftResult] = []
+        for i in 0..<3 {
+            let mockSeed = currentSeed &+ UInt64(100 + i)
+            var assignmentRNG = SeededRNG(seed: mockSeed)
+            var assignment: [Int: DraftPersonality] = [:]
+            for rid in rosterIds {
+                let idx = assignmentRNG.nextInt(in: 0..<DraftPersonality.allCases.count)
+                assignment[rid] = DraftPersonality.allCases[idx]
+            }
+
+            var runRNG = SeededRNG(seed: mockSeed &+ 1)
+            let (picks, didExhaust) = MockDraftEngine.run(
+                rookies: rookiePool,
+                slotOrder: slotOrder,
+                rounds: Self.defaultRounds,
+                teamContext: teamContext,
+                personality: { _, rosterId in
+                    assignment[rosterId] ?? .bpa
+                },
+                rng: &runRNG
+            )
+            newMixed.append(
+                MockDraftResult(
+                    id: "mixed-\(mockSeed)",
+                    mode: .mixed,
+                    purePersonality: nil,
+                    picks: picks,
+                    personalityByRosterId: assignment,
+                    seed: mockSeed,
+                    didExhaustPool: didExhaust
+                )
+            )
+        }
+        mixedMocks = newMixed
+    }
+
+    // MARK: - Slot order
+
+    /// Resolves `slot → SlotTeam` from the upcoming-draft snapshot.
+    /// `draft.draftOrder` is `[user_id: slot]`; cross-reference with
+    /// `upcomingUsers` for display names and `upcomingRosters` for
+    /// roster IDs.
+    private func resolveSlotOrder(
+        draft: Draft,
+        historyStore: HistoryStore
+    ) -> [Int: SlotTeam] {
+        guard let order = draft.draftOrder, !order.isEmpty else { return [:] }
+        var bySlot: [Int: SlotTeam] = [:]
+        for (userId, slot) in order {
+            let user = historyStore.upcomingUsers.first { ($0.userId ?? "") == userId }
+            let roster = historyStore.upcomingRosters.first { $0.ownerId == userId }
+            guard let rosterId = roster?.rosterId else { continue }
+            let teamName = user?.teamName ?? user?.resolvedDisplayName ?? "Slot \(slot)"
+            bySlot[slot] = SlotTeam(
+                rosterId: rosterId,
+                userId: userId,
+                teamName: teamName
+            )
+        }
+        return bySlot
+    }
+
+    // MARK: - Rookie pool
+
+    /// Builds the rookie pool. Strict intersection of
+    /// `Player.yearsExp == 0` ∩ FantasyCalc dynasty values ∩ skill
+    /// positions (QB / RB / WR / TE). Widens to
+    /// `yearsExp ∈ {0, 1}` if the strict intersection is under
+    /// `minPoolSize` players.
+    func buildRookiePool(
+        playerStore: PlayerStore,
+        playerValuesStore: PlayerValuesStore
+    ) -> (pool: [RookieCandidate], didFallback: Bool) {
+        let skillPositions: Set<String> = ["QB", "RB", "WR", "TE"]
+
+        func candidate(for playerId: String, player: Player) -> RookieCandidate? {
+            let value = playerValuesStore.value(for: playerId)
+            guard value > 0 else { return nil }
+            let position = player.displayPosition
+            guard skillPositions.contains(position.uppercased()) else { return nil }
+            return RookieCandidate(
+                playerId: playerId,
+                fullName: player.fullDisplayName,
+                position: position,
+                nflTeam: player.displayTeam,
+                value: Double(value)
+            )
+        }
+
+        // Strict pool.
+        var strict: [RookieCandidate] = []
+        for (pid, player) in playerStore.players where player.yearsExp == 0 {
+            if let c = candidate(for: pid, player: player) {
+                strict.append(c)
+            }
+        }
+        if strict.count >= Self.minPoolSize {
+            return (strict.sorted { $0.value > $1.value }, false)
+        }
+
+        // Fallback: widen to yearsExp ∈ {0, 1}.
+        var widened: [RookieCandidate] = strict
+        var seen = Set(strict.map(\.playerId))
+        for (pid, player) in playerStore.players
+        where (player.yearsExp == 1) && !seen.contains(pid) {
+            if let c = candidate(for: pid, player: player) {
+                widened.append(c)
+                seen.insert(pid)
+            }
+        }
+        return (widened.sorted { $0.value > $1.value }, !widened.isEmpty && widened.count > strict.count)
+    }
+
+    // MARK: - Cache key
+
+    private func makeBuildKey(
+        draftId: String,
+        valuesLoadedAt: Date?,
+        seed: UInt64
+    ) -> String {
+        let stamp = valuesLoadedAt.map { String(Int($0.timeIntervalSince1970)) } ?? "nil"
+        return "\(draftId)|\(stamp)|\(seed)"
+    }
+}

--- a/Xomper/Core/Stores/PlayerStore.swift
+++ b/Xomper/Core/Stores/PlayerStore.swift
@@ -84,6 +84,14 @@ final class PlayerStore {
         players[id]
     }
 
+    /// Test seam: inject a synthetic players dict for unit tests that
+    /// drive helpers (e.g. `HighestPossibleCalculator`) without
+    /// touching the network. Production code should never call this
+    /// — it bypasses ETag invalidation + the disk-cache contract.
+    func setPlayersForTesting(_ players: [String: Player]) {
+        self.players = players
+    }
+
     /// Lazily fetches and caches per-season fantasy stats. No-op if
     /// already cached or already in flight. Errors are swallowed
     /// silently — calling sites can render `nil` averages on failure

--- a/Xomper/Features/DraftHistory/Draft/MocksView.swift
+++ b/Xomper/Features/DraftHistory/Draft/MocksView.swift
@@ -1,70 +1,91 @@
 import SwiftUI
 
-/// Renders the three mock-draft personalities (BPA, Team Fit,
-/// Wildcard) as collapsible cards. Each card surfaces the first five
-/// rounds of the 60-pick mock as a table — round / slot / team /
-/// player / pos — with a "YOU" badge on the rows belonging to the
-/// signed-in user.
+/// Mocks tab — client-side rookie mock-draft engine. Replaces the
+/// earlier backend-fetched view that pulled `report_type=mock` rows
+/// from Dynamo. The engine is pure Swift (see
+/// `Features/DraftOrder/Mocks/MockDraftEngine`) and runs against the
+/// live FantasyCalc rookie pool + the Sleeper-set slot order for the
+/// upcoming draft.
 ///
-/// Data flow:
-/// 1. On appear, `aiReviewStore.loadMockDrafts()` pulls every
-///    `type=mock` report for the league. Cached for 12 hours.
-/// 2. Each report's `metadata.personality` field maps to a
-///    `MockDraftPersonality`; the 60-pick `metadata.picks[]` array
-///    is decoded via `AIReport.decodeMetadata(MockDraftMetadata.self)`.
-/// 3. The first personality card (BPA) is expanded by default; the
-///    other two start collapsed to keep the surface tight on first
-///    appearance.
+/// Two viewing modes (see `PLAN.md §5`):
+/// - **Pure**: one mock per personality (5 mocks, every team picks
+///   the same way).
+/// - **Mixed**: 3 mocks, each with a random per-team personality
+///   assignment.
 ///
-/// Backend dependency: the `"mock"` AIReportType case must be
-/// recognized by the list endpoint (Xomware/xomper-back-end#62). On a
-/// stack where that PR hasn't deployed yet, the fetch returns zero
-/// rows and the view falls back to the empty state.
+/// Cached for the session via `MockDraftStore`. Reshuffle bumps the
+/// seed and regenerates the stochastic mocks (Wildcard + Hype Train)
+/// — deterministic mocks (BPA / Team Fit / Win-Now) reuse the same
+/// inputs and produce identical output.
 struct MocksView: View {
-    var aiReviewStore: AIReviewStore
+    var leagueStore: LeagueStore
+    var historyStore: HistoryStore
+    var playerStore: PlayerStore
+    var playerValuesStore: PlayerValuesStore
+    var playerPointsStore: PlayerPointsStore
+    var nflStateStore: NflStateStore
     var userStore: UserStore
 
-    /// Tracks which personality cards are expanded. BPA expanded by
-    /// default per the spec ("first expanded, rest collapsed").
-    @State private var expanded: Set<MockDraftPersonality> = [.bpa]
+    @State private var store = MockDraftStore()
+    @State private var expandedIds: Set<String> = []
 
     var body: some View {
         Group {
-            if aiReviewStore.isLoadingMockDrafts && aiReviewStore.mockDrafts.isEmpty {
-                LoadingView(message: "Loading mock drafts…")
-            } else if let error = aiReviewStore.mockDraftsError,
-                      aiReviewStore.mockDrafts.isEmpty {
-                ErrorView(message: error.localizedDescription) {
-                    Task { await aiReviewStore.loadMockDrafts(force: true) }
-                }
-            } else if aiReviewStore.mockDrafts.isEmpty {
+            switch store.status {
+            case .idle, .pending:
+                LoadingView(message: "Generating mock drafts…")
+            case .noUpcomingDraft:
                 EmptyStateView(
-                    icon: "wand.and.stars",
-                    title: "No Mock Drafts Yet",
-                    message: "The mock-draft engine hasn't published results for this year. Check back after the next run."
+                    icon: "calendar.badge.exclamationmark",
+                    title: "No Upcoming Draft",
+                    message: "The commissioner hasn't set up the next draft yet. Once it's scheduled in Sleeper, mocks will appear here."
                 )
-            } else {
-                mocksContent
+            case .noRookiePool:
+                EmptyStateView(
+                    icon: "person.fill.questionmark",
+                    title: "No Rookies Found",
+                    message: "FantasyCalc didn't return any rookies with non-zero dynasty value. Try refreshing after the NFL draft."
+                )
+            case .error(let message):
+                ErrorView(message: message) {
+                    loadDependencies()
+                }
+            case .ready:
+                content
             }
         }
         .background(XomperColors.bgDark.ignoresSafeArea())
-        .task {
-            await aiReviewStore.loadMockDrafts()
+        .task(id: triggerKey) {
+            loadDependencies()
         }
         .refreshable {
-            await aiReviewStore.loadMockDrafts(force: true)
+            await refresh()
         }
     }
 
-    // MARK: - Content
+    // MARK: - Ready content
 
-    private var mocksContent: some View {
+    private var content: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
-                ForEach(MockDraftPersonality.displayOrder, id: \.self) { personality in
-                    if let report = report(for: personality) {
-                        personalityCard(report: report, personality: personality)
-                    }
+                topBar
+
+                if store.didFallbackPool {
+                    fallbackNotice(
+                        text: "Rookie pool widened to include 1st-year vets — strict yearsExp = 0 pool was too small."
+                    )
+                }
+                if store.didFallbackTeamContext {
+                    fallbackNotice(
+                        text: "Team Fit degraded to BPA — no weekly points loaded yet."
+                    )
+                }
+
+                switch store.mode {
+                case .pure:
+                    pureCards
+                case .mixed:
+                    mixedCards
                 }
             }
             .padding(.horizontal, XomperTheme.Spacing.md)
@@ -72,256 +93,216 @@ struct MocksView: View {
         }
     }
 
-    // MARK: - Personality Card
+    // MARK: - Top bar (mode toggle + reshuffle)
 
-    @ViewBuilder
-    private func personalityCard(report: AIReport, personality: MockDraftPersonality) -> some View {
-        if let metadata = report.decodeMetadata(MockDraftMetadata.self) {
-            personalityCardBody(
-                report: report,
-                personality: personality,
-                metadata: metadata
-            )
-        } else {
-            // Metadata couldn't be decoded — body markdown is still
-            // available, but the table view depends on the structured
-            // picks. Fall back to an empty card with a hint.
-            personalityHeaderOnly(personality: personality, report: report)
+    private var topBar: some View {
+        HStack(alignment: .center, spacing: XomperTheme.Spacing.sm) {
+            modeToggle
+            Spacer(minLength: 0)
+            reshuffleButton
         }
     }
 
-    private func personalityCardBody(
-        report: AIReport,
-        personality: MockDraftPersonality,
-        metadata: MockDraftMetadata
-    ) -> some View {
-        let isExpanded = expanded.contains(personality)
+    private var modeToggle: some View {
+        HStack(spacing: 0) {
+            modePill(.pure, label: "Pure")
+            modePill(.mixed, label: "Mixed")
+        }
+        .padding(2)
+        .background(XomperColors.surfaceLight.opacity(0.4))
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md + 2))
+    }
 
-        return VStack(alignment: .leading, spacing: 0) {
-            cardHeader(
-                personality: personality,
-                report: report,
-                isExpanded: isExpanded
+    private func modePill(_ mode: MockDraftResult.Mode, label: String) -> some View {
+        let isSelected = store.mode == mode
+        return Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            withAnimation(XomperTheme.defaultAnimation) {
+                store.setMode(mode)
+            }
+        } label: {
+            Text(label)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(isSelected ? XomperColors.bgDark : XomperColors.textSecondary)
+                .padding(.horizontal, XomperTheme.Spacing.sm)
+                .padding(.vertical, 6)
+                .frame(minWidth: 64)
+                .background(isSelected ? XomperColors.championGold : Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityLabel("\(label) mode")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private var reshuffleButton: some View {
+        Button {
+            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+            store.reshuffle(
+                leagueStore: leagueStore,
+                historyStore: historyStore,
+                playerStore: playerStore,
+                playerValuesStore: playerValuesStore,
+                playerPointsStore: playerPointsStore,
+                regularSeasonLastWeek: regularSeasonLastWeek
             )
+        } label: {
+            HStack(spacing: XomperTheme.Spacing.xxs) {
+                Image(systemName: "arrow.triangle.2.circlepath")
+                Text("Reshuffle")
+            }
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(XomperColors.championGold)
+            .padding(.horizontal, XomperTheme.Spacing.sm)
+            .padding(.vertical, 6)
+            .frame(minHeight: 32)
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md)
+                    .strokeBorder(XomperColors.championGold.opacity(0.4), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityLabel("Reshuffle stochastic mocks")
+    }
 
-            if isExpanded {
-                VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
-                    Text(personality.blurb)
-                        .font(.caption)
-                        .foregroundStyle(XomperColors.textSecondary)
-                        .padding(.top, XomperTheme.Spacing.xs)
+    private func fallbackNotice(text: String) -> some View {
+        HStack(alignment: .top, spacing: XomperTheme.Spacing.xs) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(XomperColors.championGold)
+            Text(text)
+                .font(.caption)
+                .foregroundStyle(XomperColors.textSecondary)
+        }
+        .padding(XomperTheme.Spacing.sm)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+    }
 
-                    Divider()
-                        .overlay(XomperColors.surfaceLight)
-                        .padding(.vertical, XomperTheme.Spacing.xs)
+    // MARK: - Cards
 
-                    picksTable(picks: metadata.picks)
-
-                    Text("Showing rounds 1–5 of \(metadata.picksCount / 12)")
-                        .font(.caption2)
-                        .foregroundStyle(XomperColors.textMuted)
-                        .padding(.top, XomperTheme.Spacing.xs)
+    private var pureCards: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
+            ForEach(DraftPersonality.displayOrder) { personality in
+                if let result = store.pureMocks[personality] {
+                    card(for: result)
                 }
-                .padding(.top, XomperTheme.Spacing.sm)
-                .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
-        .padding(XomperTheme.Spacing.md)
-        .background(XomperColors.bgCard)
-        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
-                .strokeBorder(XomperColors.championGold.opacity(0.25), lineWidth: 1)
+    }
+
+    private var mixedCards: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
+            ForEach(store.mixedMocks) { result in
+                card(for: result)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func card(for result: MockDraftResult) -> some View {
+        MockDraftCard(
+            result: result,
+            slotOrder: store.slotOrder,
+            myUserId: userStore.myUser?.userId,
+            isExpanded: binding(for: result.id)
         )
     }
 
-    private func personalityHeaderOnly(
-        personality: MockDraftPersonality,
-        report: AIReport
-    ) -> some View {
-        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
-            cardHeader(personality: personality, report: report, isExpanded: false)
-            Text("Mock results couldn't be parsed.")
-                .font(.caption)
-                .foregroundStyle(XomperColors.textMuted)
-        }
-        .padding(XomperTheme.Spacing.md)
-        .background(XomperColors.bgCard)
-        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
-    }
-
-    // MARK: - Header
-
-    private func cardHeader(
-        personality: MockDraftPersonality,
-        report: AIReport,
-        isExpanded: Bool
-    ) -> some View {
-        Button {
-            let generator = UIImpactFeedbackGenerator(style: .light)
-            generator.impactOccurred()
-            withAnimation(XomperTheme.defaultAnimation) {
-                if expanded.contains(personality) {
-                    expanded.remove(personality)
+    private func binding(for id: String) -> Binding<Bool> {
+        Binding(
+            get: { expandedIds.contains(id) },
+            set: { newValue in
+                if newValue {
+                    expandedIds.insert(id)
                 } else {
-                    expanded.insert(personality)
+                    expandedIds.remove(id)
                 }
             }
-        } label: {
-            HStack(spacing: XomperTheme.Spacing.sm) {
-                Image(systemName: "wand.and.stars")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(XomperColors.championGold)
-                    .frame(width: 24)
+        )
+    }
 
-                VStack(alignment: .leading, spacing: XomperTheme.Spacing.xxs) {
-                    Text(personality.displayName)
-                        .font(.headline)
-                        .foregroundStyle(XomperColors.textPrimary)
-                    Text(report.period)
-                        .font(.caption2)
-                        .foregroundStyle(XomperColors.textMuted)
-                        .monospacedDigit()
-                }
+    // MARK: - Side-effects
 
-                Spacer()
-
-                Image(systemName: "chevron.down")
-                    .font(.caption)
-                    .foregroundStyle(XomperColors.textMuted)
-                    .rotationEffect(.degrees(isExpanded ? 180 : 0))
-                    .animation(XomperTheme.defaultAnimation, value: isExpanded)
+    /// Pulls the dependencies the store needs and triggers generation.
+    /// Idempotent — `MockDraftStore.ensureLoaded` no-ops when the
+    /// inputs haven't changed.
+    private func loadDependencies() {
+        Task {
+            // 1. Upcoming draft (slot order). Loaded by Live tab too;
+            //    `historyStore.loadUpcomingDraft` is cached per season.
+            if historyStore.upcomingDraft == nil,
+               let userId = userStore.myUser?.userId {
+                await historyStore.loadUpcomingDraft(
+                    season: nflStateStore.currentSeason,
+                    homeLeagueName: leagueStore.resolvedHomeLeagueName,
+                    userId: userId
+                )
             }
-            .frame(minHeight: XomperTheme.minTouchTarget)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.pressableCard)
-        .accessibilityLabel("\(personality.displayName), \(report.period)")
-        .accessibilityHint(isExpanded ? "Collapse" : "Expand to see the first five rounds")
-    }
-
-    // MARK: - Picks Table
-
-    /// Renders rounds 1-5 as a simple table. Sleeper drafts are 12
-    /// teams × 60 picks (5 rounds), so for the typical mock this is
-    /// the entire roster. Filter on `round <= 5` defensively in case
-    /// the engine ever runs more.
-    private func picksTable(picks: [MockedPick]) -> some View {
-        let myUserId = userStore.myUser?.userId
-        let first5Rounds = picks
-            .filter { $0.round <= 5 }
-            .sorted { $0.pickNo < $1.pickNo }
-
-        return VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
-            tableHeader
-
-            ForEach(first5Rounds) { pick in
-                pickRow(pick: pick, isMine: !pick.userId.isEmpty && pick.userId == myUserId)
+            // 2. FantasyCalc rookie values.
+            if !playerValuesStore.hasValues {
+                await playerValuesStore.loadValues()
             }
-        }
-    }
-
-    private var tableHeader: some View {
-        HStack(spacing: XomperTheme.Spacing.xs) {
-            Text("R")
-                .frame(width: 18, alignment: .center)
-            Text("Pick")
-                .frame(width: 38, alignment: .center)
-            Text("Team")
-                .frame(width: 90, alignment: .leading)
-            Text("Player")
-                .frame(maxWidth: .infinity, alignment: .leading)
-            Text("Pos")
-                .frame(width: 34, alignment: .center)
-        }
-        .font(.caption2.weight(.bold))
-        .foregroundStyle(XomperColors.textMuted)
-        .textCase(.uppercase)
-        .tracking(0.5)
-        .padding(.vertical, XomperTheme.Spacing.xxs)
-    }
-
-    private func pickRow(pick: MockedPick, isMine: Bool) -> some View {
-        HStack(spacing: XomperTheme.Spacing.xs) {
-            Text("\(pick.round)")
-                .frame(width: 18, alignment: .center)
-                .foregroundStyle(XomperColors.championGold)
-                .font(.caption.weight(.bold))
-                .monospacedDigit()
-
-            Text("#\(pick.pickNo)")
-                .frame(width: 38, alignment: .center)
-                .foregroundStyle(XomperColors.textMuted)
-                .font(.caption2)
-                .monospacedDigit()
-
-            Text(pick.team.isEmpty ? pick.handle : pick.team)
-                .frame(width: 90, alignment: .leading)
-                .font(.caption.weight(isMine ? .bold : .regular))
-                .foregroundStyle(isMine ? XomperColors.championGold : XomperColors.textSecondary)
-                .lineLimit(1)
-                .truncationMode(.tail)
-
-            HStack(spacing: XomperTheme.Spacing.xs) {
-                Text(pick.playerName)
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(XomperColors.textPrimary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-
-                if isMine {
-                    Text("YOU")
-                        .font(.caption2.weight(.bold))
-                        .foregroundStyle(XomperColors.bgDark)
-                        .padding(.horizontal, XomperTheme.Spacing.xs)
-                        .padding(.vertical, 1)
-                        .background(XomperColors.championGold)
-                        .clipShape(Capsule())
+            // 3. Per-week per-roster points for Team Fit needBoost.
+            if playerPointsStore.weeklyRosterPoints.isEmpty,
+               let leagueId = leagueStore.myLeague?.leagueId {
+                await playerPointsStore.loadRegularSeason(
+                    leagueId: leagueId,
+                    regularSeasonLastWeek: regularSeasonLastWeek
+                )
+            }
+            // 4. Generate.
+            store.ensureLoaded(
+                leagueStore: leagueStore,
+                historyStore: historyStore,
+                playerStore: playerStore,
+                playerValuesStore: playerValuesStore,
+                playerPointsStore: playerPointsStore,
+                regularSeasonLastWeek: regularSeasonLastWeek
+            )
+            // 5. Default-expand the first card so users land on
+            //    content per the plan.
+            if expandedIds.isEmpty {
+                if let first = DraftPersonality.displayOrder
+                    .compactMap({ store.pureMocks[$0]?.id })
+                    .first {
+                    expandedIds = [first]
                 }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            Text(pick.position)
-                .frame(width: 34, alignment: .center)
-                .font(.caption2.weight(.bold))
-                .foregroundStyle(XomperColors.bgDark)
-                .padding(.vertical, 2)
-                .background(positionColor(pick.position))
-                .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.sm))
-        }
-        .padding(.vertical, XomperTheme.Spacing.xxs)
-    }
-
-    // MARK: - Helpers
-
-    /// Resolves the `AIReport` for a personality by matching
-    /// `metadata.personality`. Personality strings ride in the flat
-    /// `metadata: [String: String]` map so we don't have to round-trip
-    /// the structured decoder for the lookup.
-    private func report(for personality: MockDraftPersonality) -> AIReport? {
-        aiReviewStore.mockDrafts.first { report in
-            let raw = report.metadata["personality"] ?? ""
-            return MockDraftPersonality.from(raw) == personality
         }
     }
 
-    private func positionColor(_ pos: String) -> Color {
-        switch pos.uppercased() {
-        case "QB": return Color(red: 0.95, green: 0.30, blue: 0.42)
-        case "RB": return Color(red: 0.20, green: 0.80, blue: 0.50)
-        case "WR": return Color(red: 0.30, green: 0.55, blue: 0.95)
-        case "TE": return Color(red: 0.95, green: 0.65, blue: 0.20)
-        case "K":  return Color(red: 0.65, green: 0.55, blue: 0.85)
-        case "DEF", "DST": return Color(red: 0.55, green: 0.55, blue: 0.55)
-        default: return XomperColors.surfaceLight
-        }
+    private func refresh() async {
+        // Bump the seed + reload dependencies.
+        await playerValuesStore.loadValues(forceRefresh: true)
+        store.reshuffle(
+            leagueStore: leagueStore,
+            historyStore: historyStore,
+            playerStore: playerStore,
+            playerValuesStore: playerValuesStore,
+            playerPointsStore: playerPointsStore,
+            regularSeasonLastWeek: regularSeasonLastWeek
+        )
     }
-}
 
-#Preview {
-    MocksView(
-        aiReviewStore: AIReviewStore(),
-        userStore: UserStore()
-    )
-    .preferredColorScheme(.dark)
+    // MARK: - Triggers
+
+    /// Composite key the `.task` watches — re-runs `loadDependencies`
+    /// when the upcoming-draft id or FantasyCalc snapshot changes.
+    private var triggerKey: String {
+        let draft = historyStore.upcomingDraft?.draftId ?? "no-draft"
+        let stamp = playerValuesStore.lastLoadedAt.map { String(Int($0.timeIntervalSince1970)) } ?? "no-values"
+        let players = playerStore.players.isEmpty ? "no-players" : "players"
+        return "\(draft)|\(stamp)|\(players)"
+    }
+
+    /// Last regular-season week to feed into the per-position HPP
+    /// calc. Reuses `NflStateStore` if present; defaults to 14 (our
+    /// league's regular season).
+    private var regularSeasonLastWeek: Int {
+        // Default — matches PayoutsView and Live draft tab. If a
+        // store-driven value is needed later, lift it through here.
+        14
+    }
 }

--- a/Xomper/Features/DraftHistory/DraftHistoryView.swift
+++ b/Xomper/Features/DraftHistory/DraftHistoryView.swift
@@ -22,6 +22,7 @@ struct DraftHistoryView: View {
     var historyStore: HistoryStore
     var playerStore: PlayerStore
     var playerPointsStore: PlayerPointsStore
+    var playerValuesStore: PlayerValuesStore
     var userStore: UserStore
     var nflStateStore: NflStateStore
     var aiReviewStore: AIReviewStore
@@ -77,7 +78,12 @@ struct DraftHistoryView: View {
                     )
                 case .mocks:
                     MocksView(
-                        aiReviewStore: aiReviewStore,
+                        leagueStore: leagueStore,
+                        historyStore: historyStore,
+                        playerStore: playerStore,
+                        playerValuesStore: playerValuesStore,
+                        playerPointsStore: playerPointsStore,
+                        nflStateStore: nflStateStore,
                         userStore: userStore
                     )
                 case .recap:
@@ -1035,6 +1041,7 @@ enum DraftViewMode: String, CaseIterable, Identifiable {
             historyStore: HistoryStore(),
             playerStore: PlayerStore(),
             playerPointsStore: PlayerPointsStore(),
+            playerValuesStore: PlayerValuesStore(),
             userStore: UserStore(),
             nflStateStore: NflStateStore(),
             aiReviewStore: AIReviewStore()

--- a/Xomper/Features/DraftOrder/Mocks/DraftPersonality.swift
+++ b/Xomper/Features/DraftOrder/Mocks/DraftPersonality.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+/// The 5 client-side mock-draft personalities. Each personality picks
+/// a different "type" of GM — pure value, needs-aware, hype-chaser,
+/// win-now, or pure chaos. The engine consumes one of these per pick
+/// to decide who comes off the board.
+///
+/// This is the engine-side enum, distinct from the legacy
+/// `MockDraftPersonality` (3 cases, backend wire shape) in
+/// `Core/Models/MockDraftModels.swift`. The two coexist while the
+/// backend wire format remains compatible.
+enum DraftPersonality: String, CaseIterable, Sendable, Hashable, Identifiable {
+    case bpa
+    case teamFit       = "team_fit"
+    case wildcard
+    case winNow        = "win_now"
+    case hypeTrain     = "hype_train"
+
+    var id: String { rawValue }
+
+    /// Whether reshuffling the seed changes this personality's output.
+    /// BPA / Team Fit / Win-Now are deterministic given a fixed input,
+    /// so reshuffle is a no-op. Wildcard + Hype Train use the RNG.
+    var isStochastic: Bool {
+        switch self {
+        case .wildcard, .hypeTrain: return true
+        case .bpa, .teamFit, .winNow: return false
+        }
+    }
+
+    /// Stable display order — BPA first (most conventional), Wildcard
+    /// last (chaos take). Team Fit / Win-Now / Hype Train sit in the
+    /// middle in the order they were finalized.
+    static var displayOrder: [DraftPersonality] {
+        [.bpa, .teamFit, .winNow, .hypeTrain, .wildcard]
+    }
+
+    var displayName: String {
+        switch self {
+        case .bpa:       "Best Player Available"
+        case .teamFit:   "Team Fit"
+        case .wildcard:  "Wildcard"
+        case .winNow:    "Win-Now"
+        case .hypeTrain: "Hype Train"
+        }
+    }
+
+    var blurb: String {
+        switch self {
+        case .bpa:
+            "Picks the highest-value rookie on the board regardless of roster construction."
+        case .teamFit:
+            "Weights each team's positional needs against player value — closer to how real GMs draft."
+        case .wildcard:
+            "Random selection within the top 8 available — surfaces the chaotic alternate timelines."
+        case .winNow:
+            "Bumps RB and WR weights to favor immediate production over long-term upside."
+        case .hypeTrain:
+            "Amplifies value at the top of the board with light jitter — chases consensus."
+        }
+    }
+
+    /// Accent color used by the personality card header. Matches the
+    /// existing color vocabulary in `XomperColors` so the UI feels
+    /// consistent with Live / Recap. Win-Now / Hype Train use ad-hoc
+    /// hex values picked to read clearly against `bgCard` — they
+    /// don't have semantic equivalents in `XomperColors`.
+    var accentColor: Color {
+        switch self {
+        case .bpa:       XomperColors.championGold
+        case .teamFit:   XomperColors.successGreen
+        case .wildcard:  XomperColors.accentRed
+        case .winNow:    Color(hex: 0x4FB3FF) // bright sky blue
+        case .hypeTrain: Color(hex: 0xFFB94A) // warm amber
+        }
+    }
+
+    /// SF Symbol icon shown beside the personality name in the header.
+    var systemImage: String {
+        switch self {
+        case .bpa:       "star.fill"
+        case .teamFit:   "person.3.fill"
+        case .wildcard:  "die.face.5.fill"
+        case .winNow:    "flame.fill"
+        case .hypeTrain: "bolt.fill"
+        }
+    }
+}

--- a/Xomper/Features/DraftOrder/Mocks/EngineMockedPick.swift
+++ b/Xomper/Features/DraftOrder/Mocks/EngineMockedPick.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// One pick produced by the client-side `MockDraftEngine`. Engine-side
+/// model — distinct from `MockedPick` in `Core/Models/MockDraftModels.swift`
+/// which decodes the legacy backend wire shape. This struct carries
+/// the engine's internal fields (score, personality, rosterId) that
+/// the wire shape doesn't track.
+struct EngineMockedPick: Sendable, Hashable, Identifiable {
+
+    // MARK: - Pick coordinates
+
+    /// 1-indexed overall pick number across the whole mock
+    /// (`(round-1) * teams + slot`).
+    let pickNo: Int
+    /// 1-indexed round (1 ≤ round ≤ rounds).
+    let round: Int
+    /// 1-indexed slot within the round, matches the Sleeper
+    /// `draftOrder` slot number for this team.
+    let slot: Int
+
+    // MARK: - Team
+
+    /// Sleeper roster ID owning this slot.
+    let rosterId: Int
+    /// Sleeper user ID owning the roster — empty when the slot
+    /// couldn't resolve to a user (rare commissioner-reshuffle case).
+    let userId: String
+    /// Display team name (`SleeperUser.teamName ?? displayName`).
+    let teamName: String
+
+    // MARK: - Player
+
+    let playerId: String
+    let playerName: String
+    /// Position label — QB / RB / WR / TE for rookie pool. Used by
+    /// the row to draw the colored chip.
+    let position: String
+    /// NFL team abbreviation, or empty string for free agents.
+    let nflTeam: String
+    /// FantasyCalc dynasty value at engine time.
+    let value: Double
+
+    // MARK: - Engine internals
+
+    /// The final score the engine used to pick this player (after
+    /// applying personality multipliers / jitter / etc). Equal to
+    /// `value` for BPA. Surfaced in the row caption so users can
+    /// see "fit ×1.34 → 8,234".
+    let score: Double
+    /// The personality that made this pick. For Pure mode every pick
+    /// in a result shares one personality; for Mixed it varies per
+    /// team.
+    let personality: DraftPersonality
+
+    // MARK: - Identifiable
+
+    /// Identity by `pickNo` — picks are unique within a single mock.
+    var id: Int { pickNo }
+}

--- a/Xomper/Features/DraftOrder/Mocks/EngineMockedPickRow.swift
+++ b/Xomper/Features/DraftOrder/Mocks/EngineMockedPickRow.swift
@@ -1,0 +1,189 @@
+import SwiftUI
+
+/// A single row inside a `MockDraftCard` showing one engine-produced
+/// pick. Visually aligned with the existing draft-history row styling
+/// in `DraftHistoryView` so Live / Mocks / Recap feel like siblings.
+struct EngineMockedPickRow: View {
+    let pick: EngineMockedPick
+    /// Whether this row belongs to the signed-in user — drives the
+    /// championGold highlight + YOU badge.
+    let isMine: Bool
+    /// Whether to show the per-pick personality chip (Mixed mode shows
+    /// it; Pure mode doesn't since every row has the same
+    /// personality).
+    let showsPersonalityChip: Bool
+
+    var body: some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            roundNumber
+
+            pickNumber
+
+            teamLabel
+
+            playerInfo
+
+            positionChip
+        }
+        .padding(.vertical, XomperTheme.Spacing.xxs)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityDescription)
+    }
+
+    // MARK: - Subviews
+
+    private var roundNumber: some View {
+        Text("\(pick.round)")
+            .frame(width: 18, alignment: .center)
+            .foregroundStyle(XomperColors.championGold)
+            .font(.caption.weight(.bold))
+            .monospacedDigit()
+    }
+
+    private var pickNumber: some View {
+        Text("#\(pick.pickNo)")
+            .frame(width: 38, alignment: .center)
+            .foregroundStyle(XomperColors.textMuted)
+            .font(.caption2)
+            .monospacedDigit()
+    }
+
+    private var teamLabel: some View {
+        Text(pick.teamName.isEmpty ? "Slot \(pick.slot)" : pick.teamName)
+            .frame(width: 90, alignment: .leading)
+            .font(.caption.weight(isMine ? .bold : .regular))
+            .foregroundStyle(isMine ? XomperColors.championGold : XomperColors.textSecondary)
+            .lineLimit(1)
+            .truncationMode(.tail)
+    }
+
+    private var playerInfo: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                Text(pick.playerName)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                if isMine {
+                    Text("YOU")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(XomperColors.bgDark)
+                        .padding(.horizontal, XomperTheme.Spacing.xs)
+                        .padding(.vertical, 1)
+                        .background(XomperColors.championGold)
+                        .clipShape(Capsule())
+                }
+
+                if showsPersonalityChip {
+                    personalityChip
+                }
+
+                if pick.personality.isStochastic {
+                    Image(systemName: "die.face.5")
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .accessibilityLabel("Randomized pick")
+                }
+            }
+
+            scoreCaption
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var personalityChip: some View {
+        Text(personalityChipLabel)
+            .font(.caption2.weight(.bold))
+            .foregroundStyle(XomperColors.bgDark)
+            .padding(.horizontal, XomperTheme.Spacing.xs)
+            .padding(.vertical, 1)
+            .background(pick.personality.accentColor.opacity(0.85))
+            .clipShape(Capsule())
+    }
+
+    private var personalityChipLabel: String {
+        switch pick.personality {
+        case .bpa:       "BPA"
+        case .teamFit:   "FIT"
+        case .wildcard:  "WLD"
+        case .winNow:    "WIN"
+        case .hypeTrain: "HYPE"
+        }
+    }
+
+    @ViewBuilder
+    private var scoreCaption: some View {
+        switch pick.personality {
+        case .bpa:
+            // BPA score == value; suppress the caption since the
+            // value chip on the right already conveys it.
+            EmptyView()
+        case .teamFit:
+            Text(teamFitCaption)
+                .font(.caption2)
+                .foregroundStyle(XomperColors.textMuted)
+                .lineLimit(1)
+        case .winNow:
+            Text(winNowCaption)
+                .font(.caption2)
+                .foregroundStyle(XomperColors.textMuted)
+                .lineLimit(1)
+        case .wildcard:
+            Text("val \(Int(pick.value))")
+                .font(.caption2)
+                .foregroundStyle(XomperColors.textMuted)
+        case .hypeTrain:
+            Text("hype → \(Int(pick.score))")
+                .font(.caption2)
+                .foregroundStyle(XomperColors.textMuted)
+        }
+    }
+
+    private var teamFitCaption: String {
+        let value = max(pick.value, 1)
+        let boost = pick.score / value
+        return String(format: "fit ×%.2f → %d", boost, Int(pick.score))
+    }
+
+    private var winNowCaption: String {
+        let mult = MockDraftEngine.winNowMultipliers[pick.position] ?? 1.0
+        return String(format: "%@ ×%.2f → %d", pick.position, mult, Int(pick.score))
+    }
+
+    private var positionChip: some View {
+        Text(pick.position)
+            .frame(width: 34, alignment: .center)
+            .font(.caption2.weight(.bold))
+            .foregroundStyle(XomperColors.bgDark)
+            .padding(.vertical, 2)
+            .background(positionColor(pick.position))
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.sm))
+    }
+
+    // MARK: - Helpers
+
+    private func positionColor(_ pos: String) -> Color {
+        switch pos.uppercased() {
+        case "QB": return Color(red: 0.95, green: 0.30, blue: 0.42)
+        case "RB": return Color(red: 0.20, green: 0.80, blue: 0.50)
+        case "WR": return Color(red: 0.30, green: 0.55, blue: 0.95)
+        case "TE": return Color(red: 0.95, green: 0.65, blue: 0.20)
+        default:   return XomperColors.surfaceLight
+        }
+    }
+
+    private var accessibilityDescription: String {
+        var desc = "Pick \(pick.pickNo), round \(pick.round), \(pick.playerName), \(pick.position)"
+        if !pick.nflTeam.isEmpty {
+            desc += ", \(pick.nflTeam)"
+        }
+        desc += ", drafted by \(pick.teamName)"
+        if isMine {
+            desc += ". This is your pick."
+        }
+        return desc
+    }
+}

--- a/Xomper/Features/DraftOrder/Mocks/MockDraftCard.swift
+++ b/Xomper/Features/DraftOrder/Mocks/MockDraftCard.swift
@@ -1,0 +1,209 @@
+import SwiftUI
+
+/// One mock-draft card — collapsible `DisclosureGroup` showing the
+/// header (personality + meta) and the list of picks. Pure mode shows
+/// a single personality; Mixed mode shows a per-team personality
+/// summary in the header.
+struct MockDraftCard: View {
+    let result: MockDraftResult
+    let slotOrder: [Int: SlotTeam]
+    /// Sleeper user ID for the signed-in user — drives the YOU
+    /// highlight on rows belonging to my team.
+    let myUserId: String?
+    /// Defaults expanded for the first card; the parent passes
+    /// `true` only for the first card so subsequent cards start
+    /// collapsed per the plan.
+    @Binding var isExpanded: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            if isExpanded {
+                expandedBody
+                    .padding(.top, XomperTheme.Spacing.sm)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(accentColor.opacity(0.25), lineWidth: 1)
+        )
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            withAnimation(XomperTheme.defaultAnimation) {
+                isExpanded.toggle()
+            }
+        } label: {
+            HStack(spacing: XomperTheme.Spacing.sm) {
+                Image(systemName: headerIcon)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(accentColor)
+                    .frame(width: 24)
+
+                VStack(alignment: .leading, spacing: XomperTheme.Spacing.xxs) {
+                    Text(titleText)
+                        .font(.headline)
+                        .foregroundStyle(XomperColors.textPrimary)
+                    Text(subtitleText)
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.down")
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textMuted)
+                    .rotationEffect(.degrees(isExpanded ? 180 : 0))
+                    .animation(XomperTheme.defaultAnimation, value: isExpanded)
+            }
+            .frame(minHeight: XomperTheme.minTouchTarget)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityLabel(titleText)
+        .accessibilityHint(isExpanded ? "Collapse" : "Expand to see picks")
+    }
+
+    // MARK: - Body
+
+    @ViewBuilder
+    private var expandedBody: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            Text(blurb)
+                .font(.caption)
+                .foregroundStyle(XomperColors.textSecondary)
+
+            if result.didExhaustPool {
+                exhaustionNotice
+            }
+
+            if result.mode == .mixed {
+                mixedAssignmentsSummary
+            }
+
+            Divider()
+                .overlay(XomperColors.surfaceLight)
+                .padding(.vertical, XomperTheme.Spacing.xs)
+
+            tableHeader
+
+            LazyVStack(alignment: .leading, spacing: XomperTheme.Spacing.xxs) {
+                ForEach(result.picks) { pick in
+                    EngineMockedPickRow(
+                        pick: pick,
+                        isMine: !pick.userId.isEmpty && pick.userId == myUserId,
+                        showsPersonalityChip: result.mode == .mixed
+                    )
+                }
+            }
+
+            footer
+        }
+    }
+
+    private var exhaustionNotice: some View {
+        Text("Rookie pool exhausted at pick \(result.picks.count) of \(MockDraftStore.defaultRounds * slotOrder.count). The engine stopped early so no fake players appear.")
+            .font(.caption2)
+            .foregroundStyle(XomperColors.accentRed)
+            .padding(.vertical, XomperTheme.Spacing.xxs)
+    }
+
+    private var tableHeader: some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            Text("R").frame(width: 18, alignment: .center)
+            Text("Pick").frame(width: 38, alignment: .center)
+            Text("Team").frame(width: 90, alignment: .leading)
+            Text("Player").frame(maxWidth: .infinity, alignment: .leading)
+            Text("Pos").frame(width: 34, alignment: .center)
+        }
+        .font(.caption2.weight(.bold))
+        .foregroundStyle(XomperColors.textMuted)
+        .textCase(.uppercase)
+        .tracking(0.5)
+        .padding(.vertical, XomperTheme.Spacing.xxs)
+    }
+
+    private var footer: some View {
+        let uniqueCount = result.uniquePlayerCount
+        return Text("\(result.picks.count) picks · \(uniqueCount) unique players")
+            .font(.caption2)
+            .foregroundStyle(XomperColors.textMuted)
+            .padding(.top, XomperTheme.Spacing.xs)
+    }
+
+    private var mixedAssignmentsSummary: some View {
+        let summary = result.mixedSummary(slotOrder: slotOrder)
+        return VStack(alignment: .leading, spacing: XomperTheme.Spacing.xxs) {
+            Text("Per-team personalities")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(XomperColors.textMuted)
+                .textCase(.uppercase)
+                .tracking(0.5)
+
+            ForEach(summary, id: \.slot) { entry in
+                HStack(spacing: XomperTheme.Spacing.xs) {
+                    Text("\(entry.slot).")
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .frame(width: 22, alignment: .trailing)
+                        .monospacedDigit()
+
+                    Text(entry.teamName)
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textSecondary)
+                        .lineLimit(1)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Text(entry.personality.displayName)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(entry.personality.accentColor)
+                }
+            }
+        }
+        .padding(XomperTheme.Spacing.sm)
+        .background(XomperColors.surfaceLight.opacity(0.4))
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+    }
+
+    // MARK: - Display data
+
+    private var accentColor: Color {
+        result.purePersonality?.accentColor ?? XomperColors.championGold
+    }
+
+    private var headerIcon: String {
+        result.purePersonality?.systemImage ?? "shuffle"
+    }
+
+    private var titleText: String {
+        switch result.mode {
+        case .pure:
+            return result.purePersonality?.displayName ?? "Mock Draft"
+        case .mixed:
+            return "Mixed Mock #\(result.id.split(separator: "-").last ?? "")"
+        }
+    }
+
+    private var subtitleText: String {
+        switch result.mode {
+        case .pure:
+            return "Pure · every team picks this way"
+        case .mixed:
+            return "Mixed · per-team personalities"
+        }
+    }
+
+    private var blurb: String {
+        result.purePersonality?.blurb ?? "Each team is randomly assigned a personality so this mock surfaces variance across draft styles."
+    }
+}

--- a/Xomper/Features/DraftOrder/Mocks/MockDraftEngine.swift
+++ b/Xomper/Features/DraftOrder/Mocks/MockDraftEngine.swift
@@ -1,0 +1,248 @@
+import Foundation
+
+/// One rookie eligible for the engine's pool. Built by
+/// `MockDraftStore.buildRookiePool` from the intersection of Sleeper
+/// `yearsExp == 0` players + FantasyCalc dynasty values + skill
+/// positions (QB/RB/WR/TE).
+struct RookieCandidate: Sendable, Hashable {
+    let playerId: String
+    let fullName: String
+    /// Position label — QB / RB / WR / TE (drives Win-Now multipliers).
+    let position: String
+    /// NFL team abbreviation, or empty string for free agents.
+    let nflTeam: String
+    /// FantasyCalc dynasty value. Drives all scoring formulas.
+    let value: Double
+}
+
+/// Pure-Swift client-side mock-draft engine. No actors, no stores —
+/// inputs in, picks out. Designed to be unit-testable with synthetic
+/// pools and a fixed seed.
+///
+/// The engine takes a `personality` callback rather than a single
+/// enum so Pure mode (constant personality) and Mixed mode (per-pick
+/// lookup) share the same code path. The store builds the closure
+/// appropriately for each mode.
+enum MockDraftEngine {
+
+    /// Win-Now position multipliers from `PLAN.md §3`. QB tightened
+    /// to 0.85 in a superflex league since QB value is already
+    /// inflated by 2-QB scoring — a flat 0.9 over-picks QBs.
+    static let winNowMultipliers: [String: Double] = [
+        "RB": 1.30,
+        "WR": 1.20,
+        "TE": 1.00,
+        "QB": 0.85
+    ]
+
+    /// Team Fit needBoost clamp + curve exponent (k = 0.6 per the
+    /// plan). Lifted to constants so tests can reference them.
+    static let teamFitClampLow: Double = 0.6
+    static let teamFitClampHigh: Double = 1.8
+    static let teamFitExponent: Double = 0.6
+
+    /// Wildcard top-N pool (uniform random within the top N by raw
+    /// FantasyCalc value).
+    static let wildcardTopN: Int = 8
+
+    /// Hype Train: `value^1.20` + per-candidate jitter in
+    /// `[-jitterFraction, +jitterFraction] * value`.
+    static let hypeTrainExponent: Double = 1.20
+    static let hypeTrainJitterFraction: Double = 0.01
+
+    /// Tie-break tolerance: two scores within this relative threshold
+    /// of each other count as a tie and break by value desc then
+    /// playerId asc. 0.5% per the plan.
+    static let tieThreshold: Double = 0.005
+
+    /// Runs a full mock draft.
+    ///
+    /// - Parameters:
+    ///   - rookies: pool of eligible rookies (already filtered to
+    ///     skill positions + non-zero FantasyCalc value).
+    ///   - slotOrder: `slot → SlotTeam` map. The engine iterates
+    ///     `slot = 1...teams` so slots must be contiguous from 1.
+    ///   - rounds: how many rounds to draft (5 in v1 → 60 picks at
+    ///     12 teams).
+    ///   - teamContext: per-roster per-position HPP snapshot, used
+    ///     by Team Fit's `needBoost`.
+    ///   - personality: `(pickNo) -> DraftPersonality`. Pure mode
+    ///     returns a constant; Mixed mode looks up by rosterId.
+    ///   - rng: seeded RNG for Wildcard / Hype Train jitter. Other
+    ///     personalities don't touch it. Passed `inout` so callers
+    ///     can observe state advancement (and tests can verify).
+    ///
+    /// - Returns: tuple of `(picks, didExhaustPool)`. Pool exhaustion
+    ///   happens when the pool is smaller than `rounds × teams`; the
+    ///   engine stops appending picks at that point.
+    static func run(
+        rookies: [RookieCandidate],
+        slotOrder: [Int: SlotTeam],
+        rounds: Int,
+        teamContext: TeamContext,
+        personality: (_ pickNo: Int, _ rosterId: Int) -> DraftPersonality,
+        rng: inout SeededRNG
+    ) -> (picks: [EngineMockedPick], didExhaustPool: Bool) {
+        guard !rookies.isEmpty, rounds > 0, !slotOrder.isEmpty else {
+            return ([], !rookies.isEmpty)
+        }
+
+        let slots = slotOrder.keys.sorted()
+        let teams = slots.count
+
+        var taken: Set<String> = []
+        var picks: [EngineMockedPick] = []
+        picks.reserveCapacity(rounds * teams)
+
+        // Filter from the full rookie list each pick — a Set lookup
+        // per candidate is O(1) and N (~50–80 rookies) is tiny.
+        // Keeping `rookies` immutable avoids defensive copies.
+        var pickNo = 0
+        for round in 1...rounds {
+            for slot in slots {
+                pickNo += 1
+                guard let team = slotOrder[slot] else { continue }
+                let pers = personality(pickNo, team.rosterId)
+
+                let available = rookies.filter { !taken.contains($0.playerId) }
+                guard !available.isEmpty else {
+                    return (picks, true)
+                }
+
+                guard let chosen = pickOne(
+                    from: available,
+                    personality: pers,
+                    rosterId: team.rosterId,
+                    teamContext: teamContext,
+                    rng: &rng
+                ) else {
+                    return (picks, true)
+                }
+
+                taken.insert(chosen.candidate.playerId)
+                picks.append(
+                    EngineMockedPick(
+                        pickNo: pickNo,
+                        round: round,
+                        slot: slot,
+                        rosterId: team.rosterId,
+                        userId: team.userId,
+                        teamName: team.teamName,
+                        playerId: chosen.candidate.playerId,
+                        playerName: chosen.candidate.fullName,
+                        position: chosen.candidate.position,
+                        nflTeam: chosen.candidate.nflTeam,
+                        value: chosen.candidate.value,
+                        score: chosen.score,
+                        personality: pers
+                    )
+                )
+            }
+        }
+
+        return (picks, false)
+    }
+
+    // MARK: - Per-pick selection
+
+    private struct ScoredCandidate {
+        let candidate: RookieCandidate
+        let score: Double
+    }
+
+    private static func pickOne(
+        from available: [RookieCandidate],
+        personality: DraftPersonality,
+        rosterId: Int,
+        teamContext: TeamContext,
+        rng: inout SeededRNG
+    ) -> ScoredCandidate? {
+        switch personality {
+        case .bpa:
+            return bestByValue(available)
+
+        case .winNow:
+            let scored = available.map { c -> ScoredCandidate in
+                let mult = winNowMultipliers[c.position] ?? 1.0
+                return ScoredCandidate(candidate: c, score: c.value * mult)
+            }
+            return topByScore(scored)
+
+        case .teamFit:
+            let scored = available.map { c -> ScoredCandidate in
+                let boost = needBoost(
+                    rosterId: rosterId,
+                    position: c.position,
+                    teamContext: teamContext
+                )
+                return ScoredCandidate(candidate: c, score: c.value * boost)
+            }
+            return topByScore(scored)
+
+        case .hypeTrain:
+            let scored = available.map { c -> ScoredCandidate in
+                let base = pow(c.value, hypeTrainExponent)
+                let jitter = rng.nextDouble(
+                    in: -hypeTrainJitterFraction..<hypeTrainJitterFraction
+                ) * c.value
+                return ScoredCandidate(candidate: c, score: base + jitter)
+            }
+            return topByScore(scored)
+
+        case .wildcard:
+            // Top-N by raw FantasyCalc value, then pick uniformly at
+            // random. Score = value (we don't actually use a derived
+            // score for Wildcard — the value IS the score).
+            let sorted = available.sorted { $0.value > $1.value }
+            let topN = Array(sorted.prefix(wildcardTopN))
+            guard !topN.isEmpty else { return nil }
+            let idx = rng.nextInt(in: 0..<topN.count)
+            let chosen = topN[idx]
+            return ScoredCandidate(candidate: chosen, score: chosen.value)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// `score = value` — used by BPA, and as the trivial top-by-value
+    /// path with deterministic tie-breaking.
+    private static func bestByValue(_ candidates: [RookieCandidate]) -> ScoredCandidate? {
+        let scored = candidates.map { ScoredCandidate(candidate: $0, score: $0.value) }
+        return topByScore(scored)
+    }
+
+    /// Picks the highest-scoring candidate with deterministic
+    /// tie-breaking: any two scores within `tieThreshold` relative of
+    /// each other are tied; ties break by `value` desc, then by
+    /// `playerId` asc.
+    private static func topByScore(_ scored: [ScoredCandidate]) -> ScoredCandidate? {
+        guard let top = scored.max(by: { $0.score < $1.score }) else { return nil }
+        // Collect all within tie threshold of the top score.
+        let tieFloor = top.score * (1 - tieThreshold)
+        let tied = scored.filter { $0.score >= tieFloor }
+        guard tied.count > 1 else { return top }
+        // Break ties deterministically.
+        let sorted = tied.sorted { lhs, rhs in
+            if lhs.candidate.value != rhs.candidate.value {
+                return lhs.candidate.value > rhs.candidate.value
+            }
+            return lhs.candidate.playerId < rhs.candidate.playerId
+        }
+        return sorted.first!
+    }
+
+    /// Team Fit `needBoost` formula. Returns 1.0 in the fallback /
+    /// missing-data case so Team Fit degrades to BPA.
+    static func needBoost(
+        rosterId: Int,
+        position: String,
+        teamContext: TeamContext
+    ) -> Double {
+        let teamPos = teamContext.teamPosHPP(rosterId: rosterId, position: position)
+        let leagueAvg = teamContext.leagueAvg(position: position)
+        guard leagueAvg > 0 else { return 1.0 }
+        let ratio = leagueAvg / max(teamPos, 1)
+        let raw = pow(ratio, teamFitExponent)
+        return min(max(raw, teamFitClampLow), teamFitClampHigh)
+    }
+}

--- a/Xomper/Features/DraftOrder/Mocks/MockDraftResult.swift
+++ b/Xomper/Features/DraftOrder/Mocks/MockDraftResult.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// One full client-side mock-draft result — the picks the engine
+/// produced for either a single personality (Pure) or a per-team
+/// personality assignment (Mixed). The view renders one of these per
+/// `MockDraftCard`.
+struct MockDraftResult: Sendable, Hashable, Identifiable {
+
+    /// Which viewing mode produced this result. Pure → every team
+    /// picks via the same personality; Mixed → per-team assignments
+    /// stored in `personalityByRosterId`.
+    enum Mode: String, Sendable, Hashable {
+        case pure
+        case mixed
+    }
+
+    /// Stable id for `ForEach`. Pure mocks key by personality; Mixed
+    /// mocks key by seed since their personality is per-team.
+    let id: String
+
+    let mode: Mode
+
+    /// Personality used for the whole mock when `mode == .pure`. Nil
+    /// for Mixed mocks (read `personalityByRosterId` instead).
+    let purePersonality: DraftPersonality?
+
+    /// Picks in pickNo order. Length == rounds × teams in the happy
+    /// path; smaller when pool exhaustion clipped the run.
+    let picks: [EngineMockedPick]
+
+    /// rosterId → personality assignment when `mode == .mixed`. Nil
+    /// for Pure mocks.
+    let personalityByRosterId: [Int: DraftPersonality]?
+
+    /// RNG seed used to produce this mock. Deterministic mocks reuse
+    /// the parent store's `currentSeed` even though they don't sample
+    /// — keeps cache invalidation symmetric.
+    let seed: UInt64
+
+    /// True when the engine ran out of eligible rookies before
+    /// filling all picks. The view surfaces this in the card header
+    /// so users understand why a mock has fewer than 60 rows.
+    let didExhaustPool: Bool
+
+    /// Convenience: number of unique players picked. Matches
+    /// `picks.count` in a healthy run since no player can be picked
+    /// twice within a single mock.
+    var uniquePlayerCount: Int {
+        Set(picks.map(\.playerId)).count
+    }
+
+    /// Mocks with `mode == .mixed` only — list of (rosterId, teamName,
+    /// personality) for the header. Sorted by slot so the mix reads
+    /// like the live draft order.
+    func mixedSummary(slotOrder: [Int: SlotTeam]) -> [(slot: Int, teamName: String, personality: DraftPersonality)] {
+        guard let map = personalityByRosterId else { return [] }
+        return slotOrder
+            .compactMap { (slot, team) -> (Int, String, DraftPersonality)? in
+                guard let p = map[team.rosterId] else { return nil }
+                return (slot, team.teamName, p)
+            }
+            .sorted { $0.0 < $1.0 }
+            .map { (slot: $0.0, teamName: $0.1, personality: $0.2) }
+    }
+}
+
+/// One slot in the live draft order — slot number is the dictionary
+/// key in `MockDraftEngine.run`. Carries the roster/user/team trio
+/// the engine needs to attribute each pick.
+struct SlotTeam: Sendable, Hashable {
+    let rosterId: Int
+    let userId: String
+    let teamName: String
+}

--- a/Xomper/Features/DraftOrder/Mocks/SeededRNG.swift
+++ b/Xomper/Features/DraftOrder/Mocks/SeededRNG.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Deterministic `RandomNumberGenerator` for reproducible mock-draft
+/// runs. Uses the SplitMix64 PRNG — tiny, fast, and stateful via a
+/// single `UInt64` seed. Same seed in → identical sequence out, which
+/// is exactly what the engine tests rely on for the Wildcard / Hype
+/// Train cases.
+///
+/// Not cryptographically secure. We don't need it to be — the only
+/// goal is "two runs with seed 42 must match, and seeds 42 vs 43 must
+/// differ in observable output."
+///
+/// Reference: Vigna 2014. Implementation matches the canonical
+/// SplitMix64 constants used in the Swift forum thread for the
+/// `RandomNumberGenerator` protocol.
+struct SeededRNG: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        // Avoid the degenerate state == 0 case by mixing the seed
+        // through one round of SplitMix64 up-front. Calling code that
+        // passes seed = 0 still gets a useful sequence.
+        self.state = seed &+ 0x9E37_79B9_7F4A_7C15
+    }
+
+    mutating func next() -> UInt64 {
+        state = state &+ 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z &>> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z &>> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z &>> 31)
+    }
+
+    /// Convenience: uniform `Double` in `[0, 1)`. Useful for jitter and
+    /// percentage-based sampling without paying the `Double.random(in:)`
+    /// indirection through a `_modifying` accessor.
+    mutating func nextUnit() -> Double {
+        // Use the top 53 bits — fits in a Double's mantissa without
+        // rounding. Standard pattern from Vigna's reference.
+        let bits = next() &>> 11
+        return Double(bits) * (1.0 / Double(1 &<< 53))
+    }
+
+    /// Uniform `Double` in `[lower, upper)`. Both bounds finite; no
+    /// guard for `upper <= lower` — callers must validate.
+    mutating func nextDouble(in range: Range<Double>) -> Double {
+        let u = nextUnit()
+        return range.lowerBound + u * (range.upperBound - range.lowerBound)
+    }
+
+    /// Uniform integer in `[lower, upper)`. Crashes on empty ranges
+    /// to match `Int.random(in:)` semantics.
+    mutating func nextInt(in range: Range<Int>) -> Int {
+        precondition(range.lowerBound < range.upperBound, "SeededRNG.nextInt requires non-empty range")
+        let span = UInt64(range.upperBound - range.lowerBound)
+        // Modulo bias is acceptable for our small spans (Wildcard
+        // top-N = 8, etc.). Documented tradeoff for v1.
+        return range.lowerBound + Int(next() % span)
+    }
+}

--- a/Xomper/Features/DraftOrder/Mocks/TeamContext.swift
+++ b/Xomper/Features/DraftOrder/Mocks/TeamContext.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+/// Pre-computed positional snapshot of the league at engine time.
+/// Built once on the `MainActor`, then passed by value into
+/// `MockDraftEngine.run` (which is pure / non-actor-isolated).
+///
+/// All the read-side per-roster math the engine needs lives here so
+/// the engine itself stays a pure function of its inputs. Specifically:
+///
+/// - `posHPPByRoster[rosterId][position]` — that roster's
+///   highest-possible regular-season points contributed by `position`
+///   (the chosen optimal player at each weekly slot, attributed by
+///   the player's position).
+/// - `leagueAvgByPos[position]` — average of `teamPosHPP` across all
+///   rosters. Drives the `needBoost` formula in `Team Fit`.
+///
+/// The builder is on `MainActor` because it reads from `LeagueStore`,
+/// `HistoryStore`, `PlayerStore`, and `PlayerPointsStore` — all of
+/// which are actor-isolated.
+struct TeamContext: Sendable {
+
+    /// Per-roster per-position HPP totals. Keys are roster IDs; inner
+    /// keys are position labels (`"QB"`, `"RB"`, `"WR"`, `"TE"`).
+    /// Missing positions implicitly = 0 — Team Fit reads via a default.
+    let posHPPByRoster: [Int: [String: Double]]
+
+    /// League average per position. `posHPPByRoster.values.reduce + avg`
+    /// — pre-baked so the engine doesn't recompute on every pick.
+    let leagueAvgByPos: [String: Double]
+
+    /// True when the builder fell back to "all rosters get the
+    /// no-boost identity" because no weekly points were available
+    /// (preseason boot, fresh league, etc.). Team Fit then degrades
+    /// to ≈ BPA — useful signal for the view to surface a banner.
+    let isFallback: Bool
+
+    /// Convenience accessor that returns `posHPPByRoster[roster][pos]`
+    /// with a 0 default. Used in the `needBoost` formula.
+    func teamPosHPP(rosterId: Int, position: String) -> Double {
+        posHPPByRoster[rosterId]?[position] ?? 0
+    }
+
+    /// Convenience: league average for a position, with a 0 default.
+    func leagueAvg(position: String) -> Double {
+        leagueAvgByPos[position] ?? 0
+    }
+}
+
+// MARK: - Builder
+
+@MainActor
+extension TeamContext {
+
+    /// Builds a `TeamContext` from the live stores. Iterates each
+    /// regular-season week × roster, calls the per-position HPP
+    /// helper on `HighestPossibleCalculator`, and accumulates the
+    /// per-position totals. Then averages across rosters for the
+    /// league baseline.
+    ///
+    /// - Parameters:
+    ///   - rosterIds: full set of rosters in the league (size 12 for
+    ///     ours, but generic).
+    ///   - leagueStore: provides `myLeague.rosterPositions` (slot
+    ///     vocabulary for the optimal-lineup calc).
+    ///   - playerStore: position lookup keyed by Sleeper player ID.
+    ///   - playerPointsStore: per-week per-roster point dictionaries.
+    ///   - regularSeasonLastWeek: cutoff week (inclusive) for the
+    ///     HPP sum. Typically week 14 in a 14-week regular season.
+    ///
+    /// Falls back to `isFallback = true` with `leagueAvg = teamPosHPP`
+    /// for every team (so needBoost = 1.0 everywhere) when either:
+    /// - `rosterPositions` is missing, OR
+    /// - `weeklyRosterPoints` is empty.
+    static func build(
+        rosterIds: [Int],
+        leagueStore: LeagueStore,
+        playerStore: PlayerStore,
+        playerPointsStore: PlayerPointsStore,
+        regularSeasonLastWeek: Int
+    ) -> TeamContext {
+        let rosterPositions = leagueStore.myLeague?.rosterPositions ?? []
+        // Type is `[String]?` on League; default to empty so the
+        // `isEmpty` guard catches both the nil and empty paths.
+        let hasWeeklyData = !playerPointsStore.weeklyRosterPoints.isEmpty
+
+        guard !rosterPositions.isEmpty, hasWeeklyData, !rosterIds.isEmpty else {
+            // No usable data — return a zeroed snapshot. Team Fit's
+            // `needBoost` formula degrades to 1.0 when both team and
+            // league are 0 / equal, which is what we want.
+            return TeamContext(
+                posHPPByRoster: [:],
+                leagueAvgByPos: [:],
+                isFallback: true
+            )
+        }
+
+        var posHPPByRoster: [Int: [String: Double]] = [:]
+        for rosterId in rosterIds {
+            var totals: [String: Double] = [:]
+            for week in 1...max(regularSeasonLastWeek, 1) {
+                let key = "\(week)-\(rosterId)"
+                guard let weekPoints = playerPointsStore.weeklyRosterPoints[key],
+                      !weekPoints.isEmpty else { continue }
+                let weekly = HighestPossibleCalculator.optimalLineupPointsByPosition(
+                    playerPoints: weekPoints,
+                    rosterPositions: rosterPositions,
+                    playerStore: playerStore
+                )
+                for (pos, pts) in weekly {
+                    totals[pos, default: 0] += pts
+                }
+            }
+            posHPPByRoster[rosterId] = totals
+        }
+
+        // League average per position: sum across rosters / roster
+        // count. Rosters that genuinely have 0 at a position still
+        // count toward the divisor — they pull the average down,
+        // which makes the needBoost slightly more aggressive on weak
+        // positions. That's what we want.
+        var leagueAvgByPos: [String: Double] = [:]
+        let denom = Double(rosterIds.count)
+        var sums: [String: Double] = [:]
+        for rosterId in rosterIds {
+            let totals = posHPPByRoster[rosterId] ?? [:]
+            for (pos, pts) in totals {
+                sums[pos, default: 0] += pts
+            }
+        }
+        for (pos, sum) in sums {
+            leagueAvgByPos[pos] = denom > 0 ? sum / denom : 0
+        }
+
+        return TeamContext(
+            posHPPByRoster: posHPPByRoster,
+            leagueAvgByPos: leagueAvgByPos,
+            isFallback: false
+        )
+    }
+}

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -179,6 +179,7 @@ struct MainShell: View {
                     historyStore: historyStore,
                     playerStore: playerStore,
                     playerPointsStore: playerPointsStore,
+                    playerValuesStore: valuesStore,
                     userStore: userStore,
                     nflStateStore: nflStateStore,
                     aiReviewStore: aiReviewStore
@@ -415,6 +416,7 @@ struct MainShell: View {
                 historyStore: historyStore,
                 playerStore: playerStore,
                 playerPointsStore: playerPointsStore,
+                playerValuesStore: valuesStore,
                 userStore: userStore,
                 nflStateStore: nflStateStore,
                 aiReviewStore: aiReviewStore

--- a/XomperTests/HighestPossibleCalculatorTests.swift
+++ b/XomperTests/HighestPossibleCalculatorTests.swift
@@ -1,0 +1,200 @@
+import XCTest
+@testable import Xomper
+
+/// Tests for `HighestPossibleCalculator.optimalLineupPointsByPosition`.
+/// The existing `optimalLineupPoints` helper is now derived from the
+/// per-position breakdown — same totals, different return shape —
+/// so we also reaffirm that the total still matches expectations.
+@MainActor
+final class HighestPossibleCalculatorTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Builds a `PlayerStore` seeded with synthetic players.
+    /// `PlayerStore.players` is `private(set)`, so we use the test
+    /// seam `setPlayersForTesting(_:)`.
+    private func makeStore(_ entries: [String: String]) -> PlayerStore {
+        let store = PlayerStore()
+        let players = Dictionary(uniqueKeysWithValues: entries.map { id, pos in
+            (id, Player(playerId: id, position: pos))
+        })
+        store.setPlayersForTesting(players)
+        return store
+    }
+
+    // MARK: - Empty / edge cases
+
+    func testHelper_returnsEmptyMapForEmptyInputs() {
+        let store = PlayerStore()
+        let result = HighestPossibleCalculator.optimalLineupPointsByPosition(
+            playerPoints: [:],
+            rosterPositions: [],
+            playerStore: store
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testHelper_returnsEmptyMapWhenNoActiveSlots() {
+        let store = PlayerStore()
+        let result = HighestPossibleCalculator.optimalLineupPointsByPosition(
+            playerPoints: ["p1": 10],
+            rosterPositions: ["BN", "BN", "IR"],
+            playerStore: store
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testHelper_skipsCandidatesWithUnknownPositions() {
+        // PlayerStore returns nil for unknown ids; with no positions
+        // resolvable, candidates list is empty → no buckets credited.
+        let store = PlayerStore()
+        let result = HighestPossibleCalculator.optimalLineupPointsByPosition(
+            playerPoints: ["unknown1": 100, "unknown2": 80],
+            rosterPositions: ["QB", "RB", "WR", "TE"],
+            playerStore: store
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Standard slot config
+
+    /// QB / RB / RB / WR / WR / TE / FLEX / SUPER_FLEX with a fixed
+    /// per-player score grid → known per-position totals.
+    ///
+    /// Players + points:
+    /// - qb1=30 (QB), qb2=20 (QB) — qb2 wins SUPER_FLEX
+    /// - rb1=25, rb2=20, rb3=18, rb4=14
+    /// - wr1=22, wr2=16, wr3=15
+    /// - te1=11
+    ///
+    /// Optimal greedy assignment (specific slots first):
+    /// - QB → qb1 (30)         → QB +30
+    /// - RB → rb1 (25)         → RB +25
+    /// - RB → rb2 (20)         → RB +20
+    /// - WR → wr1 (22)         → WR +22
+    /// - WR → wr2 (16)         → WR +16
+    /// - TE → te1 (11)         → TE +11
+    /// - FLEX (RB/WR/TE) → rb3 (18) wins over wr3 (15) → RB +18
+    /// - SUPER_FLEX (QB/RB/WR/TE) → qb2 (20) → QB +20
+    func testHelper_standardSlotConfig_breakdownCorrect() {
+        let store = makeStore([
+            "qb1": "QB", "qb2": "QB",
+            "rb1": "RB", "rb2": "RB", "rb3": "RB", "rb4": "RB",
+            "wr1": "WR", "wr2": "WR", "wr3": "WR",
+            "te1": "TE"
+        ])
+        let pts: [String: Double] = [
+            "qb1": 30, "qb2": 20,
+            "rb1": 25, "rb2": 20, "rb3": 18, "rb4": 14,
+            "wr1": 22, "wr2": 16, "wr3": 15,
+            "te1": 11
+        ]
+        let slots = ["QB", "RB", "RB", "WR", "WR", "TE", "FLEX", "SUPER_FLEX", "BN", "BN"]
+
+        let result = HighestPossibleCalculator.optimalLineupPointsByPosition(
+            playerPoints: pts,
+            rosterPositions: slots,
+            playerStore: store
+        )
+
+        XCTAssertEqual(result["QB"] ?? 0, 50, accuracy: 0.001, "QB = qb1(30) + qb2 via SF(20)")
+        XCTAssertEqual(result["RB"] ?? 0, 63, accuracy: 0.001, "RB = rb1(25) + rb2(20) + rb3 via FLEX(18)")
+        XCTAssertEqual(result["WR"] ?? 0, 38, accuracy: 0.001, "WR = wr1(22) + wr2(16)")
+        XCTAssertEqual(result["TE"] ?? 0, 11, accuracy: 0.001, "TE = te1(11)")
+    }
+
+    /// FLEX edge case: WR3 at 22 beats RB3 at 20 → FLEX credits WR.
+    func testHelper_flexEdgeCase_creditsChosenPlayersPosition() {
+        let store = makeStore([
+            "qb1": "QB",
+            "rb1": "RB", "rb2": "RB", "rb3": "RB",
+            "wr1": "WR", "wr2": "WR", "wr3": "WR",
+            "te1": "TE"
+        ])
+        let pts: [String: Double] = [
+            "qb1": 25,
+            "rb1": 20, "rb2": 15, "rb3": 20,
+            "wr1": 18, "wr2": 14, "wr3": 22,
+            "te1": 10
+        ]
+        let slots = ["QB", "RB", "RB", "WR", "WR", "TE", "FLEX", "BN"]
+
+        // Greedy with specific-first ordering:
+        // - QB → qb1 (25)
+        // - RB → rb1 (20)
+        // - RB → rb3 (20)
+        // - WR → wr3 (22)
+        // - WR → wr1 (18)
+        // - TE → te1 (10)
+        // - FLEX → rb2 (15) vs wr2 (14) → rb2 wins (RB +15)
+        //   (wr3 already used at WR; the remaining best at flex is rb2.)
+        let result = HighestPossibleCalculator.optimalLineupPointsByPosition(
+            playerPoints: pts,
+            rosterPositions: slots,
+            playerStore: store
+        )
+        XCTAssertEqual(result["QB"] ?? 0, 25, accuracy: 0.001)
+        XCTAssertEqual(result["RB"] ?? 0, 55, accuracy: 0.001, "rb1 + rb3 + rb2 via FLEX")
+        XCTAssertEqual(result["WR"] ?? 0, 40, accuracy: 0.001, "wr3 + wr1")
+        XCTAssertEqual(result["TE"] ?? 0, 10, accuracy: 0.001)
+    }
+
+    /// FLEX edge case where the highest unassigned candidate is a WR:
+    /// only one WR + two RB slots already filled with great RBs leaves
+    /// a strong WR available at FLEX.
+    func testHelper_flexCreditsWR_whenWRwinsTheFlexSlot() {
+        let store = makeStore([
+            "qb1": "QB",
+            "rb1": "RB", "rb2": "RB",
+            "wr1": "WR", "wr2": "WR", "wr3": "WR",
+            "te1": "TE"
+        ])
+        let pts: [String: Double] = [
+            "qb1": 25,
+            "rb1": 30, "rb2": 28,
+            "wr1": 24, "wr2": 20, "wr3": 18,
+            "te1": 10
+        ]
+        let slots = ["QB", "RB", "RB", "WR", "TE", "FLEX", "BN"]
+
+        // - QB → qb1
+        // - RB → rb1
+        // - RB → rb2
+        // - WR → wr1
+        // - TE → te1
+        // - FLEX → wr2 (20) vs wr3 (18) → wr2 wins (WR +20)
+        let result = HighestPossibleCalculator.optimalLineupPointsByPosition(
+            playerPoints: pts,
+            rosterPositions: slots,
+            playerStore: store
+        )
+        XCTAssertEqual(result["WR"] ?? 0, 44, accuracy: 0.001, "wr1(24) + wr2 via FLEX(20)")
+        XCTAssertEqual(result["RB"] ?? 0, 58, accuracy: 0.001, "rb1(30) + rb2(28); rb-only slots full")
+    }
+
+    // MARK: - Total equivalence
+
+    func testTotalEqualsSumOfPerPositionBreakdown() {
+        let store = makeStore([
+            "qb1": "QB", "rb1": "RB", "rb2": "RB",
+            "wr1": "WR", "wr2": "WR", "te1": "TE"
+        ])
+        let pts: [String: Double] = [
+            "qb1": 22, "rb1": 18, "rb2": 14,
+            "wr1": 20, "wr2": 12, "te1": 8
+        ]
+        let slots = ["QB", "RB", "RB", "WR", "WR", "TE", "FLEX", "BN"]
+
+        let total = HighestPossibleCalculator.optimalLineupPoints(
+            playerPoints: pts,
+            rosterPositions: slots,
+            playerStore: store
+        )
+        let breakdown = HighestPossibleCalculator.optimalLineupPointsByPosition(
+            playerPoints: pts,
+            rosterPositions: slots,
+            playerStore: store
+        )
+        XCTAssertEqual(total, breakdown.values.reduce(0, +), accuracy: 0.001)
+    }
+}

--- a/XomperTests/MockDraftEngineTests.swift
+++ b/XomperTests/MockDraftEngineTests.swift
@@ -1,0 +1,341 @@
+import XCTest
+@testable import Xomper
+
+/// Tests for the pure-Swift `MockDraftEngine`. Engine is a pure
+/// function of its inputs + RNG state so these tests don't need any
+/// stores, view materialization, or networking — just synthetic
+/// rookies + a fixed seed.
+@MainActor
+final class MockDraftEngineTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// 12-team slot order, slots 1..12 → rosters 1..12. Used for most
+    /// tests so the fixture matches the league size.
+    private func standardSlotOrder() -> [Int: SlotTeam] {
+        var dict: [Int: SlotTeam] = [:]
+        for s in 1...12 {
+            dict[s] = SlotTeam(
+                rosterId: s,
+                userId: "u\(s)",
+                teamName: "Team\(s)"
+            )
+        }
+        return dict
+    }
+
+    /// 4 rookies per position with strictly-distinct values so BPA
+    /// has a single deterministic ordering.
+    private func standardRookiePool() -> [RookieCandidate] {
+        var pool: [RookieCandidate] = []
+        var value = 10_000.0
+        for (pos, count) in [("RB", 5), ("WR", 5), ("TE", 4), ("QB", 4)] {
+            for i in 0..<count {
+                pool.append(RookieCandidate(
+                    playerId: "\(pos.lowercased())\(i)",
+                    fullName: "\(pos) Rookie \(i)",
+                    position: pos,
+                    nflTeam: "TM",
+                    value: value
+                ))
+                value -= 100
+            }
+        }
+        return pool
+    }
+
+    private func emptyTeamContext() -> TeamContext {
+        TeamContext(posHPPByRoster: [:], leagueAvgByPos: [:], isFallback: true)
+    }
+
+    // MARK: - BPA
+
+    func testBPA_isValueDescending() {
+        let pool = [
+            RookieCandidate(playerId: "a", fullName: "A", position: "RB", nflTeam: "T", value: 9_900),
+            RookieCandidate(playerId: "b", fullName: "B", position: "WR", nflTeam: "T", value: 10_000),
+            RookieCandidate(playerId: "c", fullName: "C", position: "QB", nflTeam: "T", value: 9_800),
+            RookieCandidate(playerId: "d", fullName: "D", position: "TE", nflTeam: "T", value: 9_700)
+        ]
+        let slots = [1: SlotTeam(rosterId: 1, userId: "u1", teamName: "T1")]
+        var rng = SeededRNG(seed: 1)
+        let (picks, exhausted) = MockDraftEngine.run(
+            rookies: pool,
+            slotOrder: slots,
+            rounds: 4,
+            teamContext: emptyTeamContext(),
+            personality: { _, _ in .bpa },
+            rng: &rng
+        )
+        XCTAssertFalse(exhausted)
+        XCTAssertEqual(picks.map(\.playerId), ["b", "a", "c", "d"])
+    }
+
+    func testBPA_isDeterministic_acrossRuns() {
+        let pool = standardRookiePool()
+        let slots = standardSlotOrder()
+        var r1 = SeededRNG(seed: 1)
+        var r2 = SeededRNG(seed: 99) // different seed, but BPA ignores RNG
+        let (a, _) = MockDraftEngine.run(
+            rookies: pool, slotOrder: slots, rounds: 5,
+            teamContext: emptyTeamContext(),
+            personality: { _, _ in .bpa }, rng: &r1
+        )
+        let (b, _) = MockDraftEngine.run(
+            rookies: pool, slotOrder: slots, rounds: 5,
+            teamContext: emptyTeamContext(),
+            personality: { _, _ in .bpa }, rng: &r2
+        )
+        XCTAssertEqual(a.map(\.playerId), b.map(\.playerId), "BPA must be deterministic across RNG seeds")
+    }
+
+    // MARK: - Wildcard
+
+    func testWildcard_isDeterministicForSameSeed() {
+        let pool = standardRookiePool()
+        let slots = standardSlotOrder()
+        var r1 = SeededRNG(seed: 42)
+        var r2 = SeededRNG(seed: 42)
+        let (a, _) = MockDraftEngine.run(
+            rookies: pool, slotOrder: slots, rounds: 5,
+            teamContext: emptyTeamContext(),
+            personality: { _, _ in .wildcard }, rng: &r1
+        )
+        let (b, _) = MockDraftEngine.run(
+            rookies: pool, slotOrder: slots, rounds: 5,
+            teamContext: emptyTeamContext(),
+            personality: { _, _ in .wildcard }, rng: &r2
+        )
+        XCTAssertEqual(a.map(\.playerId), b.map(\.playerId))
+    }
+
+    func testWildcard_variesAcrossSeeds() {
+        let pool = standardRookiePool()
+        let slots = standardSlotOrder()
+        var r1 = SeededRNG(seed: 42)
+        var r2 = SeededRNG(seed: 4242)
+        let (a, _) = MockDraftEngine.run(
+            rookies: pool, slotOrder: slots, rounds: 5,
+            teamContext: emptyTeamContext(),
+            personality: { _, _ in .wildcard }, rng: &r1
+        )
+        let (b, _) = MockDraftEngine.run(
+            rookies: pool, slotOrder: slots, rounds: 5,
+            teamContext: emptyTeamContext(),
+            personality: { _, _ in .wildcard }, rng: &r2
+        )
+        XCTAssertNotEqual(a.map(\.playerId), b.map(\.playerId), "Wildcard with different seeds should diverge")
+    }
+
+    func testWildcard_pick1_alwaysInTop8ByValue() {
+        let pool = standardRookiePool()
+        let topByValue = pool.sorted { $0.value > $1.value }.prefix(MockDraftEngine.wildcardTopN)
+        let topIds = Set(topByValue.map(\.playerId))
+
+        let slots = [1: SlotTeam(rosterId: 1, userId: "u1", teamName: "T1")]
+        for seed: UInt64 in [1, 2, 3, 4, 5, 100, 999, 31_337] {
+            var rng = SeededRNG(seed: seed)
+            let (picks, _) = MockDraftEngine.run(
+                rookies: pool, slotOrder: slots, rounds: 1,
+                teamContext: emptyTeamContext(),
+                personality: { _, _ in .wildcard }, rng: &rng
+            )
+            XCTAssertEqual(picks.count, 1)
+            XCTAssertTrue(topIds.contains(picks[0].playerId),
+                          "Wildcard pick must be in top \(MockDraftEngine.wildcardTopN) (seed=\(seed))")
+        }
+    }
+
+    // MARK: - Team Fit
+
+    func testTeamFit_boostsWeakPositions() {
+        // Roster 5 is TE-starved (HPP 100), league avg TE = 400 →
+        // boost = clamp((400/100)^0.6) ≈ 2.30 clamped to 1.8.
+        // Roster 5's RB room is league-average so RB boost ≈ 1.0.
+        let teamContext = TeamContext(
+            posHPPByRoster: [
+                5: ["RB": 1_000, "WR": 1_000, "QB": 800, "TE": 100]
+            ],
+            leagueAvgByPos: ["RB": 1_000, "WR": 1_000, "QB": 800, "TE": 400],
+            isFallback: false
+        )
+
+        // Pool: top RB at value 10_000, top TE at value 8_500. BPA
+        // picks the RB. Team Fit at roster 5 should pick the TE
+        // because TE value × 1.8 (clamp) = 15_300 > 10_000.
+        let pool = [
+            RookieCandidate(playerId: "rb_top", fullName: "RB Top", position: "RB", nflTeam: "T", value: 10_000),
+            RookieCandidate(playerId: "te_top", fullName: "TE Top", position: "TE", nflTeam: "T", value: 8_500),
+            RookieCandidate(playerId: "wr_top", fullName: "WR Top", position: "WR", nflTeam: "T", value: 9_500)
+        ]
+        let slots = [1: SlotTeam(rosterId: 5, userId: "u5", teamName: "T5")]
+        var rng = SeededRNG(seed: 1)
+        let (picks, _) = MockDraftEngine.run(
+            rookies: pool,
+            slotOrder: slots,
+            rounds: 1,
+            teamContext: teamContext,
+            personality: { _, _ in .teamFit },
+            rng: &rng
+        )
+        XCTAssertEqual(picks.first?.playerId, "te_top",
+                       "Team Fit should pick TE when team has 4× league deficit at TE")
+    }
+
+    // MARK: - Win-Now
+
+    func testWinNow_prefersRBoverQB_atTiedValue() {
+        let pool = [
+            RookieCandidate(playerId: "qb1", fullName: "QB1", position: "QB", nflTeam: "T", value: 10_000),
+            RookieCandidate(playerId: "rb1", fullName: "RB1", position: "RB", nflTeam: "T", value: 10_000)
+        ]
+        let slots = [1: SlotTeam(rosterId: 1, userId: "u1", teamName: "T1")]
+        var rng = SeededRNG(seed: 7)
+        let (picks, _) = MockDraftEngine.run(
+            rookies: pool, slotOrder: slots, rounds: 1,
+            teamContext: emptyTeamContext(),
+            personality: { _, _ in .winNow }, rng: &rng
+        )
+        XCTAssertEqual(picks.first?.playerId, "rb1",
+                       "Win-Now should pick RB (1.30×) over QB (0.85×) at equal value")
+    }
+
+    // MARK: - Hype Train
+
+    func testHypeTrain_pick1_isFromTopTwo() {
+        // With values [10000, 9900, 100, 50] the top-two are
+        // separated by 1%; ±1% jitter on the bottom two can't catch
+        // up because their base score is dwarfed by value^1.2.
+        let pool = [
+            RookieCandidate(playerId: "a", fullName: "A", position: "RB", nflTeam: "T", value: 10_000),
+            RookieCandidate(playerId: "b", fullName: "B", position: "WR", nflTeam: "T", value: 9_900),
+            RookieCandidate(playerId: "c", fullName: "C", position: "TE", nflTeam: "T", value: 100),
+            RookieCandidate(playerId: "d", fullName: "D", position: "QB", nflTeam: "T", value: 50)
+        ]
+        let topIds: Set<String> = ["a", "b"]
+        let slots = [1: SlotTeam(rosterId: 1, userId: "u1", teamName: "T1")]
+        for seed: UInt64 in [1, 2, 3, 1000, 31337] {
+            var rng = SeededRNG(seed: seed)
+            let (picks, _) = MockDraftEngine.run(
+                rookies: pool, slotOrder: slots, rounds: 1,
+                teamContext: emptyTeamContext(),
+                personality: { _, _ in .hypeTrain }, rng: &rng
+            )
+            XCTAssertTrue(topIds.contains(picks.first?.playerId ?? ""),
+                          "Hype Train pick must be from top two; seed=\(seed) picked \(picks.first?.playerId ?? "nil")")
+        }
+    }
+
+    // MARK: - Pool exhaustion
+
+    func testPoolExhaustion_doesNotCrash_andSurfaces() {
+        // 30 rookies, 60-pick draft → engine stops at 30.
+        var pool: [RookieCandidate] = []
+        for i in 0..<30 {
+            pool.append(RookieCandidate(
+                playerId: "p\(i)", fullName: "P\(i)",
+                position: "RB", nflTeam: "T",
+                value: Double(1000 - i)
+            ))
+        }
+        let slots = standardSlotOrder()
+        var rng = SeededRNG(seed: 1)
+        let (picks, exhausted) = MockDraftEngine.run(
+            rookies: pool, slotOrder: slots, rounds: 5,
+            teamContext: emptyTeamContext(),
+            personality: { _, _ in .bpa }, rng: &rng
+        )
+        XCTAssertEqual(picks.count, 30)
+        XCTAssertTrue(exhausted)
+        // No duplicates.
+        XCTAssertEqual(Set(picks.map(\.playerId)).count, 30)
+    }
+
+    // MARK: - Mixed personality assignment
+
+    func testMixed_picksRespectPerTeamPersonality() {
+        // Slot 1 = Win-Now (should pick RB),
+        // Slot 2 = BPA (should pick highest value not yet taken).
+        let pool = [
+            RookieCandidate(playerId: "qb1", fullName: "QB Top", position: "QB", nflTeam: "T", value: 10_000),
+            RookieCandidate(playerId: "rb1", fullName: "RB Top", position: "RB", nflTeam: "T", value: 9_500),
+            RookieCandidate(playerId: "wr1", fullName: "WR Top", position: "WR", nflTeam: "T", value: 9_400)
+        ]
+        let slots: [Int: SlotTeam] = [
+            1: SlotTeam(rosterId: 1, userId: "u1", teamName: "T1"),
+            2: SlotTeam(rosterId: 2, userId: "u2", teamName: "T2")
+        ]
+        let assignment: [Int: DraftPersonality] = [1: .winNow, 2: .bpa]
+        var rng = SeededRNG(seed: 1)
+        let (picks, _) = MockDraftEngine.run(
+            rookies: pool, slotOrder: slots, rounds: 1,
+            teamContext: emptyTeamContext(),
+            personality: { _, rid in assignment[rid] ?? .bpa },
+            rng: &rng
+        )
+        XCTAssertEqual(picks.count, 2)
+        // Win-Now slot1: RB (9_500 * 1.30 = 12_350) beats QB (10_000 * 0.85 = 8_500)
+        XCTAssertEqual(picks[0].playerId, "rb1")
+        XCTAssertEqual(picks[0].personality, .winNow)
+        // BPA slot2 picks highest remaining → qb1.
+        XCTAssertEqual(picks[1].playerId, "qb1")
+        XCTAssertEqual(picks[1].personality, .bpa)
+    }
+
+    // MARK: - No duplicates
+
+    func testNoRookieAppearsTwice() {
+        let pool = standardRookiePool()
+        let slots = standardSlotOrder()
+        var rng = SeededRNG(seed: 12345)
+        let (picks, _) = MockDraftEngine.run(
+            rookies: pool, slotOrder: slots, rounds: 1,
+            teamContext: emptyTeamContext(),
+            personality: { pickNo, _ in
+                DraftPersonality.allCases[pickNo % DraftPersonality.allCases.count]
+            },
+            rng: &rng
+        )
+        XCTAssertEqual(picks.count, Set(picks.map(\.playerId)).count, "No player should appear twice within a single mock")
+    }
+
+    // MARK: - needBoost helper
+
+    func testNeedBoost_returnsOne_whenLeagueAvgIsZero() {
+        let ctx = TeamContext(posHPPByRoster: [:], leagueAvgByPos: [:], isFallback: true)
+        XCTAssertEqual(
+            MockDraftEngine.needBoost(rosterId: 1, position: "RB", teamContext: ctx),
+            1.0,
+            accuracy: 0.0001
+        )
+    }
+
+    func testNeedBoost_clampedToHighBound() {
+        // Team has 0 at TE, league avg = 400 → ratio = 400, raw boost
+        // = 400^0.6 ≈ 36, clamped to 1.8.
+        let ctx = TeamContext(
+            posHPPByRoster: [1: ["TE": 0]],
+            leagueAvgByPos: ["TE": 400],
+            isFallback: false
+        )
+        XCTAssertEqual(
+            MockDraftEngine.needBoost(rosterId: 1, position: "TE", teamContext: ctx),
+            MockDraftEngine.teamFitClampHigh,
+            accuracy: 0.0001
+        )
+    }
+
+    func testNeedBoost_clampedToLowBound() {
+        // Team WAY above league avg → boost clamped low.
+        let ctx = TeamContext(
+            posHPPByRoster: [1: ["RB": 10_000]],
+            leagueAvgByPos: ["RB": 1_000],
+            isFallback: false
+        )
+        XCTAssertEqual(
+            MockDraftEngine.needBoost(rosterId: 1, position: "RB", teamContext: ctx),
+            MockDraftEngine.teamFitClampLow,
+            accuracy: 0.0001
+        )
+    }
+}

--- a/XomperTests/SeededRNGTests.swift
+++ b/XomperTests/SeededRNGTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import Xomper
+
+/// Tests for `SeededRNG`. The engine relies on same-seed-in →
+/// same-sequence-out so test fixtures stay stable.
+final class SeededRNGTests: XCTestCase {
+
+    func testSameSeed_producesIdenticalSequence() {
+        var a = SeededRNG(seed: 42)
+        var b = SeededRNG(seed: 42)
+        for _ in 0..<128 {
+            XCTAssertEqual(a.next(), b.next(), "Same seed must reproduce next()")
+        }
+    }
+
+    func testDifferentSeeds_diverge() {
+        var a = SeededRNG(seed: 42)
+        var b = SeededRNG(seed: 43)
+        var divergences = 0
+        for _ in 0..<128 {
+            if a.next() != b.next() { divergences += 1 }
+        }
+        XCTAssertGreaterThan(divergences, 100, "Different seeds should rarely collide; expect close to 128 divergences")
+    }
+
+    func testNextUnit_inRange() {
+        var rng = SeededRNG(seed: 99)
+        for _ in 0..<1024 {
+            let u = rng.nextUnit()
+            XCTAssertGreaterThanOrEqual(u, 0)
+            XCTAssertLessThan(u, 1)
+        }
+    }
+
+    func testNextDouble_respectsBounds() {
+        var rng = SeededRNG(seed: 7)
+        for _ in 0..<512 {
+            let v = rng.nextDouble(in: -1.0..<1.0)
+            XCTAssertGreaterThanOrEqual(v, -1.0)
+            XCTAssertLessThan(v, 1.0)
+        }
+    }
+
+    func testNextInt_inRange() {
+        var rng = SeededRNG(seed: 31)
+        for _ in 0..<512 {
+            let n = rng.nextInt(in: 0..<8)
+            XCTAssertGreaterThanOrEqual(n, 0)
+            XCTAssertLessThan(n, 8)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the backend-fetched Mocks tab with a pure-Swift client-side
mock-draft engine. Generates 5 personalities (BPA, Team Fit,
Wildcard, Win-Now, Hype Train) against the FantasyCalc rookie pool +
live Sleeper draft slot order, with Pure mode (5 cards) and Mixed
mode (3 cards) toggle + a Reshuffle button for stochastic mocks.

Closes #97. Implements `docs/features/mock-draft/PLAN.md`.

## What changed

- **Engine (pure Swift, no actors, no stores)** in
  `Xomper/Features/DraftOrder/Mocks/`:
  - `DraftPersonality` enum (5 cases + accent colors + isStochastic).
  - `EngineMockedPick`, `MockDraftResult`, `SlotTeam` models.
  - `TeamContext` per-roster per-position HPP snapshot built on
    MainActor, fed into the engine by value.
  - `SeededRNG` SplitMix64 — deterministic for same seed.
  - `MockDraftEngine.run(...)` — pure function of inputs + RNG.
- **Store**: `MockDraftStore` (`@Observable @MainActor`) owns Pure +
  Mixed caches, rookie-pool derivation with `yearsExp ∈ {0,1}`
  fallback, `currentSeed`, `ensureLoaded`, `reshuffle`, `setMode`.
- **HPP helper**: `HighestPossibleCalculator.optimalLineupPointsByPosition`
  added (existing `optimalLineupPoints` now derives from it; totals
  unchanged).
- **View rewrite**: `MocksView` drops `AIReviewStore.loadMockDrafts`
  path entirely. Renders Pure/Mixed cards via `MockDraftCard` +
  `EngineMockedPickRow`. Reshuffle button surfaces in the top-right.
  Banners surface pool / TeamContext fallback states.
- **Wiring**: `DraftHistoryView` now accepts and forwards
  `playerValuesStore`; `MainShell` threads `valuesStore` through both
  call sites.
- **Test seam**: `PlayerStore.setPlayersForTesting(_:)` so HPP tests
  can drive the calc with synthetic players without hitting the
  network.

## Tests

- `SeededRNGTests` (5 cases) — same-seed reproducibility, range
  invariants.
- `HighestPossibleCalculatorTests` (7 cases) — per-position
  breakdown, FLEX edge cases (RB-wins-FLEX and WR-wins-FLEX), total
  equivalence with `optimalLineupPoints`.
- `MockDraftEngineTests` (14 cases) — BPA value-desc determinism,
  Wildcard same-seed reproducibility + cross-seed divergence + top-N
  invariant, Team Fit boosts weak positions, Win-Now prefers RB at
  tied value, Hype Train top-two invariant, pool exhaustion graceful
  stop, Mixed mode per-team personality wiring, needBoost clamps.

All 186 XomperTests pass.

## Out of scope (per PLAN)

- Snake draft support (linear-only v1; logged as a TODO if
  `draft.type == "snake"`).
- Backend mock-draft rows in Dynamo are NOT modified — the iOS app
  just stops calling `AIReviewStore.loadMockDrafts()` from
  `MocksView`. The method is still available for future use.
- User-editable personality weights, save/share/export, persisting
  across app launches.

## Test plan

- [ ] On the Mocks sub-tab, Pure mode renders 5 cards with the first
  expanded.
- [ ] BPA pick 1.01 matches FantasyCalc's top rookie.
- [ ] Wildcard pick 1.01 is in the top 8 by value; Reshuffle changes
  it, BPA stays.
- [ ] Mixed mode renders 3 cards with a "Per-team personalities"
  summary in each header.
- [ ] My team's rows are championGold + YOU badge.
- [ ] No rookie appears twice in any mock.
- [ ] Pool fallback banner appears if `yearsExp == 0` intersection is
  below 60; degrades-to-BPA banner appears if Team Fit context is
  empty.
- [ ] Empty state appears when `historyStore.upcomingDraft == nil`.
- [ ] Pull-to-refresh re-fetches FantasyCalc + reshuffles.