### PR TITLE
fix(ios): mocks fallback + postDraft recap fetch + prominent weekly recap card

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		440A44095AD70A8D3D273EEE /* StandingsScrollBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1A7B1219575171DA3ABAB7 /* StandingsScrollBar.swift */; };
 		4A321187068EEBA8C4E75EFE /* PayoutProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E3BE36BCEA1A7722157C37 /* PayoutProjection.swift */; };
 		4B629DB100C96EB68A6A9A41 /* SearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323F422F2D0E1C2BA5D46C0A /* SearchResults.swift */; };
+		4DA6A8F315E4AFF217B5C7F5 /* MockDraftStoreFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7589768F3AF9DB478D8E0419 /* MockDraftStoreFallbackTests.swift */; };
 		4DB9374CF45A69E97C02FC94 /* PlayerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC44D14381C74E97D8AF868F /* PlayerDetailView.swift */; };
 		4E0CAC9964BF3F2B59EDD844 /* DraftHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A789B8D49FA4430886626289 /* DraftHistory.swift */; };
 		4E975CC9716AFD855A964A53 /* LeagueEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8B04D9DD0B2952BBABAB46 /* LeagueEditView.swift */; };
@@ -169,6 +170,7 @@
 		DA424E9343EC13B81360C48A /* AuditEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0B55BBDA885ABE51022738 /* AuditEntryTests.swift */; };
 		DBD18478CCB04AC17621725D /* LogsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3AF6560D898E487AD13DA35 /* LogsStore.swift */; };
 		DD07BFD2B8150BC2E8256BE1 /* LogGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A099DEE55FFF98FE95185F /* LogGroup.swift */; };
+		DD40E7781004A2E748DACEFA /* WeeklyRecapHeaderCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B7D13F2B9D9E34F8AD2432E /* WeeklyRecapHeaderCard.swift */; };
 		E0951007574761D3F51B21B9 /* DraftSubTabSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7456E9AFD3FA47DA3DA0F7 /* DraftSubTabSelectionTests.swift */; };
 		E1D933F9B0C3E87F9C1C907A /* XomperAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89FC018282A1F1D8B2FD1B60 /* XomperAPIClient.swift */; };
 		E1E44482FBD2CBBA9ED6E829 /* TeamContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747BA75CF4BABB8C5748469D /* TeamContext.swift */; };
@@ -258,6 +260,7 @@
 		581D4F6F3EB8FC0547F49927 /* PlayoffBracketView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayoffBracketView.swift; sourceTree = "<group>"; };
 		58ED7387DCA3E1DC5CDD7AFF /* AdminStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStoreTests.swift; sourceTree = "<group>"; };
 		5A6D698BC8816DA02019846C /* HighestPossibleCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighestPossibleCalculatorTests.swift; sourceTree = "<group>"; };
+		5B7D13F2B9D9E34F8AD2432E /* WeeklyRecapHeaderCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapHeaderCard.swift; sourceTree = "<group>"; };
 		5CE99E9B095120FB6636FC8A /* PlayerValuesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerValuesStore.swift; sourceTree = "<group>"; };
 		5E2B7884F65B1BD0E9B82AA9 /* PastStandingsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastStandingsListView.swift; sourceTree = "<group>"; };
 		5E7AC7756D5F973D69491BC5 /* TablesSubScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TablesSubScreenView.swift; sourceTree = "<group>"; };
@@ -280,6 +283,7 @@
 		71FB63BCA4BDD437FFE6D3A8 /* PressableCardButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PressableCardButtonStyle.swift; sourceTree = "<group>"; };
 		72CFD764A2BA7FF93B318A7F /* CareerStatsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareerStatsSection.swift; sourceTree = "<group>"; };
 		747BA75CF4BABB8C5748469D /* TeamContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamContext.swift; sourceTree = "<group>"; };
+		7589768F3AF9DB478D8E0419 /* MockDraftStoreFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftStoreFallbackTests.swift; sourceTree = "<group>"; };
 		765C03E7E4268373F28754DC /* HighestPossibleLineup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighestPossibleLineup.swift; sourceTree = "<group>"; };
 		7839DD9CF0968986F91A58DB /* AdminStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStore.swift; sourceTree = "<group>"; };
 		7877A392F88F41B8D4979F23 /* MockDraftMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftMetadataTests.swift; sourceTree = "<group>"; };
@@ -546,6 +550,7 @@
 				ED8C8F9BD9880370D65EDF0B /* LogsStoreTests.swift */,
 				A951936FD34F712A8D8E66C0 /* MockDraftEngineTests.swift */,
 				7877A392F88F41B8D4979F23 /* MockDraftMetadataTests.swift */,
+				7589768F3AF9DB478D8E0419 /* MockDraftStoreFallbackTests.swift */,
 				0BC1E989411B5FACF30C4B3A /* PastStandingsArchiveTests.swift */,
 				1D61FC118C0250CA87BDF647 /* ReportFlagTests.swift */,
 				48F82C66C92981F7F8AB58CE /* SeededRNGTests.swift */,
@@ -586,6 +591,7 @@
 				D34E8D4C4B1A29FC412EBA41 /* StandingsListView.swift */,
 				1D6C6489A04EC9CA00FFBD0F /* StandingsOffseasonCard.swift */,
 				E6A47FD1CF3BE7AE0B940DEC /* StandingsView.swift */,
+				5B7D13F2B9D9E34F8AD2432E /* WeeklyRecapHeaderCard.swift */,
 				44F83A5F997AF6E13C98660E /* WorldCupView.swift */,
 			);
 			path = League;
@@ -988,6 +994,7 @@
 				7794B2E1BA5055ACFF150166 /* LogsStoreTests.swift in Sources */,
 				2ECED2F6ACF5F762D1E1462F /* MockDraftEngineTests.swift in Sources */,
 				3403B87830513963A9D86F8F /* MockDraftMetadataTests.swift in Sources */,
+				4DA6A8F315E4AFF217B5C7F5 /* MockDraftStoreFallbackTests.swift in Sources */,
 				D9737CEB4C36AEFB5EC727D0 /* PastStandingsArchiveTests.swift in Sources */,
 				9FA30DE0724E90F9914ED3BA /* ReportFlagTests.swift in Sources */,
 				CC44774FC6B17057810140CF /* SeededRNGTests.swift in Sources */,
@@ -1148,6 +1155,7 @@
 				F7AC235256A88B1877A69345 /* UserEditView.swift in Sources */,
 				E2EC532916CAA2FBB779DB35 /* UserStore.swift in Sources */,
 				629E7B504845E362943D386C /* UsersListView.swift in Sources */,
+				DD40E7781004A2E748DACEFA /* WeeklyRecapHeaderCard.swift in Sources */,
 				75AB19702AADCC870510A1FC /* WeeklyRecapMetadata.swift in Sources */,
 				F57132F0D80EAB60AC0E07F3 /* WhitelistedLeague.swift in Sources */,
 				61EBC3AC052763EAAC807AC9 /* WorldCup.swift in Sources */,

--- a/Xomper/Core/Stores/AIReviewStore.swift
+++ b/Xomper/Core/Stores/AIReviewStore.swift
@@ -40,6 +40,17 @@ final class AIReviewStore {
     private(set) var mockDraftsError: Error?
     private(set) var mockDraftsLoadedAt: Date?
 
+    /// `postDraft` reports for the league, newest-first. Populated by
+    /// `loadPostDraftArchive()` and consumed by `DraftRecapView` so
+    /// past-year recaps remain visible even when the global archive
+    /// page (limit=20) doesn't reach them. Held separately so the year
+    /// switcher in the Draft tab doesn't compete with the main archive
+    /// list for the same 20-row budget.
+    private(set) var postDraftArchive: [AIReport] = []
+    private(set) var isLoadingPostDraftArchive = false
+    private(set) var postDraftArchiveError: Error?
+    private(set) var postDraftArchiveLoadedAt: Date?
+
     /// Weekly recap reports indexed by `period` (e.g. `"2025W04"`).
     /// Populated by `loadWeeklyReport(period:)` and consumed by
     /// `MatchupsView` to render per-matchup blurbs under the matchup
@@ -176,6 +187,38 @@ final class AIReviewStore {
         }
     }
 
+    /// Fetch the postDraft archive — every `type=postDraft` report for
+    /// the league, newest-first. Replaces `postDraftArchive` wholesale.
+    /// Skips re-fetch within 12 hours unless `force` is set.
+    ///
+    /// Loaded lazily by `DraftRecapView` so the per-year year-switcher
+    /// can always resolve past recaps, even when the global archive
+    /// page (limit=20) doesn't reach them.
+    func loadPostDraftArchive(force: Bool = false) async {
+        guard !isLoadingPostDraftArchive else { return }
+        if !force,
+           !postDraftArchive.isEmpty,
+           let last = postDraftArchiveLoadedAt,
+           Date().timeIntervalSince(last) < 12 * 60 * 60 {
+            return
+        }
+        isLoadingPostDraftArchive = true
+        defer { isLoadingPostDraftArchive = false }
+        postDraftArchiveError = nil
+
+        do {
+            let response = try await apiClient.fetchAIReportsList(
+                type: .postDraft,
+                limit: 20,
+                cursor: nil
+            )
+            self.postDraftArchive = response.rows
+            self.postDraftArchiveLoadedAt = Date()
+        } catch {
+            self.postDraftArchiveError = error
+        }
+    }
+
     /// Fetch the weekly recap whose `period` matches the supplied
     /// string (e.g. `"2025W04"`). Cached in `weeklyReportsByPeriod`
     /// so subsequent reads on the same week return immediately. No-op
@@ -273,6 +316,8 @@ final class AIReviewStore {
         latestByType = [:]
         mockDrafts = []
         mockDraftsLoadedAt = nil
+        postDraftArchive = []
+        postDraftArchiveLoadedAt = nil
         weeklyReportsByPeriod = [:]
         lastLoadedAt = nil
         error = nil

--- a/Xomper/Core/Stores/MockDraftStore.swift
+++ b/Xomper/Core/Stores/MockDraftStore.swift
@@ -56,6 +56,14 @@ final class MockDraftStore {
     /// view can warn when Team Fit degrades to BPA.
     private(set) var didFallbackTeamContext: Bool = false
 
+    /// Whether the slot order was derived from prior-season standings
+    /// (inverse — worst record first) instead of the upcoming-draft's
+    /// `draft_order`. True when the commish hasn't yet created the
+    /// Sleeper league for the upcoming season, in which case Sleeper
+    /// has no `Draft` row to seed slot positions from. The view
+    /// surfaces a banner when this is true.
+    private(set) var usingFallbackSlotOrder: Bool = false
+
     /// Active viewing mode. Defaults to Pure on first appear per the
     /// plan.
     private(set) var mode: MockDraftResult.Mode = .pure
@@ -91,11 +99,8 @@ final class MockDraftStore {
         playerPointsStore: PlayerPointsStore,
         regularSeasonLastWeek: Int
     ) {
-        // Gate on the dependencies the engine needs.
-        guard let upcomingDraft = historyStore.upcomingDraft else {
-            status = .noUpcomingDraft
-            return
-        }
+        // Player values + player pool are non-negotiable — neither
+        // path (upcoming draft or fallback) can run without them.
         guard playerValuesStore.hasValues else {
             status = .pending
             return
@@ -105,33 +110,73 @@ final class MockDraftStore {
             return
         }
 
-        // Snake-draft warning per PLAN.md step 18. v1 ships linear-only;
-        // we render the mocks anyway under linear assumptions.
-        if let type = upcomingDraft.type?.lowercased(),
-           type == "snake" {
-            // Just log — the view surfaces a banner. (No print(); use
-            // os_log later if needed.)
-            _ = type
+        // Resolve slot order. Prefer the upcoming draft when Sleeper
+        // has set one; otherwise fall back to prior-season standings
+        // (inverse). The fallback exists because the commish typically
+        // creates the next Sleeper league well after we want to show
+        // mocks — without it, the Mocks tab would be empty all
+        // off-season.
+        let resolvedSlots: [Int: SlotTeam]
+        let isFallback: Bool
+        let cacheIdent: String
+        if let upcomingDraft = historyStore.upcomingDraft {
+            // Snake-draft warning per PLAN.md step 18. v1 ships
+            // linear-only; we render the mocks anyway under linear
+            // assumptions.
+            if let type = upcomingDraft.type?.lowercased(),
+               type == "snake" {
+                _ = type
+            }
+
+            let slots = resolveSlotOrder(
+                draft: upcomingDraft,
+                historyStore: historyStore
+            )
+            if slots.isEmpty {
+                // Sleeper returned a draft row with no `draft_order`
+                // populated yet — fall back to standings just like
+                // the no-draft path.
+                let proxy = Self.proxySlotOrder(
+                    rosters: leagueStore.myLeagueRosters,
+                    users: leagueStore.myLeagueUsers
+                )
+                guard !proxy.isEmpty else {
+                    status = .noUpcomingDraft
+                    return
+                }
+                resolvedSlots = proxy
+                isFallback = true
+                cacheIdent = "fallback-\(leagueStore.myLeague?.leagueId ?? "no-league")"
+            } else {
+                resolvedSlots = slots
+                isFallback = false
+                cacheIdent = upcomingDraft.draftId
+            }
+        } else {
+            let proxy = Self.proxySlotOrder(
+                rosters: leagueStore.myLeagueRosters,
+                users: leagueStore.myLeagueUsers
+            )
+            guard !proxy.isEmpty else {
+                // No upcoming draft AND no prior-season standings yet
+                // — keep the empty state.
+                status = .noUpcomingDraft
+                return
+            }
+            resolvedSlots = proxy
+            isFallback = true
+            cacheIdent = "fallback-\(leagueStore.myLeague?.leagueId ?? "no-league")"
         }
 
         let buildKey = makeBuildKey(
-            draftId: upcomingDraft.draftId,
+            draftId: cacheIdent,
             valuesLoadedAt: playerValuesStore.lastLoadedAt,
             seed: currentSeed
         )
         if buildKey == lastBuildKey { return }
 
-        // Resolve slot order from `draft_order` + upcoming users +
-        // rosters.
-        let slots = resolveSlotOrder(
-            draft: upcomingDraft,
-            historyStore: historyStore
-        )
-        guard !slots.isEmpty else {
-            status = .noUpcomingDraft
-            return
-        }
-        slotOrder = slots
+        slotOrder = resolvedSlots
+        usingFallbackSlotOrder = isFallback
 
         // Build the rookie pool.
         let (pool, didFallback) = buildRookiePool(
@@ -146,7 +191,7 @@ final class MockDraftStore {
         didFallbackPool = didFallback
 
         // Per-roster per-position HPP snapshot.
-        let rosterIds = Array(Set(slots.values.map { $0.rosterId })).sorted()
+        let rosterIds = Array(Set(resolvedSlots.values.map { $0.rosterId })).sorted()
         let context = TeamContext.build(
             rosterIds: rosterIds,
             leagueStore: leagueStore,
@@ -264,6 +309,51 @@ final class MockDraftStore {
     }
 
     // MARK: - Slot order
+
+    /// Fallback slot order: worst regular-season record gets slot 1,
+    /// best gets slot N (12 in our league). Sort key is `wins ASC,
+    /// pointsFor ASC` (worst first). Returned as the same `[slot:
+    /// SlotTeam]` dict shape `resolveSlotOrder` produces so the engine
+    /// can run unchanged.
+    ///
+    /// Used when Sleeper hasn't created the upcoming league's draft
+    /// yet — most of the off-season. The view banners the fallback so
+    /// users know the slot positions are a proxy.
+    ///
+    /// Static so tests can drive it without spinning up a full
+    /// `MockDraftStore` + dependency graph.
+    static func proxySlotOrder(
+        rosters: [Roster],
+        users: [SleeperUser]
+    ) -> [Int: SlotTeam] {
+        guard !rosters.isEmpty else { return [:] }
+
+        // Worst-first sort: lowest wins, then lowest fpts as the
+        // tiebreak (same proxy the static-mock backfill uses earlier
+        // in the year).
+        let sorted = rosters.sorted { lhs, rhs in
+            let lWins = lhs.settings?.wins ?? 0
+            let rWins = rhs.settings?.wins ?? 0
+            if lWins != rWins { return lWins < rWins }
+            return lhs.pointsFor < rhs.pointsFor
+        }
+
+        var bySlot: [Int: SlotTeam] = [:]
+        for (index, roster) in sorted.enumerated() {
+            let slot = index + 1
+            let ownerId = roster.ownerId ?? ""
+            let user = users.first { ($0.userId ?? "") == ownerId }
+            let teamName = user?.teamName
+                ?? user?.resolvedDisplayName
+                ?? "Slot \(slot)"
+            bySlot[slot] = SlotTeam(
+                rosterId: roster.rosterId,
+                userId: ownerId,
+                teamName: teamName
+            )
+        }
+        return bySlot
+    }
 
     /// Resolves `slot → SlotTeam` from the upcoming-draft snapshot.
     /// `draft.draftOrder` is `[user_id: slot]`; cross-reference with

--- a/Xomper/Features/DraftHistory/Draft/DraftRecapView.swift
+++ b/Xomper/Features/DraftHistory/Draft/DraftRecapView.swift
@@ -7,15 +7,20 @@ import SwiftUI
 /// `AIReviewDetailView`.
 ///
 /// Data flow:
-/// 1. On appear / year change, lazy-load the archive if it hasn't
-///    been pulled yet.
-/// 2. Filter `aiReviewStore.archive` for `reportType == .postDraft`
-///    AND `period.contains(year)`. The archive is newest-first so
-///    `first(where:)` returns the most recent match.
+/// 1. On appear / year change, lazy-load the dedicated postDraft
+///    archive (`loadPostDraftArchive`) if it hasn't been pulled yet.
+///    The dedicated fetch (`type=postDraft`) guarantees past-year
+///    recaps are reachable even when the global archive's first 20
+///    rows wouldn't include them.
+/// 2. Filter `aiReviewStore.postDraftArchive` for
+///    `reportType == .postDraft` AND `period.contains(year)`. The
+///    archive is newest-first so `first(where:)` returns the most
+///    recent match.
 /// 3. Render header (period + createdAt) and body
 ///    (`AttributedString(markdown:)`).
 ///
-/// Pull-to-refresh forces an archive reload via `force: true`.
+/// Pull-to-refresh forces a postDraft archive reload via
+/// `force: true`.
 struct DraftRecapView: View {
     var aiReviewStore: AIReviewStore
     let year: String
@@ -24,7 +29,7 @@ struct DraftRecapView: View {
         Group {
             if let report = matchingReport {
                 reportContent(report)
-            } else if aiReviewStore.isLoading {
+            } else if aiReviewStore.isLoadingPostDraftArchive {
                 LoadingView(message: "Loading \(year) draft recap…")
             } else {
                 EmptyStateView(
@@ -39,17 +44,17 @@ struct DraftRecapView: View {
             await ensureArchiveLoaded()
         }
         .refreshable {
-            await aiReviewStore.loadArchive(force: true)
+            await aiReviewStore.loadPostDraftArchive(force: true)
         }
     }
 
     // MARK: - Resolved report
 
-    /// Resolves the matching report from the store's archive. Static
-    /// peer (`Self.matchingReport`) holds the actual logic so tests
-    /// can drive it directly.
+    /// Resolves the matching report from the store's postDraft
+    /// archive. Static peer (`Self.matchingReport`) holds the actual
+    /// logic so tests can drive it directly.
     private var matchingReport: AIReport? {
-        Self.matchingReport(in: aiReviewStore.archive, year: year)
+        Self.matchingReport(in: aiReviewStore.postDraftArchive, year: year)
     }
 
     /// Pure filter: take the first `postDraft` report whose `period`
@@ -69,13 +74,11 @@ struct DraftRecapView: View {
     // MARK: - Loading
 
     private func ensureArchiveLoaded() async {
-        // Lazy-load only when the archive is empty. The 12-hour
-        // freshness guard inside `loadArchive` short-circuits any
-        // subsequent calls, so we don't need to gate on
-        // `lastLoadedAt` here.
-        if aiReviewStore.archive.isEmpty {
-            await aiReviewStore.loadArchive()
-        }
+        // Lazy-load the dedicated postDraft archive. The 12-hour
+        // freshness guard inside `loadPostDraftArchive` short-circuits
+        // any subsequent calls, so we don't need to gate on
+        // `postDraftArchiveLoadedAt` here.
+        await aiReviewStore.loadPostDraftArchive()
     }
 
     // MARK: - Report content

--- a/Xomper/Features/DraftHistory/Draft/MocksView.swift
+++ b/Xomper/Features/DraftHistory/Draft/MocksView.swift
@@ -35,10 +35,13 @@ struct MocksView: View {
             case .idle, .pending:
                 LoadingView(message: "Generating mock drafts…")
             case .noUpcomingDraft:
+                // Reached only when both Sleeper's upcoming-draft row
+                // is missing AND the prior-season standings fallback
+                // can't produce a slot order (no rosters loaded yet).
                 EmptyStateView(
                     icon: "calendar.badge.exclamationmark",
                     title: "No Upcoming Draft",
-                    message: "The commissioner hasn't set up the next draft yet. Once it's scheduled in Sleeper, mocks will appear here."
+                    message: "The commissioner hasn't set up the next draft yet, and prior-season standings haven't loaded. Try again once the league finishes loading."
                 )
             case .noRookiePool:
                 EmptyStateView(
@@ -70,6 +73,11 @@ struct MocksView: View {
             VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
                 topBar
 
+                if store.usingFallbackSlotOrder {
+                    fallbackNotice(
+                        text: "Using prior-season standings as proxy slot order — actual draft order TBD until commish creates the Sleeper league."
+                    )
+                }
                 if store.didFallbackPool {
                     fallbackNotice(
                         text: "Rookie pool widened to include 1st-year vets — strict yearsExp = 0 pool was too small."

--- a/Xomper/Features/League/MatchupsView.swift
+++ b/Xomper/Features/League/MatchupsView.swift
@@ -103,6 +103,16 @@ struct MatchupsView: View {
 
             if expandedWeek == weekData.week {
                 VStack(spacing: XomperTheme.Spacing.md) {
+                    // Prominent full-recap card at the top of the
+                    // expanded week. Primary surface for the
+                    // AI-generated weekly content — renders only when
+                    // the recap has loaded for this `(season, week)`.
+                    // Per-matchup blurbs below each matchup card stay
+                    // as a secondary detail surface.
+                    if let recap = weeklyRecap(for: weekData) {
+                        WeeklyRecapHeaderCard(report: recap)
+                    }
+
                     ForEach(weekData.matchups) { matchup in
                         VStack(spacing: XomperTheme.Spacing.xs) {
                             MatchupCardView(matchup: matchup) {
@@ -145,6 +155,22 @@ struct MatchupsView: View {
     /// avoids stale fetches when the season chip flips.
     private func weekRecapTaskId(_ weekData: WeekMatchups) -> String {
         "\(currentSeason)-\(weekData.week)"
+    }
+
+    /// Resolves the full weekly recap for an expanded past-and-scored
+    /// week. Returns the cached `AIReport` for the
+    /// `AIReviewStore.weeklyPeriod(season:, week:)` key, or `nil` when
+    /// the recap hasn't been generated yet (current / future weeks,
+    /// pre-AI-review backfilled weeks). The
+    /// `WeeklyRecapHeaderCard` is silently absent in either case.
+    private func weeklyRecap(for weekData: WeekMatchups) -> AIReport? {
+        guard weekData.hasScores else { return nil }
+        let period = AIReviewStore.weeklyPeriod(
+            season: currentSeason,
+            week: weekData.week
+        )
+        guard !period.isEmpty else { return nil }
+        return aiReviewStore.weeklyReportsByPeriod[period]
     }
 
     /// Resolves the per-matchup blurb for a rendered matchup. Looks

--- a/Xomper/Features/League/WeeklyRecapHeaderCard.swift
+++ b/Xomper/Features/League/WeeklyRecapHeaderCard.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+/// Prominent header card that renders the full weekly recap markdown
+/// (`AIReport.bodyMarkdown`) at the top of an expanded past-and-scored
+/// week on `MatchupsView`. Acts as the primary surface for the
+/// AI-generated weekly content — the per-matchup blurbs that sit under
+/// each matchup card stay in place as a secondary detail surface.
+///
+/// Collapsible via `DisclosureGroup` (default expanded) so users can
+/// hide a long recap after reading without scrolling past it on every
+/// expand.
+///
+/// Visual treatment mirrors `DraftRecapView.headerCard` +
+/// `bodyCard` rolled into a single card: gold "WEEKLY RECAP" pill +
+/// period label up top, then `AttributedString(markdown:)`-rendered
+/// body. Defensive: if markdown parsing fails (malformed recap), falls
+/// back to the raw string so the user still sees the content.
+struct WeeklyRecapHeaderCard: View {
+    let report: AIReport
+
+    @State private var isExpanded: Bool = true
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            DisclosureGroup(isExpanded: $isExpanded) {
+                VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+                    renderedMarkdown
+                        .font(.body)
+                        .foregroundStyle(XomperColors.textPrimary)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.top, XomperTheme.Spacing.sm)
+            } label: {
+                header
+            }
+            .tint(XomperColors.championGold)
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+        .xomperShadow(.sm)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Weekly recap for \(report.period)")
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            Text("WEEKLY RECAP")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(XomperColors.bgDark)
+                .padding(.horizontal, XomperTheme.Spacing.xs)
+                .padding(.vertical, 2)
+                .background(XomperColors.championGold)
+                .clipShape(Capsule())
+
+            Text(report.period)
+                .font(.subheadline.weight(.bold))
+                .foregroundStyle(XomperColors.championGold)
+                .monospacedDigit()
+
+            Spacer(minLength: XomperTheme.Spacing.xs)
+        }
+        .contentShape(Rectangle())
+    }
+
+    // MARK: - Markdown
+
+    /// iOS 17 `AttributedString(markdown:)` with full interpreted
+    /// syntax (headings, lists, bold). Matches `DraftRecapView`. Falls
+    /// back to plain text if the markdown is malformed so the
+    /// AI-generated body always renders, even on parse failure.
+    @ViewBuilder
+    private var renderedMarkdown: some View {
+        if let attributed = try? AttributedString(
+            markdown: report.bodyMarkdown,
+            options: AttributedString.MarkdownParsingOptions(
+                interpretedSyntax: .full
+            )
+        ) {
+            Text(attributed)
+        } else {
+            Text(report.bodyMarkdown)
+        }
+    }
+}
+
+#Preview {
+    WeeklyRecapHeaderCard(
+        report: AIReport(
+            id: "L1|REPORT#weekly#2025W09",
+            leagueId: "L1",
+            reportType: .weekly,
+            period: "2025W09",
+            bodyMarkdown: """
+            ## Week 9 Recap
+
+            **Tony Tigers** rolled to a **148.2 - 102.1** win over **Mighty Ducks**.
+
+            - Top scorer: McCaffrey, 38.4
+            - Bust of the week: Lamar, 6.2
+            """,
+            metadata: [:],
+            createdAt: Date(),
+            model: "claude-haiku-4-5",
+            promptVersion: "f0-2025-10-15"
+        )
+    )
+    .padding()
+    .background(XomperColors.bgDark)
+    .preferredColorScheme(.dark)
+}

--- a/XomperTests/DraftRecapResolverTests.swift
+++ b/XomperTests/DraftRecapResolverTests.swift
@@ -141,4 +141,47 @@ final class DraftRecapResolverTests: XCTestCase {
         let match = DraftRecapView.matchingReport(in: [], year: "2026")
         XCTAssertNil(match)
     }
+
+    // MARK: - Test 8: type=postDraft fetch surfaces past-year recaps
+    // that the global archive's first-page limit would have buried
+
+    /// Simulates the production fix: the view now reads from
+    /// `aiReviewStore.postDraftArchive`, populated by
+    /// `loadPostDraftArchive()` which calls
+    /// `fetchAIReportsList(type: .postDraft, limit: 20)`. As long as
+    /// the postDraft archive contains the 2024 row, the resolver finds
+    /// it — regardless of how many weekly / mock rows sit "ahead" of it
+    /// in the global archive.
+    func testPostDraftArchive_resolvesOldYearEvenWithLargeOtherCorpus() {
+        // 39-row corpus (36 weekly + 2 postDraft + 3 mock) where the
+        // 2024 postDraft is buried after 30 weekly rows by createdAt.
+        // The dedicated postDraft fetch trims to just the two postDraft
+        // rows, so the resolver lands on 2024 in O(2).
+        let postDraft2024 = makeReport(
+            id: "L1|REPORT#postDraft#2024",
+            type: .postDraft,
+            period: "2024",
+            createdAt: Date(timeIntervalSinceNow: -86_400 * 600)
+        )
+        let postDraft2025 = makeReport(
+            id: "L1|REPORT#postDraft#2025",
+            type: .postDraft,
+            period: "2025",
+            createdAt: Date(timeIntervalSinceNow: -86_400 * 300)
+        )
+        // What `postDraftArchive` ends up holding (newest-first).
+        let postDraftArchive = [postDraft2025, postDraft2024]
+
+        let match2024 = DraftRecapView.matchingReport(
+            in: postDraftArchive,
+            year: "2024"
+        )
+        XCTAssertEqual(match2024?.id, postDraft2024.id)
+
+        let match2025 = DraftRecapView.matchingReport(
+            in: postDraftArchive,
+            year: "2025"
+        )
+        XCTAssertEqual(match2025?.id, postDraft2025.id)
+    }
 }

--- a/XomperTests/MockDraftStoreFallbackTests.swift
+++ b/XomperTests/MockDraftStoreFallbackTests.swift
@@ -1,0 +1,190 @@
+import XCTest
+@testable import Xomper
+
+/// Tests for `MockDraftStore.proxySlotOrder(rosters:users:)` — the
+/// prior-season-standings fallback used when Sleeper has no upcoming
+/// draft (most of the off-season).
+///
+/// The static helper is pure (no store, no dependency graph), so these
+/// tests stay fast and focused.
+@MainActor
+final class MockDraftStoreFallbackTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Builds a `Roster` with the supplied wins / fpts. Other settings
+    /// fields are zeroed since the proxy only reads `wins` and the
+    /// roster's `pointsFor` computed property.
+    private func makeRoster(
+        rosterId: Int,
+        ownerId: String,
+        wins: Int,
+        fpts: Int
+    ) -> Roster {
+        // `RosterSettings` only has `init(from decoder:)`; build the
+        // raw JSON and decode so the fixture stays valid as fields
+        // shift over time.
+        let json: [String: Any] = [
+            "roster_id": rosterId,
+            "owner_id": ownerId,
+            "league_id": "L1",
+            "settings": [
+                "wins": wins,
+                "losses": 0,
+                "ties": 0,
+                "division": 0,
+                "fpts": fpts,
+                "fpts_decimal": 0,
+                "fpts_against": 0,
+                "fpts_against_decimal": 0
+            ]
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        return try! JSONDecoder().decode(Roster.self, from: data)
+    }
+
+    private func makeUser(
+        userId: String,
+        displayName: String? = nil,
+        teamName: String? = nil
+    ) -> SleeperUser {
+        var json: [String: Any] = [
+            "user_id": userId,
+            "username": userId
+        ]
+        if let displayName {
+            json["display_name"] = displayName
+        }
+        if let teamName {
+            json["metadata"] = ["team_name": teamName]
+        }
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        return try! JSONDecoder().decode(SleeperUser.self, from: data)
+    }
+
+    // MARK: - Test 1: empty rosters returns empty dict
+
+    func testProxySlotOrder_emptyRosters_returnsEmpty() {
+        let slots = MockDraftStore.proxySlotOrder(rosters: [], users: [])
+        XCTAssertTrue(slots.isEmpty)
+    }
+
+    // MARK: - Test 2: worst record gets slot 1, best gets slot N
+
+    func testProxySlotOrder_sortsWorstFirst() {
+        let rosters = [
+            makeRoster(rosterId: 1, ownerId: "u1", wins: 10, fpts: 1500),
+            makeRoster(rosterId: 2, ownerId: "u2", wins: 2, fpts: 1100),
+            makeRoster(rosterId: 3, ownerId: "u3", wins: 7, fpts: 1300),
+            makeRoster(rosterId: 4, ownerId: "u4", wins: 5, fpts: 1200)
+        ]
+        let users = [
+            makeUser(userId: "u1", teamName: "Champs"),
+            makeUser(userId: "u2", teamName: "Cellar"),
+            makeUser(userId: "u3", teamName: "Mid"),
+            makeUser(userId: "u4", teamName: "Lower")
+        ]
+
+        let slots = MockDraftStore.proxySlotOrder(rosters: rosters, users: users)
+
+        // Worst (2 wins) → slot 1
+        XCTAssertEqual(slots[1]?.rosterId, 2)
+        XCTAssertEqual(slots[1]?.teamName, "Cellar")
+        // Next worst (5 wins) → slot 2
+        XCTAssertEqual(slots[2]?.rosterId, 4)
+        XCTAssertEqual(slots[2]?.teamName, "Lower")
+        // 7 wins → slot 3
+        XCTAssertEqual(slots[3]?.rosterId, 3)
+        XCTAssertEqual(slots[3]?.teamName, "Mid")
+        // Best (10 wins) → slot 4
+        XCTAssertEqual(slots[4]?.rosterId, 1)
+        XCTAssertEqual(slots[4]?.teamName, "Champs")
+    }
+
+    // MARK: - Test 3: tie on wins → pointsFor breaks the tie (lower first)
+
+    func testProxySlotOrder_tieOnWins_pointsForBreaksTie() {
+        let rosters = [
+            makeRoster(rosterId: 10, ownerId: "u10", wins: 6, fpts: 1300),
+            makeRoster(rosterId: 11, ownerId: "u11", wins: 6, fpts: 1100),
+            makeRoster(rosterId: 12, ownerId: "u12", wins: 6, fpts: 1200)
+        ]
+        let users = [
+            makeUser(userId: "u10"),
+            makeUser(userId: "u11"),
+            makeUser(userId: "u12")
+        ]
+
+        let slots = MockDraftStore.proxySlotOrder(rosters: rosters, users: users)
+
+        XCTAssertEqual(slots[1]?.rosterId, 11, "Lowest fpts (1100) gets slot 1")
+        XCTAssertEqual(slots[2]?.rosterId, 12, "Middle fpts (1200) gets slot 2")
+        XCTAssertEqual(slots[3]?.rosterId, 10, "Highest fpts (1300) gets slot 3")
+    }
+
+    // MARK: - Test 4: team name preference (team_name > display_name > "Slot N")
+
+    func testProxySlotOrder_teamNameFallsBackThroughChain() {
+        let rosters = [
+            makeRoster(rosterId: 1, ownerId: "u1", wins: 1, fpts: 0),
+            makeRoster(rosterId: 2, ownerId: "u2", wins: 2, fpts: 0),
+            makeRoster(rosterId: 3, ownerId: "u-missing", wins: 3, fpts: 0)
+        ]
+        let users = [
+            makeUser(userId: "u1", teamName: "Tigers"),
+            makeUser(userId: "u2", displayName: "DisplayName")
+        ]
+
+        let slots = MockDraftStore.proxySlotOrder(rosters: rosters, users: users)
+
+        XCTAssertEqual(slots[1]?.teamName, "Tigers", "team_name preferred when present")
+        XCTAssertEqual(slots[2]?.teamName, "DisplayName", "displayName when no team_name")
+        // u-missing isn't in users — falls back to "Slot N" (slot 3).
+        XCTAssertEqual(slots[3]?.teamName, "Slot 3")
+    }
+
+    // MARK: - Test 5: slot dict covers exactly N entries (one per roster)
+
+    func testProxySlotOrder_coversEveryRoster() {
+        let rosters = (1...12).map { id in
+            makeRoster(rosterId: id, ownerId: "u\(id)", wins: id, fpts: id * 100)
+        }
+        let users = (1...12).map { makeUser(userId: "u\($0)") }
+
+        let slots = MockDraftStore.proxySlotOrder(rosters: rosters, users: users)
+
+        XCTAssertEqual(slots.count, 12)
+        XCTAssertEqual(Set(slots.keys), Set(1...12))
+        let coveredRosters = Set(slots.values.map(\.rosterId))
+        XCTAssertEqual(coveredRosters, Set(1...12))
+    }
+
+    // MARK: - Test 6: missing owner_id → empty userId, falls back to "Slot N"
+
+    func testProxySlotOrder_nilOwnerId_doesNotCrash() {
+        // Manually craft a roster with no owner_id key.
+        let json: [String: Any] = [
+            "roster_id": 7,
+            "league_id": "L1",
+            "settings": [
+                "wins": 0,
+                "losses": 0,
+                "ties": 0,
+                "division": 0,
+                "fpts": 0,
+                "fpts_decimal": 0,
+                "fpts_against": 0,
+                "fpts_against_decimal": 0
+            ]
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        let roster = try! JSONDecoder().decode(Roster.self, from: data)
+
+        let slots = MockDraftStore.proxySlotOrder(rosters: [roster], users: [])
+
+        XCTAssertEqual(slots.count, 1)
+        XCTAssertEqual(slots[1]?.rosterId, 7)
+        XCTAssertEqual(slots[1]?.userId, "")
+        XCTAssertEqual(slots[1]?.teamName, "Slot 1")
+    }
+}


### PR DESCRIPTION
## Summary

Three TestFlight 2.29.1 regressions caught after install.

- **Mocks tab empty all off-season.** Sleeper hasn't created the 2026 league yet (draft is 2026-07-06), so `historyStore.upcomingDraft == nil` and `MockDraftStore.ensureLoaded` bailed with `.noUpcomingDraft`. New `MockDraftStore.proxySlotOrder(rosters:users:)` derives a slot order from prior-season standings (worst record gets slot 1, best gets slot N — tiebreak on pointsFor). Renders the engine against the proxy + shows a banner via `usingFallbackSlotOrder`.
- **Past-year Draft Recap shows "No Recap Yet".** `DraftRecapView` was reading from the general 20-row archive. With 39 reports in Dynamo, the 2024 postDraft can fall outside the first page. New `AIReviewStore.postDraftArchive` + `loadPostDraftArchive()` fetches `type=postDraft` directly (limit 20 of postDraft only — covers all years). View reads from the dedicated archive.
- **Per-matchup blurbs not visible enough.** New `WeeklyRecapHeaderCard` renders the full weekly `bodyMarkdown` as a prominent card at the top of each expanded past-and-scored week. Collapsible `DisclosureGroup`, default expanded. Per-matchup blurbs stay as a secondary surface under each `MatchupCardView`. Markdown parse failure falls back to raw text — defensive against silent decode issues.

## Files

**New**
- `Xomper/Features/League/WeeklyRecapHeaderCard.swift`
- `XomperTests/MockDraftStoreFallbackTests.swift`

**Modified**
- `Xomper/Core/Stores/MockDraftStore.swift` — fallback path + `proxySlotOrder` + `usingFallbackSlotOrder` flag
- `Xomper/Core/Stores/AIReviewStore.swift` — `postDraftArchive` + `loadPostDraftArchive()`
- `Xomper/Features/DraftHistory/Draft/DraftRecapView.swift` — read from `postDraftArchive`, swap loader + loading flag
- `Xomper/Features/DraftHistory/Draft/MocksView.swift` — fallback banner
- `Xomper/Features/League/MatchupsView.swift` — inject `WeeklyRecapHeaderCard` at top of expanded weeks
- `XomperTests/DraftRecapResolverTests.swift` — test 8 covers the `postDraftArchive` read path

## Stacked dependency

This branch sits on top of `feature/mock-draft-engine` (commit `b0d96da`), not yet merged to `main`. The diff against `main` includes that commit as well — merge the engine first or merge them together. Two commits total: the engine + the fix.

## Test plan
- [x] `xcodebuild ... build` — clean, no warnings
- [x] `xcodebuild ... test` — 193/193 pass (6 new fallback tests + 8th resolver test)
- [ ] Manual: load Mocks tab against league with no upcoming draft → fallback banner + slot order renders
- [ ] Manual: open Draft Recap → 2024 sub-tab → past-year recap renders
- [ ] Manual: expand a past week in Matchups → prominent recap card at top, blurbs still under each matchup