### PR TITLE
fix(ci): include AdminFlags in generated Config.swift

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -48,6 +48,17 @@ jobs:
               static var isConfigured: Bool {
                   !supabaseURL.contains("YOUR_") && !supabaseAnonKey.contains("YOUR_")
               }
+
+              // Admin portal feature flags. Mirror the committed
+              // Xomper/Config/Config.swift.template — CI does NOT read
+              // the template; this enum must be kept in sync by hand
+              // when AdminFlags changes. Keep flags here matching the
+              // committed template so AdminView's feature gates resolve.
+              enum AdminFlags {
+                  static let showTables: Bool = true     // F4
+                  static let showLogs:   Bool = true     // F5
+                  static let showAudit:  Bool = true     // F4
+              }
           }
           EOF
 


### PR DESCRIPTION
## Summary

Every iOS TestFlight deploy since Admin Portal F1 landed has **failed** at the Archive step with:
```
Xomper/Features/Admin/AdminView.swift:59:27: error: type Config has no member AdminFlags
```

Root cause: the `Generate Config.swift` step in `testflight-deploy.yml` writes a heredoc-generated Config.swift that omits the `AdminFlags` enum added by F1. CI does NOT read `Xomper/Config/Config.swift.template` — it writes a minimal Config from scratch every build.

## Fix

Mirror the committed template so the 3 flags (`showTables`, `showLogs`, `showAudit`) resolve.

## Future maintenance note

Added a comment in the workflow: when `AdminFlags` changes, BOTH the heredoc AND `Config.swift.template` must be updated. A long-term fix is to switch to `envsubst` against the template — punted for now.

## Test plan

- [ ] CI passes on this PR
- [ ] Merge fires a TestFlight deploy that succeeds (vs the 5+ failures since F1)