### PR TITLE
feat(admin-cron-settings): iOS — kill switch + test mode toggles

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -55,9 +55,10 @@ jobs:
               // when AdminFlags changes. Keep flags here matching the
               // committed template so AdminView's feature gates resolve.
               enum AdminFlags {
-                  static let showTables: Bool = true     // F4
-                  static let showLogs:   Bool = true     // F5
-                  static let showAudit:  Bool = true     // F4
+                  static let showTables: Bool = true            // F4
+                  static let showLogs:   Bool = true            // F5
+                  static let showAudit:  Bool = true            // F4
+                  static let showCronSettings: Bool = true      // admin-cron-settings
               }
           }
           EOF

--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		04C5B75AA224E7ED8314FBA5 /* AIReviewHomeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12507ED13C57EFA8B240301 /* AIReviewHomeCard.swift */; };
 		063FCD6AA342CA5D64ED79ED /* HistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F013CD37874EFB0FA1CB4261 /* HistoryStore.swift */; };
 		08251EFB3181B634553CDCE1 /* TaxiSquadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57940AEB84889A20016648F2 /* TaxiSquadView.swift */; };
+		087C52AE54EBC054E36E696B /* CronSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B9527EA5CA26FE5197FCF5 /* CronSettingsStore.swift */; };
 		0905D6C3E336782530E5F4B4 /* LogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99981051F598B42534DE81CB /* LogLevel.swift */; };
 		0A87A5226863819FF3884F6C /* AnnouncementsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCF4387BA57375E04A8940B /* AnnouncementsCard.swift */; };
 		0C2B77E0A46ECE55AE8CE46F /* DivisionBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B670A3A0762D22FB3202E1E /* DivisionBadge.swift */; };
@@ -76,6 +77,7 @@
 		58FD67DB9B137F1A8BE50521 /* TeamAnalyzerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8098F78566BB324ACC70FB94 /* TeamAnalyzerView.swift */; };
 		5BAA65DF5DF710DCBAAC2BF8 /* StandingsOffseasonCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6C6489A04EC9CA00FFBD0F /* StandingsOffseasonCard.swift */; };
 		5C041F847E3239901238FD5F /* LandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7048EDD875E2582C792BE47 /* LandingView.swift */; };
+		5E06735B11149010019AFA3F /* CronSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7474B2C8F1F2B14821F4539 /* CronSettingsView.swift */; };
 		6010F16122E110BA50642611 /* CareerStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD43D54AB620DABD559F8A40 /* CareerStats.swift */; };
 		602B6E0F6BCF1DA7E3D75F07 /* AuthStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */; };
 		60D967E9FEA043C0CF58EFBF /* AdminTablesStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBAC7CE2DC64237D218FAB8 /* AdminTablesStoreTests.swift */; };
@@ -97,10 +99,12 @@
 		75AB19702AADCC870510A1FC /* WeeklyRecapMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2549566AC9312F44BA381BB6 /* WeeklyRecapMetadata.swift */; };
 		7607DB7C775FCCC3B7C3377B /* StandingsTeam.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29D510D87CD290AE7F76FBF /* StandingsTeam.swift */; };
 		76260F26A40213A62E5F22FB /* RecordBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AD376EFB7AD4A192FAB3E8F /* RecordBadge.swift */; };
+		76B8EBD352AAA56BD6A5F446 /* CronSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E172A0188BB654B8E010842 /* CronSetting.swift */; };
 		775985FFAD33E6481C34174A /* TrophyCaseCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2908776CDAC0CACB28B4B1 /* TrophyCaseCard.swift */; };
 		7794B2E1BA5055ACFF150166 /* LogsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8C8F9BD9880370D65EDF0B /* LogsStoreTests.swift */; };
 		77A0EFCEE4340D3A7853BF08 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43685B0C212A644C0EF202E5 /* ProfileView.swift */; };
 		77CFB7F9C5E4975E6350662B /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AFC2ADE424F95E3121BF22 /* SettingsView.swift */; };
+		77E21904E6B1A4427AB48C50 /* CronSettingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB439DD73C2D26421BE97E7 /* CronSettingTests.swift */; };
 		78094B6DF90F54E0FA59898A /* TrayDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70E04168BDBA7D3372BB605 /* TrayDestination.swift */; };
 		79083ADBA183714E71D3DC36 /* MockDraftCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6608DF8A0DC5E1EF5A36A39 /* MockDraftCard.swift */; };
 		7956271EA17998F79679D970 /* AuditFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1358E97D2A18E9A5440D8CC /* AuditFeedView.swift */; };
@@ -180,6 +184,7 @@
 		E64E815819D87CED1DF5383F /* AIReviewPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6B846E697A235684C8EBA4 /* AIReviewPreviewView.swift */; };
 		EDDACB3FFB20E468D9D9D67D /* HeaderBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E7D0FD804723AC6A3E4298 /* HeaderBar.swift */; };
 		EE987501F73209179D5CEEB4 /* TestEmailStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E98CD5B3ECB6292B6D7637B /* TestEmailStore.swift */; };
+		F118537BB85C27688E57C703 /* CronSettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4C60C4B1F35CD6B056AC29 /* CronSettingsStoreTests.swift */; };
 		F201A3A40D624F6AAA0C0CC1 /* PlayoffBracket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */; };
 		F57132F0D80EAB60AC0E07F3 /* WhitelistedLeague.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747C6FC769C117588F8A93E /* WhitelistedLeague.swift */; };
 		F5AC0E08C9F82995736A62EF /* LogsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B38051DBBEE34C89E9446FE /* LogsView.swift */; };
@@ -226,11 +231,13 @@
 		2DB0B979B62A1CF6EB80417F /* DraftRecapResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftRecapResolverTests.swift; sourceTree = "<group>"; };
 		2DBAC7CE2DC64237D218FAB8 /* AdminTablesStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminTablesStoreTests.swift; sourceTree = "<group>"; };
 		2DCF4387BA57375E04A8940B /* AnnouncementsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsCard.swift; sourceTree = "<group>"; };
+		2E172A0188BB654B8E010842 /* CronSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronSetting.swift; sourceTree = "<group>"; };
 		323F422F2D0E1C2BA5D46C0A /* SearchResults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResults.swift; sourceTree = "<group>"; };
 		36A01820FD0F6643BBF8511D /* TeamStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamStore.swift; sourceTree = "<group>"; };
 		3728C5F6BEF61FE509A3EA32 /* ClinchCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClinchCalculator.swift; sourceTree = "<group>"; };
 		3747C6FC769C117588F8A93E /* WhitelistedLeague.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhitelistedLeague.swift; sourceTree = "<group>"; };
 		37E65C159F2C84E48B61A9A8 /* ArchiveNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveNavigationTests.swift; sourceTree = "<group>"; };
+		3A4C60C4B1F35CD6B056AC29 /* CronSettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronSettingsStoreTests.swift; sourceTree = "<group>"; };
 		3A51BC6B9389405FE754DCEB /* AIReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewView.swift; sourceTree = "<group>"; };
 		3B38051DBBEE34C89E9446FE /* LogsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsView.swift; sourceTree = "<group>"; };
 		3E4EC7FDB93C47A9EE601BA3 /* TrayItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayItem.swift; sourceTree = "<group>"; };
@@ -329,6 +336,7 @@
 		AE543CB2E49335ADD02E8000 /* Roster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Roster.swift; sourceTree = "<group>"; };
 		B04B5251715A37E924DF7CEF /* LiveDraftView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveDraftView.swift; sourceTree = "<group>"; };
 		B1358E97D2A18E9A5440D8CC /* AuditFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditFeedView.swift; sourceTree = "<group>"; };
+		B1B9527EA5CA26FE5197FCF5 /* CronSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronSettingsStore.swift; sourceTree = "<group>"; };
 		B29D510D87CD290AE7F76FBF /* StandingsTeam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsTeam.swift; sourceTree = "<group>"; };
 		B3893B13276074EF6033CEA2 /* ClinchCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClinchCalculatorTests.swift; sourceTree = "<group>"; };
 		B6060C3A4F2B355757F1E3A2 /* DraftHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftHistoryView.swift; sourceTree = "<group>"; };
@@ -346,12 +354,14 @@
 		C1CD5644F6F8376CA86092AF /* Xomper.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Xomper.entitlements; sourceTree = "<group>"; };
 		C206B0A18917D2B43B17ADCF /* AdminTablesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminTablesStore.swift; sourceTree = "<group>"; };
 		C3AFC2ADE424F95E3121BF22 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		C7474B2C8F1F2B14821F4539 /* CronSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronSettingsView.swift; sourceTree = "<group>"; };
 		C82B0FEAAB9BC80BA0801E98 /* XomperColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperColors.swift; sourceTree = "<group>"; };
 		C83EF3C6C93199CF3FCBAE42 /* Matchup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Matchup.swift; sourceTree = "<group>"; };
 		C921F3EC29B03A85D9F2A42C /* ThisWeekMatchupsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThisWeekMatchupsCard.swift; sourceTree = "<group>"; };
 		C9382BCB18DFEB416A50A039 /* RulesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesView.swift; sourceTree = "<group>"; };
 		CC3F6B5022E8151683A45F4F /* PlayerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerStore.swift; sourceTree = "<group>"; };
 		CEAEC7A4917990425085AE71 /* PushNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationManager.swift; sourceTree = "<group>"; };
+		CFB439DD73C2D26421BE97E7 /* CronSettingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronSettingTests.swift; sourceTree = "<group>"; };
 		D12507ED13C57EFA8B240301 /* AIReviewHomeCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewHomeCard.swift; sourceTree = "<group>"; };
 		D34E8D4C4B1A29FC412EBA41 /* StandingsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsListView.swift; sourceTree = "<group>"; };
 		D36829F2AD0FD089788B9CE1 /* PlayerPointsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerPointsStore.swift; sourceTree = "<group>"; };
@@ -541,6 +551,8 @@
 				37E65C159F2C84E48B61A9A8 /* ArchiveNavigationTests.swift */,
 				DD0B55BBDA885ABE51022738 /* AuditEntryTests.swift */,
 				B3893B13276074EF6033CEA2 /* ClinchCalculatorTests.swift */,
+				3A4C60C4B1F35CD6B056AC29 /* CronSettingsStoreTests.swift */,
+				CFB439DD73C2D26421BE97E7 /* CronSettingTests.swift */,
 				2DB0B979B62A1CF6EB80417F /* DraftRecapResolverTests.swift */,
 				ED7456E9AFD3FA47DA3DA0F7 /* DraftSubTabSelectionTests.swift */,
 				4D0F4D0BBA2C48A0232C43FF /* EmailPreviewTests.swift */,
@@ -688,6 +700,7 @@
 				63E231D553037403D68EB216 /* AuditEntry.swift */,
 				AD43D54AB620DABD559F8A40 /* CareerStats.swift */,
 				18383A0375F5728A9E3FE065 /* Championship.swift */,
+				2E172A0188BB654B8E010842 /* CronSetting.swift */,
 				7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */,
 				A789B8D49FA4430886626289 /* DraftHistory.swift */,
 				44F22FF3CF671CAA9E80918C /* EmailPreview.swift */,
@@ -781,6 +794,7 @@
 				FB3748F7A26B406C00F1C546 /* AIReviewSubScreen.swift */,
 				1687307C5353DC42503BD721 /* AuditDetailView.swift */,
 				B1358E97D2A18E9A5440D8CC /* AuditFeedView.swift */,
+				C7474B2C8F1F2B14821F4539 /* CronSettingsView.swift */,
 				9E8B04D9DD0B2952BBABAB46 /* LeagueEditView.swift */,
 				BC0B516C6EF1C2084E204E8E /* LeaguesListView.swift */,
 				B67C55260D2B14215D920245 /* LogsRowView.swift */,
@@ -801,6 +815,7 @@
 				6E6A6BADE3F51FA922A078F4 /* AIReviewStore.swift */,
 				536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */,
 				3728C5F6BEF61FE509A3EA32 /* ClinchCalculator.swift */,
+				B1B9527EA5CA26FE5197FCF5 /* CronSettingsStore.swift */,
 				F013CD37874EFB0FA1CB4261 /* HistoryStore.swift */,
 				56BB91320E3D5EBE1F777838 /* LeagueStore.swift */,
 				A3AF6560D898E487AD13DA35 /* LogsStore.swift */,
@@ -985,6 +1000,8 @@
 				42F9C81AF6338A720FE0BC12 /* ArchiveNavigationTests.swift in Sources */,
 				DA424E9343EC13B81360C48A /* AuditEntryTests.swift in Sources */,
 				02AC6FBAE68011749AA17644 /* ClinchCalculatorTests.swift in Sources */,
+				77E21904E6B1A4427AB48C50 /* CronSettingTests.swift in Sources */,
+				F118537BB85C27688E57C703 /* CronSettingsStoreTests.swift in Sources */,
 				2BE0B9AB9BAEFD6AA714D2EF /* DraftRecapResolverTests.swift in Sources */,
 				E0951007574761D3F51B21B9 /* DraftSubTabSelectionTests.swift in Sources */,
 				50E9D9254D779960D0D2C5B1 /* EmailPreviewTests.swift in Sources */,
@@ -1032,6 +1049,9 @@
 				9134D2C8A8737083C9FB8F7F /* ClinchCalculator.swift in Sources */,
 				2F50FD9BC26550139DAD2E96 /* Config.swift in Sources */,
 				578172B9CCF7AD92CB66821E /* ContentView.swift in Sources */,
+				76B8EBD352AAA56BD6A5F446 /* CronSetting.swift in Sources */,
+				087C52AE54EBC054E36E696B /* CronSettingsStore.swift in Sources */,
+				5E06735B11149010019AFA3F /* CronSettingsView.swift in Sources */,
 				0C2B77E0A46ECE55AE8CE46F /* DivisionBadge.swift in Sources */,
 				A28A24923C27CF0929ED97E1 /* Double+Formatting.swift in Sources */,
 				1C4049A62CC4A443AC38E464 /* Draft.swift in Sources */,

--- a/Xomper/Config/Config.swift.template
+++ b/Xomper/Config/Config.swift.template
@@ -24,8 +24,9 @@ enum Config {
     /// F5 lands. AI Review + Test Email rows are always visible for
     /// admin users.
     enum AdminFlags {
-        static let showTables: Bool = true     // F4
-        static let showLogs:   Bool = true     // F5
-        static let showAudit:  Bool = true     // F4
+        static let showTables: Bool = true            // F4
+        static let showLogs:   Bool = true            // F5
+        static let showAudit:  Bool = true            // F4
+        static let showCronSettings: Bool = true      // admin-cron-settings
     }
 }

--- a/Xomper/Core/Models/CronSetting.swift
+++ b/Xomper/Core/Models/CronSetting.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// One row from the Supabase `admin_cron_settings` table — surfaced via
+/// `GET /admin/cron-settings-list` (admin-cron-settings F1). Each row
+/// represents a single scheduled notification lambda; the admin can
+/// flip `enabled` to no-op the cron entirely or `testMode` to restrict
+/// delivery to the admin's Sleeper user only (for newsletter previews).
+///
+/// JSON shape (snake_case from the backend):
+/// ```json
+/// {
+///   "cron_key": "notif_weekly_recap",
+///   "enabled": true,
+///   "test_mode": false,
+///   "description": "Weekly matchup recap — Tue 9am ET",
+///   "updated_at": "2026-06-01T14:30:00Z"
+/// }
+/// ```
+///
+/// `description` may be absent for new rows the admin hasn't yet
+/// labelled (defensive). `updatedAt` is decoded via the shared
+/// `AIReport.parseISO` so it tolerates both the fractional-seconds and
+/// integer-seconds ISO 8601 variants Supabase emits.
+struct CronSetting: Codable, Sendable, Identifiable, Hashable {
+    let cronKey: String
+    let enabled: Bool
+    let testMode: Bool
+    let description: String?
+    let updatedAt: Date?
+
+    /// `cronKey` is unique in the table — Supabase enforces it as the
+    /// primary key — so it doubles as the SwiftUI Identifiable hook.
+    var id: String { cronKey }
+
+    enum CodingKeys: String, CodingKey {
+        case cronKey = "cron_key"
+        case enabled
+        case testMode = "test_mode"
+        case description
+        case updatedAt = "updated_at"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.cronKey = (try? c.decode(String.self, forKey: .cronKey)) ?? ""
+        self.enabled = (try? c.decode(Bool.self, forKey: .enabled)) ?? true
+        self.testMode = (try? c.decode(Bool.self, forKey: .testMode)) ?? false
+        self.description = try? c.decodeIfPresent(String.self, forKey: .description)
+
+        if let raw = try? c.decodeIfPresent(String.self, forKey: .updatedAt),
+           let parsed = AIReport.parseISO(raw) {
+            self.updatedAt = parsed
+        } else {
+            self.updatedAt = nil
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(cronKey, forKey: .cronKey)
+        try c.encode(enabled, forKey: .enabled)
+        try c.encode(testMode, forKey: .testMode)
+        try c.encodeIfPresent(description, forKey: .description)
+        if let updatedAt {
+            let iso = ISO8601DateFormatter()
+            iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            try c.encode(iso.string(from: updatedAt), forKey: .updatedAt)
+        }
+    }
+
+    /// Memberwise init for tests / previews. The decoder uses the
+    /// throwing init above; this overload sidesteps that for in-memory
+    /// fixtures.
+    init(
+        cronKey: String,
+        enabled: Bool,
+        testMode: Bool,
+        description: String? = nil,
+        updatedAt: Date? = nil
+    ) {
+        self.cronKey = cronKey
+        self.enabled = enabled
+        self.testMode = testMode
+        self.description = description
+        self.updatedAt = updatedAt
+    }
+
+    /// Title rendered in `CronSettingsView`'s rows. Prefer the
+    /// human-friendly `description`; fall back to the `cron_key` so a
+    /// freshly-seeded row without a description still shows something
+    /// readable.
+    var displayTitle: String {
+        if let description, !description.isEmpty {
+            return description
+        }
+        return cronKey
+    }
+
+    /// Returns a copy with `enabled` swapped. Used by the store for
+    /// optimistic UI updates before the network call resolves.
+    func with(enabled newEnabled: Bool) -> CronSetting {
+        CronSetting(
+            cronKey: cronKey,
+            enabled: newEnabled,
+            testMode: testMode,
+            description: description,
+            updatedAt: updatedAt
+        )
+    }
+
+    /// Returns a copy with `testMode` swapped. Used by the store for
+    /// optimistic UI updates before the network call resolves.
+    func with(testMode newTestMode: Bool) -> CronSetting {
+        CronSetting(
+            cronKey: cronKey,
+            enabled: enabled,
+            testMode: newTestMode,
+            description: description,
+            updatedAt: updatedAt
+        )
+    }
+}

--- a/Xomper/Core/Networking/XomperAPIClient.swift
+++ b/Xomper/Core/Networking/XomperAPIClient.swift
@@ -49,6 +49,10 @@ protocol XomperAPIClientProtocol: Sendable {
         limit: Int,
         cursor: String?
     ) async throws -> LogsQueryResponse
+
+    // Admin: Cron settings (kill switch + test mode)
+    func fetchCronSettings() async throws -> CronSettingsListResponse
+    func updateCronSetting(cronKey: String, enabled: Bool?, testMode: Bool?) async throws -> CronSettingUpdateResponse
 }
 
 // MARK: - Request Payloads
@@ -396,6 +400,55 @@ struct AuditListResponse: Decodable, Sendable {
         self.rows = rows
         self.nextCursor = nextCursor
         self.tableMissing = tableMissing
+    }
+}
+
+// MARK: - Admin Cron Settings
+
+/// Wraps `GET /admin/cron-settings-list`. The backend returns the rows
+/// under a top-level `rows` key alongside a `count`. `tableMissing` is
+/// set true when the Supabase `admin_cron_settings` table hasn't been
+/// provisioned yet (manual migration pending) — iOS renders a friendly
+/// explanatory empty state in that case (mirrors the F4 audit pattern).
+struct CronSettingsListResponse: Decodable, Sendable {
+    let count: Int
+    let rows: [CronSetting]
+    let tableMissing: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case count
+        case rows
+        case tableMissing = "table_missing"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.count = (try? c.decode(Int.self, forKey: .count)) ?? 0
+        self.rows = (try? c.decode([CronSetting].self, forKey: .rows)) ?? []
+        self.tableMissing = (try? c.decodeIfPresent(Bool.self, forKey: .tableMissing)) ?? false
+    }
+
+    /// Memberwise init for tests / previews.
+    init(count: Int, rows: [CronSetting], tableMissing: Bool) {
+        self.count = count
+        self.rows = rows
+        self.tableMissing = tableMissing
+    }
+}
+
+/// Wraps `POST /admin/cron-settings-update`. Backend echoes the
+/// resolved row state after the patch so the iOS store can confirm
+/// the optimistic flip stuck (or rebuild if it didn't). Backend also
+/// writes an `admin_audit` row per call.
+struct CronSettingUpdateResponse: Decodable, Sendable {
+    let cronKey: String
+    let enabled: Bool
+    let testMode: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case cronKey = "cron_key"
+        case enabled
+        case testMode = "test_mode"
     }
 }
 
@@ -948,6 +1001,38 @@ final class XomperAPIClient: XomperAPIClientProtocol {
             items.append(URLQueryItem(name: "next_token", value: cursor))
         }
         return try await get("/admin/logs-query", queryItems: items)
+    }
+
+    // MARK: - Admin Cron Settings
+
+    /// Admin-only: list every row of `admin_cron_settings`. Backend
+    /// returns the rows under `rows` plus a `tableMissing` flag when
+    /// the Supabase migration hasn't yet been applied — iOS renders a
+    /// dedicated empty state in that case.
+    func fetchCronSettings() async throws -> CronSettingsListResponse {
+        return try await get("/admin/cron-settings-list", queryItems: [])
+    }
+
+    /// Admin-only: patch a single `admin_cron_settings` row. Pass
+    /// `enabled` and/or `testMode` — either may be nil to leave that
+    /// column untouched. The wire payload omits any nil key (via
+    /// per-key add) so the backend treats absence as "don't touch".
+    /// Backend writes an `admin_audit` row per call.
+    func updateCronSetting(
+        cronKey: String,
+        enabled: Bool?,
+        testMode: Bool?
+    ) async throws -> CronSettingUpdateResponse {
+        var body: [String: Any] = [
+            "cron_key": cronKey,
+        ]
+        if let enabled {
+            body["enabled"] = enabled
+        }
+        if let testMode {
+            body["test_mode"] = testMode
+        }
+        return try await postDecoding("/admin/cron-settings-update", body: body)
     }
 
     // MARK: - Private

--- a/Xomper/Core/Stores/CronSettingsStore.swift
+++ b/Xomper/Core/Stores/CronSettingsStore.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+/// Drives the Admin → Cron Settings sub-screen.
+///
+/// One store per sub-screen — kept separate from `AdminTablesStore`
+/// because cron settings have their own lifecycle (loaded on push,
+/// not bootstrap-cached) and a different write pattern (per-row
+/// optimistic toggle vs. F4's typed diff form). Splitting also
+/// avoids polluting the F4 store with cron-specific state.
+///
+/// Optimistic updates: flipping a toggle mutates `settings` in place
+/// immediately so the UI feels instantaneous, then fires the POST.
+/// On failure we revert the row to its prior shape and surface the
+/// error via `lastError`. Per-row spinner state lives in
+/// `pendingKeys` so the row can show a small `ProgressView` while
+/// the POST is in flight without blocking the rest of the list.
+///
+/// All API calls go through `XomperAPIClientProtocol`; tests
+/// substitute a mock via the init.
+@Observable
+@MainActor
+final class CronSettingsStore {
+
+    // MARK: - State
+
+    private(set) var settings: [CronSetting] = []
+    private(set) var tableMissing: Bool = false
+    private(set) var isLoading: Bool = false
+    private(set) var error: String?
+
+    /// Per-row in-flight tracker. The set holds the `cronKey` of any
+    /// row whose toggle is currently mid-POST. Used both for spinner
+    /// visibility and for deduplication — a second toggle-tap on the
+    /// same row while a save is in flight is dropped.
+    private(set) var pendingKeys: Set<String> = []
+
+    /// Last write error surfaced to the view. Cleared at the start of
+    /// the next write. Distinct from `error` (load failure) so the
+    /// list can keep rendering after a toggle fails.
+    private(set) var lastError: String?
+
+    // MARK: - Dependencies
+
+    private let apiClient: XomperAPIClientProtocol
+
+    init(apiClient: XomperAPIClientProtocol = XomperAPIClient()) {
+        self.apiClient = apiClient
+    }
+
+    // MARK: - Load
+
+    /// Fetch the cron settings list. Replaces `settings` wholesale on
+    /// success. Surfaces error to `error` on failure (keeping any
+    /// previously-loaded settings on screen so a transient network
+    /// blip doesn't blank the list).
+    func load() async {
+        guard !isLoading else { return }
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+
+        do {
+            let response = try await apiClient.fetchCronSettings()
+            settings = response.rows
+            tableMissing = response.tableMissing
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    // MARK: - Toggle
+
+    /// Flip the `enabled` flag on one row. Optimistic — the row's
+    /// state flips immediately, then the POST fires. On error the
+    /// row is reverted and `lastError` is populated.
+    ///
+    /// Deduplicates: a second tap on the same row while the first
+    /// POST is in flight is dropped.
+    func toggleEnabled(cronKey: String, enabled: Bool) async {
+        guard !pendingKeys.contains(cronKey) else { return }
+        guard let idx = settings.firstIndex(where: { $0.cronKey == cronKey }) else { return }
+
+        let original = settings[idx]
+        // Optimistic flip.
+        settings[idx] = original.with(enabled: enabled)
+        pendingKeys.insert(cronKey)
+        lastError = nil
+        defer { pendingKeys.remove(cronKey) }
+
+        do {
+            let response = try await apiClient.updateCronSetting(
+                cronKey: cronKey,
+                enabled: enabled,
+                testMode: nil
+            )
+            // Reconcile with server truth. If the server-resolved state
+            // differs from our optimistic flip (e.g. concurrent edit),
+            // the server value wins.
+            if let confirmIdx = settings.firstIndex(where: { $0.cronKey == cronKey }) {
+                let current = settings[confirmIdx]
+                settings[confirmIdx] = CronSetting(
+                    cronKey: response.cronKey,
+                    enabled: response.enabled,
+                    testMode: response.testMode,
+                    description: current.description,
+                    updatedAt: Date()
+                )
+            }
+        } catch {
+            // Revert the optimistic mutation. Look up the row again
+            // because settings may have been replaced in between.
+            if let revertIdx = settings.firstIndex(where: { $0.cronKey == cronKey }) {
+                settings[revertIdx] = original
+            }
+            lastError = error.localizedDescription
+        }
+    }
+
+    /// Flip the `test_mode` flag on one row. Same shape as
+    /// `toggleEnabled` — optimistic mutation, server reconciliation,
+    /// revert on failure.
+    func toggleTestMode(cronKey: String, testMode: Bool) async {
+        guard !pendingKeys.contains(cronKey) else { return }
+        guard let idx = settings.firstIndex(where: { $0.cronKey == cronKey }) else { return }
+
+        let original = settings[idx]
+        settings[idx] = original.with(testMode: testMode)
+        pendingKeys.insert(cronKey)
+        lastError = nil
+        defer { pendingKeys.remove(cronKey) }
+
+        do {
+            let response = try await apiClient.updateCronSetting(
+                cronKey: cronKey,
+                enabled: nil,
+                testMode: testMode
+            )
+            if let confirmIdx = settings.firstIndex(where: { $0.cronKey == cronKey }) {
+                let current = settings[confirmIdx]
+                settings[confirmIdx] = CronSetting(
+                    cronKey: response.cronKey,
+                    enabled: response.enabled,
+                    testMode: response.testMode,
+                    description: current.description,
+                    updatedAt: Date()
+                )
+            }
+        } catch {
+            if let revertIdx = settings.firstIndex(where: { $0.cronKey == cronKey }) {
+                settings[revertIdx] = original
+            }
+            lastError = error.localizedDescription
+        }
+    }
+
+    // MARK: - Derived
+
+    /// True when any row has `test_mode == true`. Drives the
+    /// "Test mode active" banner at the top of `CronSettingsView` —
+    /// the recommendation from the plan's open-question section to
+    /// surface a forgot-to-flip-back warning prominently.
+    var anyTestModeActive: Bool {
+        settings.contains(where: { $0.testMode })
+    }
+}

--- a/Xomper/Features/Admin/AdminView.swift
+++ b/Xomper/Features/Admin/AdminView.swift
@@ -56,6 +56,15 @@ struct AdminView: View {
                     action: { router.navigate(to: .adminTestEmail) }
                 )
 
+                if Config.AdminFlags.showCronSettings {
+                    AdminMenuRow(
+                        icon: "clock.badge.checkmark",
+                        title: "Cron Settings",
+                        subtitle: "Kill switch + test mode per scheduled lambda",
+                        action: { router.navigate(to: .adminCronSettings) }
+                    )
+                }
+
                 if Config.AdminFlags.showTables {
                     AdminMenuRow(
                         icon: "tablecells",

--- a/Xomper/Features/Admin/CronSettingsView.swift
+++ b/Xomper/Features/Admin/CronSettingsView.swift
@@ -1,0 +1,243 @@
+import SwiftUI
+
+/// Admin → Cron Settings.
+///
+/// List of every scheduled-notification lambda with two toggles per row:
+/// `Enabled` (kill switch — no-op the lambda) and `Test mode` (restrict
+/// delivery to the admin's Sleeper user only — useful for previewing
+/// AI Review newsletters or recap emails before they fan out to the
+/// league).
+///
+/// UX rules:
+/// - The "Test mode" toggle is disabled (greyed) when `enabled == false`
+///   so the admin doesn't toggle test-mode on a disabled cron by mistake.
+/// - A prominent "Test mode active" banner pins to the top when any
+///   cron has `test_mode == true` — mitigation for the "set test mode,
+///   forgot to flip back" risk called out in the plan.
+/// - Each row gets its own spinner during the per-row save POST.
+/// - `tableMissing` from the backend renders a dedicated empty state
+///   explaining the manual Supabase migration needs to be applied.
+struct CronSettingsView: View {
+    var store: CronSettingsStore
+
+    var body: some View {
+        content
+            .background(XomperColors.bgDark.ignoresSafeArea())
+            .navigationTitle("Cron Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .task {
+                if store.settings.isEmpty {
+                    await store.load()
+                }
+            }
+            .refreshable {
+                await store.load()
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if store.isLoading && store.settings.isEmpty {
+            LoadingView(message: "Loading cron settings…")
+        } else if let error = store.error, store.settings.isEmpty {
+            EmptyStateView(
+                icon: "exclamationmark.triangle",
+                title: "Couldn't load settings",
+                message: error
+            )
+        } else if store.tableMissing {
+            EmptyStateView(
+                icon: "tray",
+                title: "Cron settings not yet provisioned",
+                message: "An admin needs to apply the Supabase migration for `admin_cron_settings` via the dashboard before this view will render rows."
+            )
+        } else if store.settings.isEmpty {
+            EmptyStateView(
+                icon: "clock.badge.checkmark",
+                title: "No cron settings",
+                message: "Nothing scheduled yet. New crons appear here as they're added."
+            )
+        } else {
+            list
+        }
+    }
+
+    // MARK: - List
+
+    private var list: some View {
+        ScrollView {
+            VStack(spacing: XomperTheme.Spacing.md) {
+                if store.anyTestModeActive {
+                    testModeBanner
+                }
+
+                if let lastError = store.lastError, !lastError.isEmpty {
+                    saveErrorBanner(lastError)
+                }
+
+                VStack(spacing: XomperTheme.Spacing.sm) {
+                    ForEach(store.settings) { setting in
+                        CronSettingRow(
+                            setting: setting,
+                            isPending: store.pendingKeys.contains(setting.cronKey),
+                            onToggleEnabled: { newValue in
+                                let generator = UIImpactFeedbackGenerator(style: .light)
+                                generator.impactOccurred()
+                                Task { await store.toggleEnabled(cronKey: setting.cronKey, enabled: newValue) }
+                            },
+                            onToggleTestMode: { newValue in
+                                let generator = UIImpactFeedbackGenerator(style: .light)
+                                generator.impactOccurred()
+                                Task { await store.toggleTestMode(cronKey: setting.cronKey, testMode: newValue) }
+                            }
+                        )
+                    }
+                }
+            }
+            .padding(.horizontal, XomperTheme.Spacing.md)
+            .padding(.vertical, XomperTheme.Spacing.sm)
+        }
+    }
+
+    // MARK: - Banners
+
+    private var testModeBanner: some View {
+        HStack(spacing: XomperTheme.Spacing.sm) {
+            Image(systemName: "flask.fill")
+                .font(.headline)
+                .foregroundStyle(XomperColors.championGold)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.xxs) {
+                Text("Test mode active")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.textPrimary)
+                Text("At least one cron is delivering only to the admin. Flip back before the next live send.")
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textSecondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.championGold.opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.4), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Test mode active. At least one cron is delivering only to the admin.")
+    }
+
+    private func saveErrorBanner(_ message: String) -> some View {
+        HStack(spacing: XomperTheme.Spacing.sm) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.headline)
+                .foregroundStyle(XomperColors.errorRed)
+                .accessibilityHidden(true)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(XomperColors.errorRed)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.errorRed.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.errorRed.opacity(0.4), lineWidth: 1)
+        )
+    }
+}
+
+// MARK: - Row
+
+/// One cron row. Two toggles + a small spinner gutter so the layout
+/// doesn't reflow when a save is in flight. The Test-mode toggle is
+/// disabled when `setting.enabled == false`.
+private struct CronSettingRow: View {
+    let setting: CronSetting
+    let isPending: Bool
+    let onToggleEnabled: (Bool) -> Void
+    let onToggleTestMode: (Bool) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            HStack(spacing: XomperTheme.Spacing.sm) {
+                Text(setting.displayTitle)
+                    .font(.headline)
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                if isPending {
+                    ProgressView()
+                        .scaleEffect(0.8)
+                        .tint(XomperColors.championGold)
+                        .accessibilityLabel("Saving")
+                }
+            }
+
+            Text(setting.cronKey)
+                .font(.caption)
+                .foregroundStyle(XomperColors.textMuted)
+                .lineLimit(1)
+
+            Toggle(isOn: enabledBinding) {
+                Text("Enabled")
+                    .font(.subheadline)
+                    .foregroundStyle(XomperColors.textPrimary)
+            }
+            .tint(XomperColors.successGreen)
+
+            Toggle(isOn: testModeBinding) {
+                VStack(alignment: .leading, spacing: XomperTheme.Spacing.xxs) {
+                    Text("Test mode")
+                        .font(.subheadline)
+                        .foregroundStyle(setting.enabled ? XomperColors.textPrimary : XomperColors.textMuted)
+                    if !setting.enabled {
+                        Text("Enable the cron to toggle test mode")
+                            .font(.caption2)
+                            .foregroundStyle(XomperColors.textMuted)
+                    } else if setting.testMode {
+                        Text("Delivers only to the admin user")
+                            .font(.caption2)
+                            .foregroundStyle(XomperColors.championGold)
+                    }
+                }
+            }
+            .tint(XomperColors.championGold)
+            .disabled(!setting.enabled)
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(minHeight: XomperTheme.minTouchTarget)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(
+                    setting.testMode
+                        ? XomperColors.championGold.opacity(0.4)
+                        : XomperColors.championGold.opacity(0.15),
+                    lineWidth: 1
+                )
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(setting.displayTitle). \(setting.enabled ? "Enabled" : "Disabled"). \(setting.testMode ? "Test mode on" : "Test mode off").")
+    }
+
+    // MARK: - Bindings
+
+    private var enabledBinding: Binding<Bool> {
+        Binding(
+            get: { setting.enabled },
+            set: { onToggleEnabled($0) }
+        )
+    }
+
+    private var testModeBinding: Binding<Bool> {
+        Binding(
+            get: { setting.testMode },
+            set: { onToggleTestMode($0) }
+        )
+    }
+}

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -44,6 +44,10 @@ struct MainShell: View {
     /// so the lists + edit forms + detail view read from the
     /// same in-memory rows.
     @State private var adminTablesStore = AdminTablesStore()
+    /// admin-cron-settings: drives the Admin → Cron Settings sub-screen.
+    /// Single-instance to keep optimistic toggles + pending-row state
+    /// stable across re-renders during the in-flight POST.
+    @State private var cronSettingsStore = CronSettingsStore()
 
     // MARK: - Body
 
@@ -531,6 +535,9 @@ struct MainShell: View {
 
         case .adminAudit:
             AuditFeedView(store: adminTablesStore, router: router)
+
+        case .adminCronSettings:
+            CronSettingsView(store: cronSettingsStore)
 
         case .adminAIReviewPreview(let reportType):
             AIReviewPreviewView(

--- a/Xomper/Navigation/AppRouter.swift
+++ b/Xomper/Navigation/AppRouter.swift
@@ -64,6 +64,10 @@ enum AppRoute: Hashable {
     /// admin actions, paginated via cursor). F4 deliverable.
     case adminAudit
 
+    /// Pushed from `AdminView`'s menu — opens the Cron Settings
+    /// sub-screen (per-lambda kill switch + test-mode toggles).
+    case adminCronSettings
+
     // MARK: - Admin Portal (F4)
 
     /// Pushed from `TablesSubScreenView` — list of all

--- a/XomperTests/AIReviewStoreTests.swift
+++ b/XomperTests/AIReviewStoreTests.swift
@@ -367,6 +367,11 @@ final class MockXomperAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
 
     func fetchLogEvents(logGroup: LogGroup, level: LogLevel?, search: String?, limit: Int, cursor: String?) async throws -> LogsQueryResponse { throw Unsupported.method }
 
+    // MARK: - admin-cron-settings — unused here.
+
+    func fetchCronSettings() async throws -> CronSettingsListResponse { throw Unsupported.method }
+    func updateCronSetting(cronKey: String, enabled: Bool?, testMode: Bool?) async throws -> CronSettingUpdateResponse { throw Unsupported.method }
+
     enum Unsupported: Error { case method }
 }
 

--- a/XomperTests/AdminStoreTests.swift
+++ b/XomperTests/AdminStoreTests.swift
@@ -306,6 +306,10 @@ final class MockAdminAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
 
     // F5 admin logs — unused here.
     func fetchLogEvents(logGroup: LogGroup, level: LogLevel?, search: String?, limit: Int, cursor: String?) async throws -> LogsQueryResponse { throw MockError.unsupported }
+
+    // admin-cron-settings — unused here.
+    func fetchCronSettings() async throws -> CronSettingsListResponse { throw MockError.unsupported }
+    func updateCronSetting(cronKey: String, enabled: Bool?, testMode: Bool?) async throws -> CronSettingUpdateResponse { throw MockError.unsupported }
 }
 
 enum MockError: Error, LocalizedError {

--- a/XomperTests/AdminTablesStoreTests.swift
+++ b/XomperTests/AdminTablesStoreTests.swift
@@ -434,6 +434,8 @@ final class MockAdminTablesAPIClient: XomperAPIClientProtocol, @unchecked Sendab
     func triggerWeeklyAIReview(week: Int?, dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw AdminTablesMockError.unsupported }
     func setReportFlag(leagueId: String, reportType: AIReportType, period: String, flag: ReportFlag, value: Bool) async throws -> ReportFlagResponse { throw AdminTablesMockError.unsupported }
     func fetchLogEvents(logGroup: LogGroup, level: LogLevel?, search: String?, limit: Int, cursor: String?) async throws -> LogsQueryResponse { throw AdminTablesMockError.unsupported }
+    func fetchCronSettings() async throws -> CronSettingsListResponse { throw AdminTablesMockError.unsupported }
+    func updateCronSetting(cronKey: String, enabled: Bool?, testMode: Bool?) async throws -> CronSettingUpdateResponse { throw AdminTablesMockError.unsupported }
 }
 
 enum AdminTablesMockError: Error, LocalizedError {

--- a/XomperTests/CronSettingTests.swift
+++ b/XomperTests/CronSettingTests.swift
@@ -1,0 +1,206 @@
+import XCTest
+@testable import Xomper
+
+/// admin-cron-settings — verifies `CronSetting` decodes the wire shape
+/// returned by `GET /admin/cron-settings-list` (snake_case ↔ camelCase),
+/// tolerates missing optional fields, and that `CronSettingsListResponse`
+/// surfaces the `table_missing` empty-state signal cleanly.
+@MainActor
+final class CronSettingTests: XCTestCase {
+
+    // MARK: - CronSetting
+
+    func test_cronSetting_decodesFullPayload() throws {
+        let json = """
+        {
+            "cron_key": "notif_weekly_recap",
+            "enabled": true,
+            "test_mode": false,
+            "description": "Weekly matchup recap — Tue 9am ET",
+            "updated_at": "2026-06-01T14:30:00Z"
+        }
+        """
+        let setting = try JSONDecoder().decode(
+            CronSetting.self,
+            from: Data(json.utf8)
+        )
+
+        XCTAssertEqual(setting.cronKey, "notif_weekly_recap")
+        XCTAssertTrue(setting.enabled)
+        XCTAssertFalse(setting.testMode)
+        XCTAssertEqual(setting.description, "Weekly matchup recap — Tue 9am ET")
+        XCTAssertNotNil(setting.updatedAt)
+        XCTAssertEqual(setting.id, "notif_weekly_recap", "id should mirror cron_key")
+    }
+
+    func test_cronSetting_missingOptionalFields() throws {
+        let json = """
+        {
+            "cron_key": "notif_lineup_not_set",
+            "enabled": false,
+            "test_mode": true
+        }
+        """
+        let setting = try JSONDecoder().decode(
+            CronSetting.self,
+            from: Data(json.utf8)
+        )
+
+        XCTAssertEqual(setting.cronKey, "notif_lineup_not_set")
+        XCTAssertFalse(setting.enabled)
+        XCTAssertTrue(setting.testMode)
+        XCTAssertNil(setting.description)
+        XCTAssertNil(setting.updatedAt)
+    }
+
+    func test_cronSetting_fractionalSecondsTimestamp() throws {
+        let json = """
+        {
+            "cron_key": "notif_close_game_alert",
+            "enabled": true,
+            "test_mode": false,
+            "updated_at": "2026-06-01T14:30:00.123Z"
+        }
+        """
+        let setting = try JSONDecoder().decode(
+            CronSetting.self,
+            from: Data(json.utf8)
+        )
+        XCTAssertNotNil(setting.updatedAt, "Fractional-seconds ISO 8601 timestamp should decode.")
+    }
+
+    func test_cronSetting_displayTitleFallsBackToCronKey() {
+        let setting = CronSetting(
+            cronKey: "notif_misc",
+            enabled: true,
+            testMode: false,
+            description: nil
+        )
+        XCTAssertEqual(setting.displayTitle, "notif_misc")
+    }
+
+    func test_cronSetting_displayTitlePrefersDescription() {
+        let setting = CronSetting(
+            cronKey: "notif_misc",
+            enabled: true,
+            testMode: false,
+            description: "Friendly label"
+        )
+        XCTAssertEqual(setting.displayTitle, "Friendly label")
+    }
+
+    func test_cronSetting_withEnabledFlipsCorrectly() {
+        let original = CronSetting(
+            cronKey: "x",
+            enabled: true,
+            testMode: true,
+            description: "Desc"
+        )
+        let flipped = original.with(enabled: false)
+        XCTAssertFalse(flipped.enabled)
+        XCTAssertTrue(flipped.testMode, "testMode preserved on enabled flip")
+        XCTAssertEqual(flipped.description, "Desc")
+    }
+
+    func test_cronSetting_withTestModeFlipsCorrectly() {
+        let original = CronSetting(
+            cronKey: "x",
+            enabled: true,
+            testMode: false,
+            description: "Desc"
+        )
+        let flipped = original.with(testMode: true)
+        XCTAssertTrue(flipped.testMode)
+        XCTAssertTrue(flipped.enabled, "enabled preserved on testMode flip")
+    }
+
+    // MARK: - CronSettingsListResponse
+
+    func test_listResponse_decodesFullPayload() throws {
+        let json = """
+        {
+            "Success": true,
+            "count": 2,
+            "rows": [
+                {
+                    "cron_key": "notif_weekly_recap",
+                    "enabled": true,
+                    "test_mode": false,
+                    "description": "Weekly recap",
+                    "updated_at": "2026-06-01T14:30:00Z"
+                },
+                {
+                    "cron_key": "notif_lineup_not_set",
+                    "enabled": false,
+                    "test_mode": true,
+                    "description": "Lineup not set",
+                    "updated_at": "2026-06-01T14:30:00Z"
+                }
+            ]
+        }
+        """
+        let response = try JSONDecoder().decode(
+            CronSettingsListResponse.self,
+            from: Data(json.utf8)
+        )
+
+        XCTAssertEqual(response.count, 2)
+        XCTAssertEqual(response.rows.count, 2)
+        XCTAssertEqual(response.rows.first?.cronKey, "notif_weekly_recap")
+        XCTAssertFalse(response.tableMissing)
+    }
+
+    func test_listResponse_tableMissingTrue() throws {
+        let json = """
+        {
+            "Success": true,
+            "count": 0,
+            "rows": [],
+            "table_missing": true
+        }
+        """
+        let response = try JSONDecoder().decode(
+            CronSettingsListResponse.self,
+            from: Data(json.utf8)
+        )
+
+        XCTAssertTrue(response.tableMissing)
+        XCTAssertEqual(response.rows.count, 0)
+        XCTAssertEqual(response.count, 0)
+    }
+
+    func test_listResponse_tableMissingAbsentDefaultsFalse() throws {
+        let json = """
+        {
+            "Success": true,
+            "count": 0,
+            "rows": []
+        }
+        """
+        let response = try JSONDecoder().decode(
+            CronSettingsListResponse.self,
+            from: Data(json.utf8)
+        )
+        XCTAssertFalse(response.tableMissing)
+    }
+
+    // MARK: - CronSettingUpdateResponse
+
+    func test_updateResponse_decodesPayload() throws {
+        let json = """
+        {
+            "Success": true,
+            "cron_key": "notif_weekly_recap",
+            "enabled": false,
+            "test_mode": true
+        }
+        """
+        let response = try JSONDecoder().decode(
+            CronSettingUpdateResponse.self,
+            from: Data(json.utf8)
+        )
+        XCTAssertEqual(response.cronKey, "notif_weekly_recap")
+        XCTAssertFalse(response.enabled)
+        XCTAssertTrue(response.testMode)
+    }
+}

--- a/XomperTests/CronSettingsStoreTests.swift
+++ b/XomperTests/CronSettingsStoreTests.swift
@@ -1,0 +1,307 @@
+import XCTest
+@testable import Xomper
+
+/// admin-cron-settings — drives `CronSettingsStore` through its loader
+/// + toggle paths using a mock `XomperAPIClientProtocol`. Covers:
+/// happy-path load, tableMissing empty state, optimistic toggle +
+/// revert-on-error, server reconciliation, duplicate-toggle dedup, and
+/// the `anyTestModeActive` derived flag that drives the banner.
+@MainActor
+final class CronSettingsStoreTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeSetting(
+        cronKey: String = "notif_weekly_recap",
+        enabled: Bool = true,
+        testMode: Bool = false,
+        description: String? = "Weekly recap"
+    ) -> CronSetting {
+        CronSetting(
+            cronKey: cronKey,
+            enabled: enabled,
+            testMode: testMode,
+            description: description,
+            updatedAt: nil
+        )
+    }
+
+    // MARK: - load
+
+    func test_load_populatesFromMock() async {
+        let mock = MockCronSettingsAPIClient(
+            listResponse: CronSettingsListResponse(
+                count: 2,
+                rows: [
+                    makeSetting(cronKey: "notif_weekly_recap"),
+                    makeSetting(cronKey: "notif_lineup_not_set", enabled: false),
+                ],
+                tableMissing: false
+            )
+        )
+        let store = CronSettingsStore(apiClient: mock)
+
+        await store.load()
+
+        XCTAssertEqual(store.settings.count, 2)
+        XCTAssertFalse(store.tableMissing)
+        XCTAssertNil(store.error)
+        XCTAssertFalse(store.isLoading)
+    }
+
+    func test_load_tableMissingFlagsEmptyState() async {
+        let mock = MockCronSettingsAPIClient(
+            listResponse: CronSettingsListResponse(
+                count: 0,
+                rows: [],
+                tableMissing: true
+            )
+        )
+        let store = CronSettingsStore(apiClient: mock)
+
+        await store.load()
+
+        XCTAssertTrue(store.settings.isEmpty)
+        XCTAssertTrue(store.tableMissing)
+    }
+
+    func test_load_surfacesError() async {
+        let mock = MockCronSettingsAPIClient(listError: CronMockError.boom)
+        let store = CronSettingsStore(apiClient: mock)
+
+        await store.load()
+
+        XCTAssertTrue(store.settings.isEmpty)
+        XCTAssertNotNil(store.error)
+    }
+
+    // MARK: - toggleEnabled
+
+    func test_toggleEnabled_optimisticUpdateAndServerReconciliation() async {
+        let initial = makeSetting(enabled: true, testMode: false)
+        let mock = MockCronSettingsAPIClient(
+            listResponse: CronSettingsListResponse(count: 1, rows: [initial], tableMissing: false),
+            updateResponse: CronSettingUpdateResponse(
+                cronKey: initial.cronKey,
+                enabled: false,
+                testMode: false
+            )
+        )
+        let store = CronSettingsStore(apiClient: mock)
+        await store.load()
+
+        await store.toggleEnabled(cronKey: initial.cronKey, enabled: false)
+
+        XCTAssertEqual(mock.updateCalls.count, 1)
+        XCTAssertEqual(mock.updateCalls.first?.enabled, false)
+        XCTAssertNil(mock.updateCalls.first?.testMode, "testMode unset when toggling enabled only")
+        XCTAssertEqual(store.settings.first?.enabled, false)
+        XCTAssertNil(store.lastError)
+    }
+
+    func test_toggleEnabled_revertsOnError() async {
+        let initial = makeSetting(enabled: true)
+        let mock = MockCronSettingsAPIClient(
+            listResponse: CronSettingsListResponse(count: 1, rows: [initial], tableMissing: false),
+            updateError: CronMockError.boom
+        )
+        let store = CronSettingsStore(apiClient: mock)
+        await store.load()
+
+        await store.toggleEnabled(cronKey: initial.cronKey, enabled: false)
+
+        XCTAssertEqual(store.settings.first?.enabled, true, "Reverted to pre-toggle state on error.")
+        XCTAssertNotNil(store.lastError)
+        XCTAssertTrue(store.pendingKeys.isEmpty, "Pending key cleared even on failure.")
+    }
+
+    // MARK: - toggleTestMode
+
+    func test_toggleTestMode_optimisticUpdate() async {
+        let initial = makeSetting(enabled: true, testMode: false)
+        let mock = MockCronSettingsAPIClient(
+            listResponse: CronSettingsListResponse(count: 1, rows: [initial], tableMissing: false),
+            updateResponse: CronSettingUpdateResponse(
+                cronKey: initial.cronKey,
+                enabled: true,
+                testMode: true
+            )
+        )
+        let store = CronSettingsStore(apiClient: mock)
+        await store.load()
+
+        await store.toggleTestMode(cronKey: initial.cronKey, testMode: true)
+
+        XCTAssertEqual(mock.updateCalls.count, 1)
+        XCTAssertEqual(mock.updateCalls.first?.testMode, true)
+        XCTAssertNil(mock.updateCalls.first?.enabled, "enabled unset when toggling testMode only")
+        XCTAssertEqual(store.settings.first?.testMode, true)
+    }
+
+    func test_toggleTestMode_revertsOnError() async {
+        let initial = makeSetting(enabled: true, testMode: false)
+        let mock = MockCronSettingsAPIClient(
+            listResponse: CronSettingsListResponse(count: 1, rows: [initial], tableMissing: false),
+            updateError: CronMockError.boom
+        )
+        let store = CronSettingsStore(apiClient: mock)
+        await store.load()
+
+        await store.toggleTestMode(cronKey: initial.cronKey, testMode: true)
+
+        XCTAssertEqual(store.settings.first?.testMode, false, "Reverted to pre-toggle state on error.")
+        XCTAssertNotNil(store.lastError)
+    }
+
+    // MARK: - dedup
+
+    func test_toggleEnabled_dedupesWhilePending() async {
+        // Use an explicitly slow update so the second tap arrives while
+        // the first is in flight. We can't await across two toggles in a
+        // single task, so spawn them and wait on the group.
+        let initial = makeSetting(enabled: true)
+        let mock = MockCronSettingsAPIClient(
+            listResponse: CronSettingsListResponse(count: 1, rows: [initial], tableMissing: false),
+            updateResponse: CronSettingUpdateResponse(
+                cronKey: initial.cronKey,
+                enabled: false,
+                testMode: false
+            ),
+            updateDelayNanos: 50_000_000 // 50ms
+        )
+        let store = CronSettingsStore(apiClient: mock)
+        await store.load()
+
+        async let first: Void = store.toggleEnabled(cronKey: initial.cronKey, enabled: false)
+        // Yield so the first toggle inserts into pendingKeys before the second runs.
+        await Task.yield()
+        async let second: Void = store.toggleEnabled(cronKey: initial.cronKey, enabled: false)
+        _ = await (first, second)
+
+        XCTAssertEqual(mock.updateCalls.count, 1, "Duplicate-while-pending toggle should be dropped.")
+    }
+
+    // MARK: - anyTestModeActive
+
+    func test_anyTestModeActive_trueWhenAnyRowHasTestMode() async {
+        let mock = MockCronSettingsAPIClient(
+            listResponse: CronSettingsListResponse(
+                count: 2,
+                rows: [
+                    makeSetting(cronKey: "a", testMode: false),
+                    makeSetting(cronKey: "b", testMode: true),
+                ],
+                tableMissing: false
+            )
+        )
+        let store = CronSettingsStore(apiClient: mock)
+        await store.load()
+
+        XCTAssertTrue(store.anyTestModeActive)
+    }
+
+    func test_anyTestModeActive_falseWhenAllOff() async {
+        let mock = MockCronSettingsAPIClient(
+            listResponse: CronSettingsListResponse(
+                count: 2,
+                rows: [
+                    makeSetting(cronKey: "a", testMode: false),
+                    makeSetting(cronKey: "b", testMode: false),
+                ],
+                tableMissing: false
+            )
+        )
+        let store = CronSettingsStore(apiClient: mock)
+        await store.load()
+
+        XCTAssertFalse(store.anyTestModeActive)
+    }
+}
+
+// MARK: - Mock API client
+
+final class MockCronSettingsAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
+    var listResponse: CronSettingsListResponse?
+    var listError: Error?
+    var updateResponse: CronSettingUpdateResponse?
+    var updateError: Error?
+    var updateDelayNanos: UInt64 = 0
+
+    private(set) var updateCalls: [(cronKey: String, enabled: Bool?, testMode: Bool?)] = []
+
+    init(
+        listResponse: CronSettingsListResponse? = nil,
+        listError: Error? = nil,
+        updateResponse: CronSettingUpdateResponse? = nil,
+        updateError: Error? = nil,
+        updateDelayNanos: UInt64 = 0
+    ) {
+        self.listResponse = listResponse
+        self.listError = listError
+        self.updateResponse = updateResponse
+        self.updateError = updateError
+        self.updateDelayNanos = updateDelayNanos
+    }
+
+    func fetchCronSettings() async throws -> CronSettingsListResponse {
+        if let err = listError { throw err }
+        return listResponse ?? CronSettingsListResponse(count: 0, rows: [], tableMissing: false)
+    }
+
+    func updateCronSetting(
+        cronKey: String,
+        enabled: Bool?,
+        testMode: Bool?
+    ) async throws -> CronSettingUpdateResponse {
+        updateCalls.append((cronKey, enabled, testMode))
+        if updateDelayNanos > 0 {
+            try? await Task.sleep(nanoseconds: updateDelayNanos)
+        }
+        if let err = updateError { throw err }
+        guard let response = updateResponse else {
+            throw CronMockError.notConfigured
+        }
+        return response
+    }
+
+    // MARK: - Unused protocol surface
+
+    func sendRuleProposalEmail(proposal: RuleProposalEmailPayload, recipients: [String], userIds: [String]) async throws { throw CronMockError.unsupported }
+    func sendRuleAcceptedEmail(proposal: RuleProposalEmailPayload, approvedBy: [String], rejectedBy: [String], recipients: [String], userIds: [String]) async throws { throw CronMockError.unsupported }
+    func sendRuleDeniedEmail(proposal: RuleProposalEmailPayload, approvedBy: [String], rejectedBy: [String], recipients: [String], userIds: [String]) async throws { throw CronMockError.unsupported }
+    func sendTaxiStealEmail(stealer: TaxiStealerPayload, player: TaxiPlayerPayload, owner: TaxiOwnerPayload, recipients: [String], userIds: [String], leagueName: String) async throws { throw CronMockError.unsupported }
+    func registerDevice(userId: String, deviceToken: String) async throws { throw CronMockError.unsupported }
+    func unregisterDevice(userId: String, deviceToken: String) async throws { throw CronMockError.unsupported }
+    func adminListNotifications(sleeperUserId: String, daysBack: Int, kind: String?, status: String?, limit: Int) async throws -> AdminNotificationsResponse { throw CronMockError.unsupported }
+    func adminTestSend(sleeperUserId: String, email: String?, kind: String, channels: [String]) async throws -> AdminTestSendResponse { throw CronMockError.unsupported }
+    func fetchTestEmailRecipients() async throws -> [TestEmailRecipient] { throw CronMockError.unsupported }
+    func sendTestEmail(recipientSleeperUserId: String, reportId: String) async throws -> TestEmailResponse { throw CronMockError.unsupported }
+    func fetchLatestAIReport(type: AIReportType) async throws -> AIReport? { nil }
+    func fetchAIReportsList(type: AIReportType?, limit: Int, cursor: String?) async throws -> AIReportsListResponse { AIReportsListResponse(rows: [], nextCursor: nil) }
+    func fetchAIReportByPeriod(type: AIReportType, period: String) async throws -> AIReport? { nil }
+    func fetchMockDrafts() async throws -> [AIReport] { [] }
+    func triggerPostDraftAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw CronMockError.unsupported }
+    func triggerPreseasonAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw CronMockError.unsupported }
+    func triggerWeeklyAIReview(week: Int?, dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw CronMockError.unsupported }
+    func setReportFlag(leagueId: String, reportType: AIReportType, period: String, flag: ReportFlag, value: Bool) async throws -> ReportFlagResponse { throw CronMockError.unsupported }
+    func fetchWhitelistedUsers() async throws -> [WhitelistedUser] { throw CronMockError.unsupported }
+    func updateWhitelistedUser(userId: String, fields: [String: AdminFieldValue]) async throws -> UserUpdateResponse { throw CronMockError.unsupported }
+    func fetchAdminWhitelistedLeagues() async throws -> [WhitelistedLeague] { throw CronMockError.unsupported }
+    func updateWhitelistedLeague(leagueId: String, fields: [String: AdminFieldValue]) async throws -> LeagueUpdateResponse { throw CronMockError.unsupported }
+    func fetchAuditEntries(limit: Int, cursor: String?) async throws -> AuditListResponse { throw CronMockError.unsupported }
+    func fetchLogEvents(logGroup: LogGroup, level: LogLevel?, search: String?, limit: Int, cursor: String?) async throws -> LogsQueryResponse { throw CronMockError.unsupported }
+}
+
+enum CronMockError: Error, LocalizedError {
+    case boom
+    case unsupported
+    case notConfigured
+
+    var errorDescription: String? {
+        switch self {
+        case .boom: "boom"
+        case .unsupported: "mock method not supported"
+        case .notConfigured: "mock response not configured"
+        }
+    }
+}

--- a/XomperTests/LogsStoreTests.swift
+++ b/XomperTests/LogsStoreTests.swift
@@ -291,6 +291,8 @@ final class MockLogsAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
     func fetchAdminWhitelistedLeagues() async throws -> [WhitelistedLeague] { throw LogsMockError.unsupported }
     func updateWhitelistedLeague(leagueId: String, fields: [String: AdminFieldValue]) async throws -> LeagueUpdateResponse { throw LogsMockError.unsupported }
     func fetchAuditEntries(limit: Int, cursor: String?) async throws -> AuditListResponse { throw LogsMockError.unsupported }
+    func fetchCronSettings() async throws -> CronSettingsListResponse { throw LogsMockError.unsupported }
+    func updateCronSetting(cronKey: String, enabled: Bool?, testMode: Bool?) async throws -> CronSettingUpdateResponse { throw LogsMockError.unsupported }
 }
 
 enum LogsMockError: Error, LocalizedError {

--- a/XomperTests/TestEmailStoreTests.swift
+++ b/XomperTests/TestEmailStoreTests.swift
@@ -291,6 +291,10 @@ final class MockTestEmailAPIClient: XomperAPIClientProtocol, @unchecked Sendable
 
     // F5 admin logs — unused here.
     func fetchLogEvents(logGroup: LogGroup, level: LogLevel?, search: String?, limit: Int, cursor: String?) async throws -> LogsQueryResponse { throw TestEmailMockError.unsupported }
+
+    // admin-cron-settings — unused here.
+    func fetchCronSettings() async throws -> CronSettingsListResponse { throw TestEmailMockError.unsupported }
+    func updateCronSetting(cronKey: String, enabled: Bool?, testMode: Bool?) async throws -> CronSettingUpdateResponse { throw TestEmailMockError.unsupported }
 }
 
 enum TestEmailMockError: Error, LocalizedError {

--- a/docs/features/admin-cron-settings/PLAN.md
+++ b/docs/features/admin-cron-settings/PLAN.md
@@ -1,0 +1,213 @@
+# Plan: Admin Cron Settings — Kill Switch + Test Mode
+
+**Status**: Ready
+**Created**: 2026-06-01
+**Last updated**: 2026-06-01
+**Repos touched**: xomper-infrastructure, xomper-back-end, xomper-ios
+
+---
+
+## Summary
+
+Give admin (Dominick) two switches per scheduled lambda: an **Enabled** kill switch (no-op the lambda) and a **Test Mode** flag (run normally but restrict delivery to admin's Sleeper user_id `594625531702460416`). Backed by a new Supabase `admin_cron_settings` table, two new admin-gated API endpoints, lambda-side wraps on five notif lambdas, and a new iOS sub-screen under `AdminView`. Test mode lets us preview AI Review newsletters + recap emails before they fan out to the league; the kill switch is a safety belt against the offseason guard.
+
+---
+
+## Approach
+
+- One row per **lambda** (not per EventBridge rule) in `admin_cron_settings`. `notif_close_game_alert` fires from two rules but has a single setting.
+- Lambdas read `admin_cron_settings` on cold start via a `lambdas/common/cron_settings.py` helper. **Best-effort read**: on Supabase failure, default to `{enabled: True, test_mode: False}` — the offseason guard is the primary safety, so we prefer "send" over "skip" when settings are unreachable.
+- Test mode reuses each lambda's existing recipient-resolution code path: filter the active-user list down to admin only before SES/SNS fanout. For F3's AI Review weekly orchestrator (already has `dry_run`), pass `test_mode` through as `dry_run=True`.
+- EventBridge rules stay enabled regardless — disabling a cron just makes the lambda no-op cheaply. Cheaper to administer (single Supabase write) and avoids Terraform churn on every toggle.
+- Migration applied **out-of-band** via Supabase dashboard (same pattern as F4's `admin_audit`). SQL committed under `xomper-back-end/sql/`.
+- Two admin endpoints (`GET` list, `POST` update), each as its own API GW resource since the API GW module is one-method-per-`path_part`. Update writes an `admin_audit` row.
+
+---
+
+## Affected Files / Components
+
+### xomper-infrastructure
+
+| File | Change | Why |
+|------|--------|-----|
+| `terraform/lambdas_api.tf` | Add `admin-cron-settings-list` (GET) + `admin-cron-settings-update` (POST) entries | Expose endpoints behind API GW with admin auth |
+
+### xomper-back-end
+
+| File | Change | Why |
+|------|--------|-----|
+| `sql/admin_cron_settings_migration.sql` | New: create table + seed 5 rows | Schema applied manually via Supabase dashboard |
+| `lambdas/common/cron_settings.py` | New: `get_cron_setting`, `update_cron_setting`, `list_cron_settings` | Shared helper across all five notif lambdas + both endpoints |
+| `lambdas/common/constants.py` | Add `ADMIN_DOMINICK_USER_ID = "594625531702460416"` if not present | Used by every lambda's test-mode filter |
+| `lambdas/api_admin_cron_settings_list/__init__.py` + `handler.py` | New: GET endpoint returning all rows | iOS list source |
+| `lambdas/api_admin_cron_settings_update/__init__.py` + `handler.py` | New: POST endpoint patching one row + writing `admin_audit` | iOS edit target |
+| `lambdas/notif_weekly_recap/handler.py` | Add enabled check + test-mode recipient filter | Wrap with kill switch + preview gate |
+| `lambdas/notif_lineup_not_set/handler.py` | Same | Same |
+| `lambdas/notif_close_game_alert/handler.py` | Same | Single setting covers both Sun + Mon firings |
+| `lambdas/notif_worldcup_movement/handler.py` | Same | Same |
+| `lambdas/notif_ai_review_weekly/handler.py` | Add enabled check + map `test_mode -> dry_run=True` on orchestrator call | Reuse F3's existing dry-run path instead of duplicating filter logic |
+| `tests/common/test_cron_settings.py` | New: helper unit tests (failure default, patch round-trip) | Lock the best-effort failure mode |
+| `tests/api/test_admin_cron_settings_list.py` | New | Endpoint coverage |
+| `tests/api/test_admin_cron_settings_update.py` | New: include audit-row assertion | Endpoint + audit plumbing |
+| `tests/notif/test_*_settings_gate.py` (5 files) | New: per-lambda — assert skip when `enabled=false`, assert admin-only when `test_mode=true` | Pin per-lambda integration |
+
+### xomper-ios
+
+| File | Change | Why |
+|------|--------|-----|
+| `Xomper/Core/Models/CronSetting.swift` | New: Codable struct `{cronKey, enabled, testMode, description, updatedAt}` | Model for list + patch responses |
+| `Xomper/Core/Stores/CronSettingsStore.swift` | New: `@Observable @MainActor` — `load()`, `toggleEnabled(key:)`, `toggleTestMode(key:)`, optimistic update + rollback on failure | Drives the new sub-screen |
+| `Xomper/Core/Networking/XomperAPIClient.swift` | Add `fetchCronSettings()` + `updateCronSetting(key:enabled:testMode:)` | Wire to the two new endpoints |
+| `Xomper/Features/Admin/CronSettingsView.swift` | New: list view, one row per cron with two toggles + description | Admin UI |
+| `Xomper/Features/Admin/AdminView.swift` | Add menu row "Cron Settings" with `clock.badge.checkmark` icon between AI Review and Tables | Entry point |
+| `Xomper/Navigation/AppRouter.swift` | Add `.adminCronSettings` route case | Routing |
+| `Xomper/Features/Shell/MainShell.swift` | Wire route to `CronSettingsView` | Navigation glue |
+| `Xomper/Config/Config.swift.template` | Add `AdminFlags.showCronSettings = true` flag | Feature flag (consistency w/ other admin sub-screens) |
+| `.github/workflows/testflight-deploy.yml` | Update Config.swift heredoc to match template | Lesson learned from PR #113 — heredoc must mirror template |
+| `XomperTests/Stores/CronSettingsStoreTests.swift` | New: load + toggle round-trip + rollback-on-failure tests | Store coverage |
+| `XomperTests/Features/Admin/CronSettingsViewTests.swift` | New: snapshot or render assertions | UI coverage |
+
+---
+
+## Implementation Steps
+
+### Phase 1 — Infrastructure (PR #1: xomper-infrastructure)
+
+- [ ] Add `admin-cron-settings-list` GET entry to `terraform/lambdas_api.tf`
+- [ ] Add `admin-cron-settings-update` POST entry to `terraform/lambdas_api.tf`
+- [ ] Verify both routes flow through the existing admin authorizer
+- [ ] `terraform plan` — confirm only the two new resources are added
+- [ ] Open PR, merge, apply via CI
+
+### Phase 2 — Backend (PR #2: xomper-back-end)
+
+- [ ] Write `sql/admin_cron_settings_migration.sql` with table + 5 seeded rows
+- [ ] Apply migration manually via Supabase dashboard (document in PR body)
+- [ ] Add `ADMIN_DOMINICK_USER_ID` constant if missing
+- [ ] Write `lambdas/common/cron_settings.py`:
+  - `get_cron_setting(cron_key)` — Supabase select; on exception, log warn + return `{enabled: True, test_mode: False, description: None}`
+  - `update_cron_setting(cron_key, enabled, test_mode)` — upsert with `updated_at = now()`; raise on failure
+  - `list_cron_settings()` — select all, order by `cron_key`
+- [ ] Write `tests/common/test_cron_settings.py` — failure-mode default + happy path
+- [ ] Implement `api_admin_cron_settings_list` (GET, admin-gated, returns array)
+- [ ] Implement `api_admin_cron_settings_update` (POST, admin-gated, body `{cron_key, enabled?, test_mode?}`, writes `admin_audit` row with `action="cron_settings.update"` and the diff)
+- [ ] Write endpoint tests including the audit-row assertion
+- [ ] Wrap `notif_weekly_recap/handler.py`:
+  ```python
+  setting = get_cron_setting("notif_weekly_recap")
+  if not setting["enabled"]:
+      log.info("notif_weekly_recap disabled — skipping")
+      return success_response({"Success": True, "skipped": True, "reason": "disabled"})
+  test_mode = setting["test_mode"]
+  # ... existing logic ...
+  if test_mode:
+      recipients = [u for u in recipients if u["sleeper_user_id"] == ADMIN_DOMINICK_USER_ID]
+  ```
+- [ ] Wrap `notif_lineup_not_set/handler.py` — same pattern
+- [ ] Wrap `notif_close_game_alert/handler.py` — same pattern (one setting covers both rule firings)
+- [ ] Wrap `notif_worldcup_movement/handler.py` — same pattern
+- [ ] Wrap `notif_ai_review_weekly/handler.py` — enabled check + map `test_mode -> dry_run=True` into orchestrator invocation
+- [ ] Write 5 per-lambda integration tests (skip-on-disabled, admin-only-on-test-mode)
+- [ ] Run full test suite — all green
+- [ ] Open PR
+
+### Phase 3 — iOS (PR #3: xomper-ios)
+
+- [ ] Add `CronSetting` model with snake_case ↔ camelCase Codable
+- [ ] Add API client methods `fetchCronSettings`, `updateCronSetting`
+- [ ] Build `CronSettingsStore` with optimistic toggle + rollback on patch failure
+- [ ] Build `CronSettingsView` — `List` of rows, each row: title (description), `Toggle("Enabled")`, `Toggle("Test mode")`, subtle disabled-state styling when `enabled=false`
+- [ ] Add `Config.AdminFlags.showCronSettings` (default `true`)
+- [ ] Update `testflight-deploy.yml` heredoc to mirror template (PR #113 lesson)
+- [ ] Add `.adminCronSettings` to `AppRouter`
+- [ ] Wire route in `MainShell`
+- [ ] Add menu row to `AdminView` with `clock.badge.checkmark` icon, gated on `Config.AdminFlags.showCronSettings`
+- [ ] Write `CronSettingsStoreTests` — load, toggle, rollback
+- [ ] Write `CronSettingsViewTests` — render with mock store
+- [ ] `xcodegen generate` + build for iPhone 17 Pro simulator — green
+- [ ] Open PR
+
+### Phase 4 — Cutover & Validation
+
+- [ ] Merge PRs in order: infra → backend → iOS
+- [ ] Confirm rows visible in iOS app, all defaulting to `enabled=true, test_mode=false`
+- [ ] Flip `notif_ai_review_weekly` to `test_mode=true`, wait for next Tue 2pm ET cron, confirm only admin receives email
+- [ ] Flip back to `test_mode=false` before league-wide send
+- [ ] Confirm `admin_audit` rows captured every toggle
+
+---
+
+## Out of Scope
+
+- Per-EventBridge-rule control (close_game_alert stays as one setting)
+- Rescheduling / changing cron expressions from the iOS app
+- Disabling EventBridge rules themselves (lambdas no-op instead)
+- Surfacing cron settings to non-admin users
+- Historical view of past toggle states (only `updated_at` on the row; full history lives in `admin_audit`)
+- Adjusting the offseason guard behavior (separate concern)
+
+---
+
+## Risks / Tradeoffs
+
+- **Supabase outage during cron fire**: helper defaults to `enabled=true` — lambda will run. Accepted because the offseason guard is the actual safety. Documented in helper docstring and PR body.
+- **Test mode forgotten in "true"**: admin sets `test_mode=true` before AI Review preview, then forgets to flip back. Mitigation: optional follow-up — surface "Test mode active" badge in iOS Admin home. Not included in this plan.
+- **Recipient filter drift across lambdas**: each lambda implements the test-mode filter inline. Risk of divergence over time. Mitigation: small helper (`filter_to_admin_only(recipients)`) in `lambdas/common/cron_settings.py` so all five share one function. Add to step list.
+- **EventBridge fires twice for close_game_alert** but only one setting: confirmed acceptable — single lambda body, single setting toggles both invocations.
+- **Audit row noise**: every toggle writes an audit row. Acceptable — already the established pattern for other admin edits.
+
+---
+
+## Open Questions
+
+- [ ] Should `CronSettingsView` show the **next scheduled fire time** for each cron (parsed from the EventBridge cron expression)? Nice-to-have, can defer.
+- [ ] Should the iOS view surface a **"Last toggled by / when"** indicator? `updated_at` is already on the row — cheap to display.
+- [ ] Do we need a **"Test mode active" warning banner** on `AdminView` home when any cron has `test_mode=true`? Considered helpful given the "forgot to flip back" risk.
+- [ ] If `enabled=false`, should the **Test mode toggle in iOS UI be visually disabled** (greyed) so the admin doesn't accidentally toggle test mode on a disabled cron? Recommend yes — implement.
+
+---
+
+## Skills / Agents to Use
+
+- **swift-engineer**: build `CronSettingsView`, `CronSettingsStore`, model + routing. iOS-side work in Phase 3.
+- **python-engineer** (if defined; else execute manually): backend helper, endpoints, lambda wraps in Phase 2.
+- **terraform-engineer** (if defined; else execute manually): API GW route additions in Phase 1.
+- **test-writer**: scaffold the 8+ new test files (5 per-lambda, 1 helper, 2 endpoint, 2 iOS).
+
+---
+
+## Test Plan
+
+### Backend
+- `test_cron_settings.py`: `get_cron_setting` returns default on Supabase exception; round-trip via `update_cron_setting`.
+- `test_admin_cron_settings_list.py`: returns all rows; 403 for non-admin.
+- `test_admin_cron_settings_update.py`: patches enabled-only, test_mode-only, both; writes audit row with diff; 403 for non-admin; 400 for missing `cron_key`.
+- `test_notif_*_settings_gate.py` (×5): mock helper to `enabled=false` → assert lambda returns skipped without calling SES/SNS; mock `test_mode=true` → assert recipient list filtered to admin only.
+
+### iOS
+- `CronSettingsStoreTests`: load populates list; toggle calls API; failure rolls back optimistic state.
+- `CronSettingsViewTests`: renders all rows from store; toggles invoke store methods.
+
+### Manual / Integration
+- Apply migration to Supabase staging; confirm 5 rows seeded.
+- Hit `/admin/cron-settings` via iOS app; confirm list renders.
+- Toggle `notif_ai_review_weekly` test_mode in iOS; wait for next Tue 2pm cron; confirm only admin email received.
+- Toggle `notif_weekly_recap` enabled=false; confirm Tue 9am cron logs "skipped" and sends no notifications.
+- Verify `admin_audit` rows show up for each toggle.
+
+---
+
+## Acceptance Checklist
+
+- [ ] `admin_cron_settings` table exists in Supabase with 5 seeded rows
+- [ ] `GET /admin/cron-settings` returns all rows for admin, 403 otherwise
+- [ ] `POST /admin/cron-settings` patches a row and writes `admin_audit`
+- [ ] All 5 notif lambdas honor `enabled=false` (no-op skip)
+- [ ] All 5 notif lambdas honor `test_mode=true` (admin-only delivery)
+- [ ] `notif_ai_review_weekly` passes `test_mode` through as `dry_run` on the orchestrator
+- [ ] iOS `CronSettingsView` lists all crons and toggles persist
+- [ ] iOS optimistic toggle rolls back on API failure
+- [ ] `admin_audit` entry created on every toggle
+- [ ] All new tests pass; full suites green in CI
+- [ ] PR bodies document the manual Supabase migration step
+- [ ] TestFlight build deploys without Config.swift heredoc drift (PR #113 lesson applied)


### PR DESCRIPTION
## Summary

iOS portion of the admin-cron-settings feature. Plan: `docs/features/admin-cron-settings/PLAN.md`.

Adds a new Admin → Cron Settings sub-screen surfacing per-lambda **Enabled** (kill switch) + **Test mode** (admin-only delivery) toggles backed by `GET /admin/cron-settings-list` + `POST /admin/cron-settings-update`.

- New `CronSetting` model with snake_case ↔ camelCase Codable + optional fields
- New `CronSettingsStore` (`@Observable @MainActor`) with:
  - Optimistic toggle (flip first, POST after, revert on failure)
  - Per-row `pendingKeys` for in-flight spinner + duplicate-tap dedup
  - Server reconciliation (server-resolved row replaces the optimistic flip on success)
  - `tableMissing` empty-state signal
  - `anyTestModeActive` derived flag for the banner
- New `CronSettingsView` with:
  - One row per cron with two `Toggle`s + per-row `ProgressView`
  - Test-mode toggle **disabled (greyed) when `enabled == false`** with inline hint
  - Prominent "Test mode active" banner at the top when any cron has `test_mode == true` (mitigation for the forgot-to-flip-back risk)
  - `tableMissing` empty state: "Cron settings not yet provisioned…"
  - Loading + error + empty + pull-to-refresh
- `.adminCronSettings` `AppRoute` case wired into `MainShell.destinationView(for:)`
- `AdminView` menu row above Tables (icon: `clock.badge.checkmark`), gated by new `Config.AdminFlags.showCronSettings` flag (default `true`)
- **CI heredoc updated** in `.github/workflows/testflight-deploy.yml` — the PR #113 lesson applied
- Existing mock `XomperAPIClientProtocol` conformances in 5 test files updated with stub `fetchCronSettings` / `updateCronSetting`

## Dependencies

- Backend PR #71 (admin-cron-settings list + update endpoints)
- Infra PR #114 (`admin-cron-settings-list` GET + `admin-cron-settings-update` POST API GW routes)
- **Manual Supabase migration**: `admin_cron_settings` table + 5 seed rows must be applied via the Supabase dashboard before the view renders rows. Until then the view shows the "Cron settings not yet provisioned" empty state (driven by backend `table_missing: true`).

## Test plan

- [x] `xcodegen generate` + build clean for iPhone 17 Pro simulator (no warnings)
- [x] All 214 XomperTests pass, including new `CronSettingTests` (11 cases) + `CronSettingsStoreTests` (10 cases)
- [x] Workflow heredoc includes the new `showCronSettings` flag inline
- [x] `tableMissing` empty state renders when backend returns `table_missing: true`
- [x] Test-mode toggle disabled when `enabled == false`
- [x] "Test mode active" banner renders when any row has `test_mode == true`
- [ ] Manual: hit the live endpoint after backend + infra merge, confirm 5 rows render
- [ ] Manual: flip a toggle, confirm it persists across a refresh