### PR TITLE
feat(announcements): iOS — admin CRUD + Landing public read

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -59,6 +59,7 @@ jobs:
                   static let showLogs:   Bool = true            // F5
                   static let showAudit:  Bool = true            // F4
                   static let showCronSettings: Bool = true      // admin-cron-settings
+                  static let showAnnouncements: Bool = true     // announcements
               }
           }
           EOF

--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -47,11 +47,13 @@
 		366C0075FA9F4ABA1C88C1A9 /* Championship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18383A0375F5728A9E3FE065 /* Championship.swift */; };
 		368D96609CAF02430F340657 /* MatchupHistoryBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A3969B9E9E60F0C59D83C9 /* MatchupHistoryBrowserView.swift */; };
 		37E600A31B5AA5DA5A766692 /* AdminStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ED7387DCA3E1DC5CDD7AFF /* AdminStoreTests.swift */; };
+		38443B41FCC1E80A22E818B5 /* AnnouncementsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A884A785F461C755979D421 /* AnnouncementsStoreTests.swift */; };
 		3B1DDBCA7B19B8703FAF717E /* DrawerScrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D921732971689E8096F9549 /* DrawerScrim.swift */; };
 		3B67875F822BE9AA9BD052EF /* DraftHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6060C3A4F2B355757F1E3A2 /* DraftHistoryView.swift */; };
 		3B72E4DFCC9CB503A8EB4BD0 /* MockDraftStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C33587E13342D4234DD55FA /* MockDraftStore.swift */; };
 		3E5A98150356BEB75FD87145 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = 72178EB48829A7D249085476 /* Supabase */; };
 		3E78C9E4D65745EF23FACBBA /* MockDraftResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C1490E2B5B3B9C4FAB735 /* MockDraftResult.swift */; };
+		401769059B8F113892411DE1 /* AnnouncementEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA617F940D736CBA78987B46 /* AnnouncementEditView.swift */; };
 		40C507B6FB2EF2A7E647AA3C /* TeamStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36A01820FD0F6643BBF8511D /* TeamStore.swift */; };
 		427F23653F78A52108C55692 /* XomperLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3B178733D5AF9EB7DA7189 /* XomperLoader.swift */; };
 		42BF3DEE63074148F1DF0BD1 /* AIReviewDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967DCE922FE090CE4F067587 /* AIReviewDetailView.swift */; };
@@ -146,6 +148,7 @@
 		B3826B5CCBF64A347CCF75D0 /* DraftPersonality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E909175D4E989F36E6A4B9B /* DraftPersonality.swift */; };
 		B48B9F6061A67CFC74A096CC /* StandingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957EE31D25CFE325633622D4 /* StandingsStore.swift */; };
 		B7EB06298BFBF6AC76ABF53E /* TeamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51CC9357B13AB7ADD9C8586 /* TeamView.swift */; };
+		BAD102C79A8A7F98CFB6DA68 /* AnnouncementsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C249C7D8A57EDD62886B0D /* AnnouncementsListView.swift */; };
 		BB91E92DC29E6ECA5E1F0DEC /* SeasonStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F3F1A18F4EEC5A3F81FD28 /* SeasonStore.swift */; };
 		BBBE8D43F297A49A915AA789 /* WorldCupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F83A5F997AF6E13C98660E /* WorldCupView.swift */; };
 		BDD14CA33B905F7A31910B1D /* SupabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10CD226D313FDD91E4037D8E /* SupabaseManager.swift */; };
@@ -182,6 +185,7 @@
 		E2E0551B857C17254E9B789B /* AdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E257076F7FE641947D1DC978 /* AdminView.swift */; };
 		E2EC532916CAA2FBB779DB35 /* UserStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62948D0A455E7CE99B15CB75 /* UserStore.swift */; };
 		E64E815819D87CED1DF5383F /* AIReviewPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6B846E697A235684C8EBA4 /* AIReviewPreviewView.swift */; };
+		EC07E5ADB7CEF9AFDC9B152A /* LeagueAnnouncementDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E84A86BA7FCA57856BD476 /* LeagueAnnouncementDecoderTests.swift */; };
 		EDDACB3FFB20E468D9D9D67D /* HeaderBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E7D0FD804723AC6A3E4298 /* HeaderBar.swift */; };
 		EE987501F73209179D5CEEB4 /* TestEmailStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E98CD5B3ECB6292B6D7637B /* TestEmailStore.swift */; };
 		F118537BB85C27688E57C703 /* CronSettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4C60C4B1F35CD6B056AC29 /* CronSettingsStoreTests.swift */; };
@@ -196,6 +200,7 @@
 		F7E0A8B9AECD0291527E0D0E /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F46A0AAE61A4E963BB15B0 /* SearchView.swift */; };
 		F9A37723FE37F4C30D46D6E1 /* PressableCardButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FB63BCA4BDD437FFE6D3A8 /* PressableCardButtonStyle.swift */; };
 		FAE7847413A293EF8CE9090C /* NFLTeamColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DF8F2FE857C55AFB1C1205 /* NFLTeamColors.swift */; };
+		FC8AD0A6A8B4648E71C63553 /* AnnouncementsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C814C64F50004B297F6808 /* AnnouncementsStore.swift */; };
 		FCC663F09AC754C35DF93A3D /* AdminStorePreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46FB9B5B4B8700EACD4A9CFD /* AdminStorePreviewTests.swift */; };
 		FCD03562C1879183A5DC02E2 /* PlayerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3F6B5022E8151683A45F4F /* PlayerStore.swift */; };
 /* End PBXBuildFile section */
@@ -212,6 +217,7 @@
 
 /* Begin PBXFileReference section */
 		01A3969B9E9E60F0C59D83C9 /* MatchupHistoryBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupHistoryBrowserView.swift; sourceTree = "<group>"; };
+		02C249C7D8A57EDD62886B0D /* AnnouncementsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsListView.swift; sourceTree = "<group>"; };
 		08BD215787E2BFC1C57E7E7E /* AIReviewStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewStoreTests.swift; sourceTree = "<group>"; };
 		09DF8F2FE857C55AFB1C1205 /* NFLTeamColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFLTeamColors.swift; sourceTree = "<group>"; };
 		0BC1E989411B5FACF30C4B3A /* PastStandingsArchiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastStandingsArchiveTests.swift; sourceTree = "<group>"; };
@@ -219,6 +225,7 @@
 		1687307C5353DC42503BD721 /* AuditDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditDetailView.swift; sourceTree = "<group>"; };
 		16CD7928EAED8A9ADA1C683B /* EngineMockedPick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineMockedPick.swift; sourceTree = "<group>"; };
 		18383A0375F5728A9E3FE065 /* Championship.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Championship.swift; sourceTree = "<group>"; };
+		1A884A785F461C755979D421 /* AnnouncementsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsStoreTests.swift; sourceTree = "<group>"; };
 		1AD376EFB7AD4A192FAB3E8F /* RecordBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordBadge.swift; sourceTree = "<group>"; };
 		1D61FC118C0250CA87BDF647 /* ReportFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportFlagTests.swift; sourceTree = "<group>"; };
 		1D6C6489A04EC9CA00FFBD0F /* StandingsOffseasonCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsOffseasonCard.swift; sourceTree = "<group>"; };
@@ -234,6 +241,7 @@
 		2E172A0188BB654B8E010842 /* CronSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronSetting.swift; sourceTree = "<group>"; };
 		323F422F2D0E1C2BA5D46C0A /* SearchResults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResults.swift; sourceTree = "<group>"; };
 		36A01820FD0F6643BBF8511D /* TeamStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamStore.swift; sourceTree = "<group>"; };
+		36E84A86BA7FCA57856BD476 /* LeagueAnnouncementDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeagueAnnouncementDecoderTests.swift; sourceTree = "<group>"; };
 		3728C5F6BEF61FE509A3EA32 /* ClinchCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClinchCalculator.swift; sourceTree = "<group>"; };
 		3747C6FC769C117588F8A93E /* WhitelistedLeague.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhitelistedLeague.swift; sourceTree = "<group>"; };
 		37E65C159F2C84E48B61A9A8 /* ArchiveNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveNavigationTests.swift; sourceTree = "<group>"; };
@@ -278,6 +286,7 @@
 		6387E34B6FA70159F3F9D80A /* TaxiSquadStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiSquadStore.swift; sourceTree = "<group>"; };
 		63E231D553037403D68EB216 /* AuditEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditEntry.swift; sourceTree = "<group>"; };
 		6504EE31A645398C41BC2ED1 /* EnvironmentValues+Season.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+Season.swift"; sourceTree = "<group>"; };
+		65C814C64F50004B297F6808 /* AnnouncementsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsStore.swift; sourceTree = "<group>"; };
 		669A80C2A9F46A0C4612388C /* Double+Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Formatting.swift"; sourceTree = "<group>"; };
 		67C24A12080AD428D5A40A7E /* PlayerSeasonStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerSeasonStats.swift; sourceTree = "<group>"; };
 		69B7E5CBAFC3B1281D1134F0 /* LeagueAnnouncement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeagueAnnouncement.swift; sourceTree = "<group>"; };
@@ -400,6 +409,7 @@
 		F5EA1D700C954EFB08B185F2 /* MockDraftEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftEngine.swift; sourceTree = "<group>"; };
 		F6F606D0624D23D47A171D26 /* SearchResultGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultGroup.swift; sourceTree = "<group>"; };
 		F7048EDD875E2582C792BE47 /* LandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingView.swift; sourceTree = "<group>"; };
+		FA617F940D736CBA78987B46 /* AnnouncementEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementEditView.swift; sourceTree = "<group>"; };
 		FB3748F7A26B406C00F1C546 /* AIReviewSubScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewSubScreen.swift; sourceTree = "<group>"; };
 		FC09DFF48D9AAFEF0A286BAD /* TeamAnalysis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamAnalysis.swift; sourceTree = "<group>"; };
 		FD5AF5657020E1DBB5CB8886 /* SeasonPickerBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonPickerBar.swift; sourceTree = "<group>"; };
@@ -548,6 +558,7 @@
 				6CFEC46AB65E6E7A90E0A695 /* AdminStoreWeeklyTests.swift */,
 				2DBAC7CE2DC64237D218FAB8 /* AdminTablesStoreTests.swift */,
 				08BD215787E2BFC1C57E7E7E /* AIReviewStoreTests.swift */,
+				1A884A785F461C755979D421 /* AnnouncementsStoreTests.swift */,
 				37E65C159F2C84E48B61A9A8 /* ArchiveNavigationTests.swift */,
 				DD0B55BBDA885ABE51022738 /* AuditEntryTests.swift */,
 				B3893B13276074EF6033CEA2 /* ClinchCalculatorTests.swift */,
@@ -558,6 +569,7 @@
 				4D0F4D0BBA2C48A0232C43FF /* EmailPreviewTests.swift */,
 				5A6D698BC8816DA02019846C /* HighestPossibleCalculatorTests.swift */,
 				D7F3E6606D89CF3AEB320314 /* LandingViewTests.swift */,
+				36E84A86BA7FCA57856BD476 /* LeagueAnnouncementDecoderTests.swift */,
 				82A98546D2F68452085EEC9C /* LogEventTests.swift */,
 				ED8C8F9BD9880370D65EDF0B /* LogsStoreTests.swift */,
 				A951936FD34F712A8D8E66C0 /* MockDraftEngineTests.swift */,
@@ -792,6 +804,8 @@
 				E257076F7FE641947D1DC978 /* AdminView.swift */,
 				DE6B846E697A235684C8EBA4 /* AIReviewPreviewView.swift */,
 				FB3748F7A26B406C00F1C546 /* AIReviewSubScreen.swift */,
+				FA617F940D736CBA78987B46 /* AnnouncementEditView.swift */,
+				02C249C7D8A57EDD62886B0D /* AnnouncementsListView.swift */,
 				1687307C5353DC42503BD721 /* AuditDetailView.swift */,
 				B1358E97D2A18E9A5440D8CC /* AuditFeedView.swift */,
 				C7474B2C8F1F2B14821F4539 /* CronSettingsView.swift */,
@@ -813,6 +827,7 @@
 				7839DD9CF0968986F91A58DB /* AdminStore.swift */,
 				C206B0A18917D2B43B17ADCF /* AdminTablesStore.swift */,
 				6E6A6BADE3F51FA922A078F4 /* AIReviewStore.swift */,
+				65C814C64F50004B297F6808 /* AnnouncementsStore.swift */,
 				536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */,
 				3728C5F6BEF61FE509A3EA32 /* ClinchCalculator.swift */,
 				B1B9527EA5CA26FE5197FCF5 /* CronSettingsStore.swift */,
@@ -997,6 +1012,7 @@
 				37E600A31B5AA5DA5A766692 /* AdminStoreTests.swift in Sources */,
 				6D9C0E43C329D80ED8933AD2 /* AdminStoreWeeklyTests.swift in Sources */,
 				60D967E9FEA043C0CF58EFBF /* AdminTablesStoreTests.swift in Sources */,
+				38443B41FCC1E80A22E818B5 /* AnnouncementsStoreTests.swift in Sources */,
 				42F9C81AF6338A720FE0BC12 /* ArchiveNavigationTests.swift in Sources */,
 				DA424E9343EC13B81360C48A /* AuditEntryTests.swift in Sources */,
 				02AC6FBAE68011749AA17644 /* ClinchCalculatorTests.swift in Sources */,
@@ -1007,6 +1023,7 @@
 				50E9D9254D779960D0D2C5B1 /* EmailPreviewTests.swift in Sources */,
 				90B62C24495752B9C03F5CE8 /* HighestPossibleCalculatorTests.swift in Sources */,
 				007B11207486956897981421 /* LandingViewTests.swift in Sources */,
+				EC07E5ADB7CEF9AFDC9B152A /* LeagueAnnouncementDecoderTests.swift in Sources */,
 				31527A4E320270A464DBADDB /* LogEventTests.swift in Sources */,
 				7794B2E1BA5055ACFF150166 /* LogsStoreTests.swift in Sources */,
 				2ECED2F6ACF5F762D1E1462F /* MockDraftEngineTests.swift in Sources */,
@@ -1033,7 +1050,10 @@
 				1720E856ACCE0189331605F2 /* AdminStore.swift in Sources */,
 				D2CB1CF4D61C27A0AEA9E1C3 /* AdminTablesStore.swift in Sources */,
 				E2E0551B857C17254E9B789B /* AdminView.swift in Sources */,
+				401769059B8F113892411DE1 /* AnnouncementEditView.swift in Sources */,
 				0A87A5226863819FF3884F6C /* AnnouncementsCard.swift in Sources */,
+				BAD102C79A8A7F98CFB6DA68 /* AnnouncementsListView.swift in Sources */,
+				FC8AD0A6A8B4648E71C63553 /* AnnouncementsStore.swift in Sources */,
 				9D9E8D2C4A8A0C623AC1EF0D /* AppDelegate.swift in Sources */,
 				8C67D3AAFE5A0A124BDE5F1A /* AppRouter.swift in Sources */,
 				D1F778B07CC0F05640F72142 /* ArchiveView.swift in Sources */,

--- a/Xomper/Config/Config.swift.template
+++ b/Xomper/Config/Config.swift.template
@@ -28,5 +28,6 @@ enum Config {
         static let showLogs:   Bool = true            // F5
         static let showAudit:  Bool = true            // F4
         static let showCronSettings: Bool = true      // admin-cron-settings
+        static let showAnnouncements: Bool = true     // announcements
     }
 }

--- a/Xomper/Core/Networking/XomperAPIClient.swift
+++ b/Xomper/Core/Networking/XomperAPIClient.swift
@@ -53,6 +53,20 @@ protocol XomperAPIClientProtocol: Sendable {
     // Admin: Cron settings (kill switch + test mode)
     func fetchCronSettings() async throws -> CronSettingsListResponse
     func updateCronSetting(cronKey: String, enabled: Bool?, testMode: Bool?) async throws -> CronSettingUpdateResponse
+
+    // Announcements (public read + admin CRUD)
+    func fetchAnnouncements() async throws -> AnnouncementsListResponse
+    func fetchAdminAnnouncements() async throws -> AdminAnnouncementsListResponse
+    func createAnnouncement(
+        title: String,
+        body: String,
+        priority: String,
+        expiresAt: Date?,
+        isActive: Bool,
+        displayOrder: Int
+    ) async throws -> AnnouncementMutationResponse
+    func updateAnnouncement(id: UUID, fields: [String: AdminFieldValue]) async throws -> AnnouncementMutationResponse
+    func deleteAnnouncement(id: UUID) async throws -> AnnouncementMutationResponse
 }
 
 // MARK: - Request Payloads
@@ -299,21 +313,29 @@ struct TestEmailResponse: Codable, Sendable {
 
 // MARK: - Admin Tables + Audit (F4)
 
-/// Strongly-typed value for an `updateUser` / `updateLeague` field
-/// payload. The wire body is `{"fields": {...}}` with heterogeneous
-/// types — strings for names + emails, bools for is_admin /
-/// is_active / is_dynasty / has_taxi. Wrapping the values in this
-/// enum keeps the API surface type-safe up to the JSONSerialization
-/// hop, which expects `Any`.
+/// Strongly-typed value for an `updateUser` / `updateLeague` /
+/// `updateAnnouncement` field payload. The wire body is
+/// `{"fields": {...}}` with heterogeneous types — strings for names +
+/// emails, bools for is_admin / is_active / is_dynasty / has_taxi,
+/// ints for display_order, ISO8601 strings (or explicit JSON null)
+/// for expires_at. Wrapping the values in this enum keeps the API
+/// surface type-safe up to the JSONSerialization hop, which expects
+/// `Any`.
 enum AdminFieldValue: Sendable, Hashable {
     case string(String)
     case bool(Bool)
+    case int(Int)
+    /// Explicit null — used for `expires_at` clears. JSONSerialization
+    /// represents null as `NSNull()`.
+    case null
 
     /// Render this value as a JSONSerialization-compatible scalar.
     var jsonValue: Any {
         switch self {
         case .string(let s): return s
         case .bool(let b):   return b
+        case .int(let i):    return i
+        case .null:          return NSNull()
         }
     }
 }
@@ -485,6 +507,99 @@ struct LogsQueryResponse: Decodable, Sendable {
         self.logGroup = logGroup
         self.events = events
         self.nextToken = nextToken
+    }
+}
+
+// MARK: - Announcements
+
+/// Wraps `GET /announcements`. Public-read endpoint (JWT-gated only,
+/// not admin-gated). Returns active + non-expired rows sorted
+/// critical-first then `display_order`. `Success` matches the
+/// canonical `XomperAPIResponse` convention.
+struct AnnouncementsListResponse: Decodable, Sendable {
+    let success: Bool
+    let count: Int
+    let rows: [LeagueAnnouncement]
+
+    enum CodingKeys: String, CodingKey {
+        case success = "Success"
+        case count
+        case rows
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.success = (try? c.decode(Bool.self, forKey: .success)) ?? false
+        self.count = (try? c.decode(Int.self, forKey: .count)) ?? 0
+        self.rows = (try? c.decode([LeagueAnnouncement].self, forKey: .rows)) ?? []
+    }
+
+    /// Memberwise init for tests / previews.
+    init(success: Bool, count: Int, rows: [LeagueAnnouncement]) {
+        self.success = success
+        self.count = count
+        self.rows = rows
+    }
+}
+
+/// Wraps `GET /admin/announcements-list`. Returns every row including
+/// inactive + expired so the admin can manage them. `tableMissing` is
+/// set true when the Supabase `league_announcements` table hasn't been
+/// provisioned yet — iOS renders a dedicated empty state in that case
+/// (mirrors the F4 audit / cron-settings pattern).
+struct AdminAnnouncementsListResponse: Decodable, Sendable {
+    let success: Bool
+    let count: Int
+    let rows: [LeagueAnnouncement]
+    let tableMissing: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case success = "Success"
+        case count
+        case rows
+        case tableMissing = "table_missing"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.success = (try? c.decode(Bool.self, forKey: .success)) ?? false
+        self.count = (try? c.decode(Int.self, forKey: .count)) ?? 0
+        self.rows = (try? c.decode([LeagueAnnouncement].self, forKey: .rows)) ?? []
+        self.tableMissing = (try? c.decodeIfPresent(Bool.self, forKey: .tableMissing)) ?? false
+    }
+
+    /// Memberwise init for tests / previews.
+    init(success: Bool, count: Int, rows: [LeagueAnnouncement], tableMissing: Bool) {
+        self.success = success
+        self.count = count
+        self.rows = rows
+        self.tableMissing = tableMissing
+    }
+}
+
+/// Wraps `POST /admin/announcements-create|update|delete`. Backend
+/// echoes the resolved row after the mutation so the iOS store can
+/// reconcile the optimistic state. Delete returns the row with
+/// `is_active = false`.
+struct AnnouncementMutationResponse: Decodable, Sendable {
+    let success: Bool
+    let row: LeagueAnnouncement
+
+    enum CodingKeys: String, CodingKey {
+        case success = "Success"
+        case row
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.success = (try? c.decode(Bool.self, forKey: .success)) ?? false
+        self.row = try c.decode(LeagueAnnouncement.self, forKey: .row)
+    }
+
+    /// Memberwise init for tests / previews.
+    init(success: Bool, row: LeagueAnnouncement) {
+        self.success = success
+        self.row = row
     }
 }
 
@@ -1034,6 +1149,88 @@ final class XomperAPIClient: XomperAPIClientProtocol {
         }
         return try await postDecoding("/admin/cron-settings-update", body: body)
     }
+
+    // MARK: - Announcements
+
+    /// Public-read of active + non-expired announcements. JWT-gated
+    /// only — any signed-in league member can read. Sort + filter are
+    /// applied server-side (critical-first then `display_order`,
+    /// `is_active = true AND (expires_at IS NULL OR expires_at > now())`).
+    func fetchAnnouncements() async throws -> AnnouncementsListResponse {
+        return try await get("/announcements/list", queryItems: [])
+    }
+
+    /// Admin-only: list every row of `league_announcements`, including
+    /// inactive + expired ones. `tableMissing` is set true by the
+    /// backend when the Supabase migration hasn't yet been applied —
+    /// iOS renders a friendly empty state in that case.
+    func fetchAdminAnnouncements() async throws -> AdminAnnouncementsListResponse {
+        return try await get("/admin/announcements-list", queryItems: [])
+    }
+
+    /// Admin-only: create one row. Backend writes the row plus one
+    /// `admin_audit` entry (`announcements.create`). Returns the
+    /// resolved row including the server-assigned `id` + timestamps.
+    func createAnnouncement(
+        title: String,
+        body: String,
+        priority: String,
+        expiresAt: Date?,
+        isActive: Bool,
+        displayOrder: Int
+    ) async throws -> AnnouncementMutationResponse {
+        var body: [String: Any] = [
+            "title": title,
+            "body": body,
+            "priority": priority,
+            "is_active": isActive,
+            "display_order": displayOrder,
+        ]
+        if let expiresAt {
+            body["expires_at"] = Self.iso8601Formatter.string(from: expiresAt)
+        }
+        return try await postDecoding("/admin/announcements-create", body: body)
+    }
+
+    /// Admin-only: partial-update one row by `id`. Only the fields the
+    /// admin actually changed are sent — the backend writes one
+    /// `admin_audit` row per call with the field-level diff.
+    func updateAnnouncement(
+        id: UUID,
+        fields: [String: AdminFieldValue]
+    ) async throws -> AnnouncementMutationResponse {
+        var jsonFields: [String: Any] = [:]
+        for (key, value) in fields {
+            jsonFields[key] = value.jsonValue
+        }
+        let body: [String: Any] = [
+            "id": id.uuidString,
+            "fields": jsonFields,
+        ]
+        return try await postDecoding("/admin/announcements-update", body: body)
+    }
+
+    /// Admin-only: soft-delete one row. Sets `is_active = false` and
+    /// writes one `admin_audit` entry. Row stays in `league_announcements`
+    /// so the audit trail remains queryable.
+    func deleteAnnouncement(id: UUID) async throws -> AnnouncementMutationResponse {
+        let body: [String: Any] = [
+            "id": id.uuidString,
+        ]
+        return try await postDecoding("/admin/announcements-delete", body: body)
+    }
+
+    /// Shared ISO8601 formatter for outgoing `expires_at` strings.
+    /// Matches the format the backend's Pydantic models expect for
+    /// `datetime` columns (full datetime, no fractional seconds, UTC
+    /// `Z` suffix). `nonisolated(unsafe)` acknowledges that
+    /// `ISO8601DateFormatter` is thread-safe for read-only access
+    /// once configured.
+    nonisolated(unsafe) private static let iso8601Formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
 
     // MARK: - Private
 

--- a/Xomper/Core/Stores/AnnouncementsStore.swift
+++ b/Xomper/Core/Stores/AnnouncementsStore.swift
@@ -1,0 +1,343 @@
+import Foundation
+
+/// Drives the Landing → Announcements card (public read) and the
+/// Admin → Announcements sub-screen (admin CRUD).
+///
+/// Two parallel state machines on one store so a single instance can
+/// satisfy both surfaces — the public read uses a 5-minute freshness
+/// cache and falls back to `LeagueAnnouncements.current` on failure
+/// (acceptance criterion: Landing never blanks). The admin surface
+/// has no cache because the admin always wants fresh data after a
+/// write, and is gated to admin users only.
+///
+/// Optimistic mutations: `create` appends to `adminAnnouncements`
+/// immediately, then reconciles with the server response on success
+/// (the server row carries the canonical `id` + timestamps). Failed
+/// writes revert the optimistic mutation and surface the error.
+@Observable
+@MainActor
+final class AnnouncementsStore {
+
+    // MARK: - Public-read state (Landing)
+
+    /// Active + non-expired rows for the public Landing card. Mutated
+    /// by `load(force:)`. Empty when no read has succeeded yet.
+    private(set) var announcements: [LeagueAnnouncement] = []
+    private(set) var isLoading: Bool = false
+    private(set) var error: String?
+    private(set) var lastLoadedAt: Date?
+
+    // MARK: - Admin state
+
+    /// Every row (including inactive + expired) for the admin list.
+    /// Mutated by `loadAdmin`, `create`, `update`, `delete`.
+    private(set) var adminAnnouncements: [LeagueAnnouncement] = []
+    private(set) var isLoadingAdmin: Bool = false
+    private(set) var adminError: String?
+    /// True when the backend signalled the `league_announcements`
+    /// table hasn't been provisioned yet (manual Supabase migration
+    /// pending). UI renders a dedicated empty state in that case.
+    private(set) var tableMissing: Bool = false
+
+    /// Per-row in-flight tracker for admin mutations. Used by the
+    /// list view to show a small spinner on the row currently being
+    /// deleted, and to dedupe rapid taps.
+    private(set) var pendingIds: Set<UUID> = []
+
+    /// Last write error surfaced to the admin edit/list view. Cleared
+    /// at the start of the next write.
+    private(set) var lastWriteError: String?
+
+    // MARK: - Dependencies
+
+    /// 5-minute freshness gate for `load()`. The admin's "+ New" flow
+    /// + pull-to-refresh on Landing both bypass with `force: true`.
+    private let cacheLifetime: TimeInterval = 5 * 60
+
+    private let apiClient: XomperAPIClientProtocol
+
+    init(apiClient: XomperAPIClientProtocol = XomperAPIClient()) {
+        self.apiClient = apiClient
+    }
+
+    // MARK: - Public read
+
+    /// Fetch the public-read announcements list. Respects a 5-minute
+    /// freshness cache unless `force == true`. On error, falls back
+    /// to `LeagueAnnouncements.current` so the Landing card always
+    /// renders something — keeps the acceptance criterion of "Landing
+    /// never blanks" honest even when the backend is down.
+    func load(force: Bool = false) async {
+        guard !isLoading else { return }
+        if !force, let lastLoadedAt,
+           Date().timeIntervalSince(lastLoadedAt) < cacheLifetime,
+           !announcements.isEmpty {
+            return
+        }
+
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+
+        do {
+            let response = try await apiClient.fetchAnnouncements()
+            announcements = response.rows
+            lastLoadedAt = Date()
+        } catch {
+            self.error = error.localizedDescription
+            // Fallback: only seed from the hardcoded list if we have
+            // nothing else to show. Preserves any previously-loaded
+            // server rows across transient network blips.
+            if announcements.isEmpty {
+                announcements = LeagueAnnouncements.current
+            }
+        }
+    }
+
+    // MARK: - Admin read
+
+    /// Fetch every row for the admin list (including inactive +
+    /// expired). No cache — the admin always wants fresh data.
+    func loadAdmin() async {
+        guard !isLoadingAdmin else { return }
+        isLoadingAdmin = true
+        adminError = nil
+        defer { isLoadingAdmin = false }
+
+        do {
+            let response = try await apiClient.fetchAdminAnnouncements()
+            adminAnnouncements = response.rows
+            tableMissing = response.tableMissing
+        } catch {
+            adminError = error.localizedDescription
+        }
+    }
+
+    // MARK: - Admin writes
+
+    /// Create one row. Optimistic: appends a placeholder to the
+    /// admin list immediately with a client-side UUID, then replaces
+    /// it with the server's resolved row on success. Reverts on
+    /// failure and re-throws so the caller can stay on the form.
+    @discardableResult
+    func create(
+        title: String,
+        body: String,
+        priority: LeagueAnnouncement.Priority,
+        expiresAt: Date?,
+        isActive: Bool,
+        displayOrder: Int
+    ) async throws -> LeagueAnnouncement {
+        let placeholderId = UUID()
+        let placeholder = LeagueAnnouncement(
+            id: placeholderId,
+            title: title,
+            body: body,
+            priority: priority,
+            expiresAt: expiresAt,
+            isActive: isActive,
+            displayOrder: displayOrder,
+            createdAt: Date(),
+            updatedAt: Date()
+        )
+        adminAnnouncements.insert(placeholder, at: 0)
+        pendingIds.insert(placeholderId)
+        lastWriteError = nil
+        defer { pendingIds.remove(placeholderId) }
+
+        do {
+            let response = try await apiClient.createAnnouncement(
+                title: title,
+                body: body,
+                priority: priority.rawValue,
+                expiresAt: expiresAt,
+                isActive: isActive,
+                displayOrder: displayOrder
+            )
+            // Swap the placeholder for the server-resolved row.
+            if let idx = adminAnnouncements.firstIndex(where: { $0.id == placeholderId }) {
+                adminAnnouncements[idx] = response.row
+            } else {
+                // Defensive — placeholder was somehow lost. Insert the
+                // canonical row at the top.
+                adminAnnouncements.insert(response.row, at: 0)
+            }
+            // Mirror onto public list if the new row is active +
+            // not yet expired (saves a follow-up `load(force: true)`).
+            if response.row.isActive,
+               (response.row.expiresAt.map { $0 > Date() } ?? true) {
+                announcements.insert(response.row, at: 0)
+            }
+            return response.row
+        } catch {
+            // Revert the optimistic insertion.
+            adminAnnouncements.removeAll { $0.id == placeholderId }
+            lastWriteError = error.localizedDescription
+            throw error
+        }
+    }
+
+    /// Update one row by id. Optimistic — applies the diff in place
+    /// immediately, then replaces the row with the server response on
+    /// success. Reverts on failure and re-throws.
+    @discardableResult
+    func update(
+        id: UUID,
+        fields: [String: AdminFieldValue]
+    ) async throws -> LeagueAnnouncement {
+        guard let idx = adminAnnouncements.firstIndex(where: { $0.id == id }) else {
+            throw AnnouncementsStoreError.notFound
+        }
+        let original = adminAnnouncements[idx]
+        adminAnnouncements[idx] = Self.applyFields(to: original, fields: fields)
+        pendingIds.insert(id)
+        lastWriteError = nil
+        defer { pendingIds.remove(id) }
+
+        do {
+            let response = try await apiClient.updateAnnouncement(id: id, fields: fields)
+            // Reconcile with the server row.
+            if let confirmIdx = adminAnnouncements.firstIndex(where: { $0.id == id }) {
+                adminAnnouncements[confirmIdx] = response.row
+            }
+            // Mirror onto the public list if visible there.
+            if let pubIdx = announcements.firstIndex(where: { $0.id == id }) {
+                if response.row.isActive,
+                   (response.row.expiresAt.map { $0 > Date() } ?? true) {
+                    announcements[pubIdx] = response.row
+                } else {
+                    announcements.remove(at: pubIdx)
+                }
+            }
+            return response.row
+        } catch {
+            // Revert the optimistic mutation.
+            if let revertIdx = adminAnnouncements.firstIndex(where: { $0.id == id }) {
+                adminAnnouncements[revertIdx] = original
+            }
+            lastWriteError = error.localizedDescription
+            throw error
+        }
+    }
+
+    /// Soft-delete one row (backend flips `is_active = false`).
+    /// Optimistic: flips locally first, then awaits the server. On
+    /// failure, restores the row to its prior active state.
+    func delete(id: UUID) async throws {
+        guard let idx = adminAnnouncements.firstIndex(where: { $0.id == id }) else {
+            throw AnnouncementsStoreError.notFound
+        }
+        let original = adminAnnouncements[idx]
+        adminAnnouncements[idx] = LeagueAnnouncement(
+            id: original.id,
+            title: original.title,
+            body: original.body,
+            priority: original.priority,
+            expiresAt: original.expiresAt,
+            isActive: false,
+            displayOrder: original.displayOrder,
+            createdAt: original.createdAt,
+            updatedAt: Date()
+        )
+        // Drop from the public list immediately — the backend will
+        // do the same on its next read, but the UI shouldn't lag.
+        announcements.removeAll { $0.id == id }
+
+        pendingIds.insert(id)
+        lastWriteError = nil
+        defer { pendingIds.remove(id) }
+
+        do {
+            let response = try await apiClient.deleteAnnouncement(id: id)
+            if let confirmIdx = adminAnnouncements.firstIndex(where: { $0.id == id }) {
+                adminAnnouncements[confirmIdx] = response.row
+            }
+        } catch {
+            // Revert the optimistic flip — restore the original row
+            // back into both admin + public lists.
+            if let revertIdx = adminAnnouncements.firstIndex(where: { $0.id == id }) {
+                adminAnnouncements[revertIdx] = original
+            }
+            if original.isActive {
+                announcements.insert(original, at: 0)
+            }
+            lastWriteError = error.localizedDescription
+            throw error
+        }
+    }
+
+    // MARK: - Misc
+
+    /// Clear the last write error. Call when navigating away from a
+    /// form so the next open doesn't show stale state.
+    func clearLastWriteError() {
+        lastWriteError = nil
+    }
+
+    // MARK: - Private — field-merge helper
+
+    /// Apply a partial field diff to a `LeagueAnnouncement`. Mirrors
+    /// the backend's allowlist (`title`, `body`, `priority`,
+    /// `expires_at`, `is_active`, `display_order`). Unknown keys are
+    /// ignored — the server is the hard backstop.
+    private static func applyFields(
+        to original: LeagueAnnouncement,
+        fields: [String: AdminFieldValue]
+    ) -> LeagueAnnouncement {
+        var title = original.title
+        var body = original.body
+        var priority = original.priority
+        var expiresAt = original.expiresAt
+        var isActive = original.isActive
+        var displayOrder = original.displayOrder
+
+        for (key, value) in fields {
+            switch (key, value) {
+            case ("title", .string(let s)):        title = s
+            case ("body", .string(let s)):         body = s
+            case ("priority", .string(let s)):     priority = LeagueAnnouncement.Priority(rawValue: s) ?? priority
+            case ("expires_at", .string(let s)):
+                expiresAt = Self.parseISODate(s)
+            case ("expires_at", .null):            expiresAt = nil
+            case ("is_active", .bool(let b)):      isActive = b
+            case ("display_order", .int(let i)):   displayOrder = i
+            default:
+                continue
+            }
+        }
+
+        return LeagueAnnouncement(
+            id: original.id,
+            title: title,
+            body: body,
+            priority: priority,
+            expiresAt: expiresAt,
+            isActive: isActive,
+            displayOrder: displayOrder,
+            createdAt: original.createdAt,
+            updatedAt: Date()
+        )
+    }
+
+    /// Permissive ISO8601 parser — handles with and without fractional
+    /// seconds (Postgres `timestamptz` can serialise either way).
+    private static func parseISODate(_ raw: String) -> Date? {
+        let plain = ISO8601DateFormatter()
+        plain.formatOptions = [.withInternetDateTime]
+        if let date = plain.date(from: raw) { return date }
+        let frac = ISO8601DateFormatter()
+        frac.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return frac.date(from: raw)
+    }
+}
+
+/// Errors thrown by `AnnouncementsStore` mutations.
+enum AnnouncementsStoreError: Error, LocalizedError {
+    case notFound
+
+    var errorDescription: String? {
+        switch self {
+        case .notFound: "Announcement not found in the local list. Refresh and try again."
+        }
+    }
+}

--- a/Xomper/Features/Admin/AdminView.swift
+++ b/Xomper/Features/Admin/AdminView.swift
@@ -56,6 +56,15 @@ struct AdminView: View {
                     action: { router.navigate(to: .adminTestEmail) }
                 )
 
+                if Config.AdminFlags.showAnnouncements {
+                    AdminMenuRow(
+                        icon: "megaphone.fill",
+                        title: "Announcements",
+                        subtitle: "Create, edit, and retire league announcements",
+                        action: { router.navigate(to: .adminAnnouncements) }
+                    )
+                }
+
                 if Config.AdminFlags.showCronSettings {
                     AdminMenuRow(
                         icon: "clock.badge.checkmark",

--- a/Xomper/Features/Admin/AnnouncementEditView.swift
+++ b/Xomper/Features/Admin/AnnouncementEditView.swift
@@ -1,0 +1,280 @@
+import SwiftUI
+
+/// Admin → Announcements → Edit (announcements feature).
+///
+/// Typed form for one `league_announcements` row. When `id == nil`
+/// the form opens empty for a create; otherwise it hydrates from the
+/// matching row in `store.adminAnnouncements`.
+///
+/// Allowlisted fields per the backend handler: title, body, priority,
+/// expires_at, is_active, display_order. On Save:
+/// - Create path: calls `store.create(...)`.
+/// - Update path: sends only the fields that actually changed (so the
+///   backend's `admin_audit` diff stays tight).
+///
+/// Validation:
+/// - Title + body must be non-empty after trimming.
+/// - `display_order` is a non-negative `Stepper`.
+struct AnnouncementEditView: View {
+    let id: UUID?
+    var store: AnnouncementsStore
+    var router: AppRouter
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var titleDraft: String = ""
+    @State private var bodyDraft: String = ""
+    @State private var priorityDraft: LeagueAnnouncement.Priority = .info
+    @State private var isActiveDraft: Bool = true
+    @State private var displayOrderDraft: Int = 0
+    @State private var hasExpiry: Bool = false
+    @State private var expiresAtDraft: Date = Calendar.current.date(byAdding: .day, value: 7, to: Date()) ?? Date()
+    @State private var didPopulateFromStore: Bool = false
+    @State private var isSaving: Bool = false
+    @State private var inlineError: String?
+
+    var body: some View {
+        content
+            .background(XomperColors.bgDark.ignoresSafeArea())
+            .navigationTitle(isCreate ? "New Announcement" : "Edit Announcement")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar { saveToolbar }
+            .task {
+                if id != nil && store.adminAnnouncements.isEmpty {
+                    await store.loadAdmin()
+                }
+                populateDraftIfNeeded()
+            }
+            .onChange(of: store.adminAnnouncements) { _, _ in
+                populateDraftIfNeeded()
+            }
+            .onDisappear {
+                store.clearLastWriteError()
+            }
+    }
+
+    private var isCreate: Bool { id == nil }
+
+    private var resolvedRow: LeagueAnnouncement? {
+        guard let id else { return nil }
+        return store.adminAnnouncements.first(where: { $0.id == id })
+    }
+
+    // MARK: - Form
+
+    @ViewBuilder
+    private var content: some View {
+        if !isCreate && resolvedRow == nil && store.isLoadingAdmin {
+            LoadingView(message: "Loading announcement…")
+        } else if !isCreate && resolvedRow == nil {
+            EmptyStateView(
+                icon: "megaphone.fill",
+                title: "Announcement not found",
+                message: "We couldn't find that announcement. Pull to refresh and try again."
+            )
+        } else {
+            Form {
+                Section("Content") {
+                    TextField("Title", text: $titleDraft)
+                        .textInputAutocapitalization(.sentences)
+
+                    VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+                        Text("Body")
+                            .font(.caption)
+                            .foregroundStyle(XomperColors.textSecondary)
+                        TextEditor(text: $bodyDraft)
+                            .frame(minHeight: 120)
+                            .scrollContentBackground(.hidden)
+                            .background(XomperColors.bgCard.opacity(0.4))
+                            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.sm))
+                        Text("Supports **bold** markdown and [links](https://example.com).")
+                            .font(.caption2)
+                            .foregroundStyle(XomperColors.textMuted)
+                    }
+                }
+
+                Section("Priority & Visibility") {
+                    Picker("Priority", selection: $priorityDraft) {
+                        Text("Info").tag(LeagueAnnouncement.Priority.info)
+                        Text("Critical").tag(LeagueAnnouncement.Priority.critical)
+                    }
+                    .pickerStyle(.segmented)
+
+                    Toggle("Active", isOn: $isActiveDraft)
+                        .tint(XomperColors.successGreen)
+
+                    Stepper(
+                        "Display order: \(displayOrderDraft)",
+                        value: $displayOrderDraft,
+                        in: 0...999
+                    )
+                }
+
+                Section("Expiry") {
+                    Toggle("Has expiry", isOn: $hasExpiry)
+                        .tint(XomperColors.championGold)
+                    if hasExpiry {
+                        DatePicker(
+                            "Expires at",
+                            selection: $expiresAtDraft,
+                            displayedComponents: [.date, .hourAndMinute]
+                        )
+                    }
+                }
+
+                if let inlineError {
+                    Section {
+                        Label(inlineError, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(XomperColors.errorRed)
+                            .font(.callout)
+                    }
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .background(XomperColors.bgDark)
+        }
+    }
+
+    // MARK: - Save toolbar
+
+    @ToolbarContentBuilder
+    private var saveToolbar: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
+            Button {
+                Task { await save() }
+            } label: {
+                if isSaving {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                        .tint(XomperColors.championGold)
+                } else {
+                    Text("Save")
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(canSave ? XomperColors.championGold : XomperColors.textMuted)
+                }
+            }
+            .disabled(!canSave)
+            .accessibilityHint(canSave ? "Save changes" : "Fill in title and body to enable saving")
+        }
+    }
+
+    // MARK: - Draft hydration
+
+    private func populateDraftIfNeeded() {
+        guard !didPopulateFromStore else { return }
+        if isCreate {
+            didPopulateFromStore = true
+            return
+        }
+        guard let row = resolvedRow else { return }
+        titleDraft = row.title
+        bodyDraft = row.body
+        priorityDraft = row.priority
+        isActiveDraft = row.isActive
+        displayOrderDraft = row.displayOrder
+        if let expiresAt = row.expiresAt {
+            hasExpiry = true
+            expiresAtDraft = expiresAt
+        } else {
+            hasExpiry = false
+        }
+        didPopulateFromStore = true
+    }
+
+    // MARK: - Validation
+
+    private var titleTrimmed: String {
+        titleDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var bodyTrimmed: String {
+        bodyDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var canSave: Bool {
+        guard !isSaving else { return false }
+        guard !titleTrimmed.isEmpty, !bodyTrimmed.isEmpty else { return false }
+        if isCreate { return true }
+        return !changedFields.isEmpty
+    }
+
+    // MARK: - Diff for update
+
+    private var changedFields: [String: AdminFieldValue] {
+        guard let row = resolvedRow else { return [:] }
+        var diff: [String: AdminFieldValue] = [:]
+
+        if titleTrimmed != row.title {
+            diff["title"] = .string(titleTrimmed)
+        }
+        if bodyTrimmed != row.body {
+            diff["body"] = .string(bodyTrimmed)
+        }
+        if priorityDraft != row.priority {
+            diff["priority"] = .string(priorityDraft.rawValue)
+        }
+        if isActiveDraft != row.isActive {
+            diff["is_active"] = .bool(isActiveDraft)
+        }
+        if displayOrderDraft != row.displayOrder {
+            diff["display_order"] = .int(displayOrderDraft)
+        }
+        // expires_at — three transitions to consider:
+        //   on → off  → send null
+        //   off → on  → send new date string
+        //   on → on   → send new date string IF it changed
+        let originalExpiry = row.expiresAt
+        if hasExpiry {
+            if originalExpiry == nil || originalExpiry != expiresAtDraft {
+                diff["expires_at"] = .string(Self.iso8601(expiresAtDraft))
+            }
+        } else if originalExpiry != nil {
+            diff["expires_at"] = .null
+        }
+        return diff
+    }
+
+    // MARK: - Save
+
+    private func save() async {
+        guard canSave else { return }
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+
+        isSaving = true
+        inlineError = nil
+        defer { isSaving = false }
+
+        do {
+            if isCreate {
+                _ = try await store.create(
+                    title: titleTrimmed,
+                    body: bodyTrimmed,
+                    priority: priorityDraft,
+                    expiresAt: hasExpiry ? expiresAtDraft : nil,
+                    isActive: isActiveDraft,
+                    displayOrder: displayOrderDraft
+                )
+            } else if let id {
+                _ = try await store.update(id: id, fields: changedFields)
+            }
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            dismiss()
+        } catch {
+            inlineError = error.localizedDescription
+            UINotificationFeedbackGenerator().notificationOccurred(.error)
+        }
+    }
+
+    // MARK: - ISO helper
+
+    nonisolated(unsafe) private static let iso8601Formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    private static func iso8601(_ date: Date) -> String {
+        iso8601Formatter.string(from: date)
+    }
+}

--- a/Xomper/Features/Admin/AnnouncementsListView.swift
+++ b/Xomper/Features/Admin/AnnouncementsListView.swift
@@ -1,0 +1,269 @@
+import SwiftUI
+
+/// Admin → Announcements list (announcements feature).
+///
+/// Lists every row from `league_announcements` via
+/// `GET /admin/announcements-list` (active + inactive + expired). Each
+/// row surfaces the title, priority chip, and status chips
+/// (ACTIVE / INACTIVE / EXPIRED) so the admin can scan the state at
+/// a glance. Tap a row → push `.adminAnnouncementEdit(id: row.id)`.
+/// Top-trailing toolbar "+ New" → push
+/// `.adminAnnouncementEdit(id: nil)` (empty form).
+struct AnnouncementsListView: View {
+    var store: AnnouncementsStore
+    var router: AppRouter
+
+    @State private var deleteCandidate: LeagueAnnouncement?
+
+    var body: some View {
+        content
+            .background(XomperColors.bgDark.ignoresSafeArea())
+            .navigationTitle("Announcements")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar { newToolbar }
+            .task {
+                if store.adminAnnouncements.isEmpty {
+                    await store.loadAdmin()
+                }
+            }
+            .refreshable {
+                await store.loadAdmin()
+            }
+            .alert(
+                "Soft-delete this announcement?",
+                isPresented: deleteAlertBinding,
+                presenting: deleteCandidate
+            ) { row in
+                Button("Delete", role: .destructive) {
+                    Task { await performDelete(id: row.id) }
+                }
+                Button("Cancel", role: .cancel) {
+                    deleteCandidate = nil
+                }
+            } message: { row in
+                Text("'\(row.title)' will be hidden from the Landing page. The row stays in Supabase so the audit trail is preserved — you can re-activate it from the edit form.")
+            }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        if store.isLoadingAdmin && store.adminAnnouncements.isEmpty {
+            LoadingView(message: "Loading announcements…")
+        } else if store.tableMissing {
+            EmptyStateView(
+                icon: "tablecells.badge.ellipsis",
+                title: "Migration pending",
+                message: "The Supabase 'league_announcements' table hasn't been created yet. Apply the migration from the backend repo, then refresh."
+            )
+        } else if let error = store.adminError, store.adminAnnouncements.isEmpty {
+            EmptyStateView(
+                icon: "exclamationmark.triangle",
+                title: "Couldn't load announcements",
+                message: error
+            )
+        } else if store.adminAnnouncements.isEmpty {
+            EmptyStateView(
+                icon: "megaphone",
+                title: "No announcements yet",
+                message: "Tap + to create the first one."
+            )
+        } else {
+            ScrollView {
+                VStack(spacing: XomperTheme.Spacing.sm) {
+                    if let lastWriteError = store.lastWriteError {
+                        ErrorBanner(text: lastWriteError)
+                    }
+                    ForEach(store.adminAnnouncements) { row in
+                        AnnouncementAdminRow(
+                            announcement: row,
+                            isPending: store.pendingIds.contains(row.id),
+                            onTap: {
+                                let generator = UIImpactFeedbackGenerator(style: .light)
+                                generator.impactOccurred()
+                                router.navigate(to: .adminAnnouncementEdit(id: row.id))
+                            },
+                            onDelete: {
+                                deleteCandidate = row
+                            }
+                        )
+                    }
+                }
+                .padding(.horizontal, XomperTheme.Spacing.md)
+                .padding(.vertical, XomperTheme.Spacing.sm)
+            }
+        }
+    }
+
+    // MARK: - New toolbar
+
+    @ToolbarContentBuilder
+    private var newToolbar: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
+            Button {
+                let generator = UIImpactFeedbackGenerator(style: .light)
+                generator.impactOccurred()
+                router.navigate(to: .adminAnnouncementEdit(id: nil))
+            } label: {
+                Image(systemName: "plus")
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+            }
+            .accessibilityLabel("New announcement")
+        }
+    }
+
+    // MARK: - Alert binding
+
+    private var deleteAlertBinding: Binding<Bool> {
+        Binding(
+            get: { deleteCandidate != nil },
+            set: { newValue in
+                if !newValue { deleteCandidate = nil }
+            }
+        )
+    }
+
+    // MARK: - Delete
+
+    private func performDelete(id: UUID) async {
+        let generator = UINotificationFeedbackGenerator()
+        do {
+            try await store.delete(id: id)
+            generator.notificationOccurred(.success)
+        } catch {
+            generator.notificationOccurred(.error)
+        }
+        deleteCandidate = nil
+    }
+}
+
+// MARK: - Row
+
+private struct AnnouncementAdminRow: View {
+    let announcement: LeagueAnnouncement
+    let isPending: Bool
+    let onTap: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 0) {
+                if announcement.priority == .critical {
+                    Rectangle()
+                        .fill(XomperColors.accentRed)
+                        .frame(width: 3)
+                }
+
+                VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+                    HStack(spacing: XomperTheme.Spacing.xs) {
+                        Text(announcement.title)
+                            .font(.headline)
+                            .foregroundStyle(XomperColors.textPrimary)
+                            .multilineTextAlignment(.leading)
+                            .lineLimit(2)
+                        Spacer()
+                        if isPending {
+                            ProgressView()
+                                .scaleEffect(0.6)
+                                .tint(XomperColors.championGold)
+                                .accessibilityHidden(true)
+                        }
+                        Image(systemName: "chevron.right")
+                            .font(.footnote.weight(.bold))
+                            .foregroundStyle(XomperColors.textMuted)
+                            .accessibilityHidden(true)
+                    }
+
+                    if !announcement.body.isEmpty {
+                        Text(announcement.body)
+                            .font(.caption)
+                            .foregroundStyle(XomperColors.textSecondary)
+                            .lineLimit(2)
+                            .multilineTextAlignment(.leading)
+                    }
+
+                    HStack(spacing: XomperTheme.Spacing.xs) {
+                        chip(
+                            text: announcement.priority == .critical ? "CRITICAL" : "INFO",
+                            color: announcement.priority == .critical ? XomperColors.accentRed : XomperColors.textMuted
+                        )
+                        chip(
+                            text: announcement.isActive ? "ACTIVE" : "INACTIVE",
+                            color: announcement.isActive ? XomperColors.successGreen : XomperColors.textMuted
+                        )
+                        if isExpired {
+                            chip(text: "EXPIRED", color: XomperColors.errorRed)
+                        }
+                        Spacer()
+                        Text("#\(announcement.displayOrder)")
+                            .font(.caption2)
+                            .foregroundStyle(XomperColors.textMuted)
+                    }
+                }
+                .padding(XomperTheme.Spacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+            .overlay(
+                RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                    .strokeBorder(XomperColors.championGold.opacity(0.2), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.pressableCard)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive, action: onDelete) {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint("Double tap to edit, swipe left to delete")
+    }
+
+    private var accessibilityLabel: String {
+        var parts = [announcement.title]
+        parts.append(announcement.priority == .critical ? "Critical" : "Info")
+        parts.append(announcement.isActive ? "Active" : "Inactive")
+        if isExpired { parts.append("Expired") }
+        return parts.joined(separator: ", ")
+    }
+
+    private var isExpired: Bool {
+        guard let expiresAt = announcement.expiresAt else { return false }
+        return expiresAt <= Date()
+    }
+
+    private func chip(text: String, color: Color) -> some View {
+        Text(text)
+            .font(.caption2.weight(.bold))
+            .foregroundStyle(color)
+            .padding(.horizontal, XomperTheme.Spacing.xs)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.15))
+            .clipShape(Capsule())
+    }
+}
+
+// MARK: - Inline error banner
+
+private struct ErrorBanner: View {
+    let text: String
+
+    var body: some View {
+        HStack(spacing: XomperTheme.Spacing.sm) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(XomperColors.errorRed)
+            Text(text)
+                .font(.footnote)
+                .foregroundStyle(XomperColors.textPrimary)
+                .multilineTextAlignment(.leading)
+            Spacer()
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.errorRed.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+    }
+}

--- a/Xomper/Features/Landing/AnnouncementsCard.swift
+++ b/Xomper/Features/Landing/AnnouncementsCard.swift
@@ -1,43 +1,60 @@
 import SwiftUI
 
-/// Renders the hardcoded `LeagueAnnouncements.current` list as a
-/// stacked set of compact cards. Expired entries (`expiresAt < now`)
-/// are filtered out; remaining entries sort critical-first, then by
-/// the order they appear in the source array.
+/// Renders the league announcements list as a stacked set of compact
+/// cards. v2 reads from `AnnouncementsStore.announcements` (backed by
+/// Supabase via `/announcements`). Expired entries (`expiresAt < now`)
+/// are filtered out client-side as a defensive guard against
+/// stale-cache rendering; the backend already applies the same filter.
 ///
 /// When the filtered list is empty, the card renders zero-height —
 /// the Landing page collapses around it instead of showing an empty
 /// state. Announcements are an opportunistic surface, not a required
 /// one.
+///
+/// Body text is rendered via `AttributedString(markdown:)` so the
+/// admin can bold key dates / italicise + add links. Falls back to
+/// plain `Text` on parse failure.
 struct AnnouncementsCard: View {
+    var store: AnnouncementsStore
+
     /// Filtered + sorted list. Computed at render time so date-based
     /// expiry kicks in without any timers / observers.
     private var visible: [LeagueAnnouncement] {
         let now = Date()
-        return LeagueAnnouncements.current
+        return store.announcements
             .filter { entry in
+                guard entry.isActive else { return false }
                 guard let expiresAt = entry.expiresAt else { return true }
                 return expiresAt > now
             }
             .sorted { a, b in
-                // critical (priority order 0) before info (1)
-                priorityOrder(a.priority) < priorityOrder(b.priority)
+                // critical (priority order 0) before info (1), then by
+                // display_order ascending within a priority bucket.
+                let aOrder = priorityOrder(a.priority)
+                let bOrder = priorityOrder(b.priority)
+                if aOrder != bOrder { return aOrder < bOrder }
+                return a.displayOrder < b.displayOrder
             }
     }
 
     var body: some View {
-        if visible.isEmpty {
-            EmptyView()
-        } else {
-            VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
-                sectionHeader
+        Group {
+            if visible.isEmpty {
+                EmptyView()
+            } else {
+                VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+                    sectionHeader
 
-                VStack(spacing: XomperTheme.Spacing.sm) {
-                    ForEach(visible) { entry in
-                        AnnouncementRow(announcement: entry)
+                    VStack(spacing: XomperTheme.Spacing.sm) {
+                        ForEach(visible) { entry in
+                            AnnouncementRow(announcement: entry)
+                        }
                     }
                 }
             }
+        }
+        .task {
+            await store.load()
         }
     }
 
@@ -65,7 +82,8 @@ struct AnnouncementsCard: View {
 }
 
 /// Single announcement row. Critical entries get a 3pt-wide red left
-/// edge accent; info entries are plain `bgCard`.
+/// edge accent; info entries are plain `bgCard`. Body renders as
+/// markdown when parseable; otherwise falls back to plain text.
 private struct AnnouncementRow: View {
     let announcement: LeagueAnnouncement
 
@@ -92,7 +110,7 @@ private struct AnnouncementRow: View {
                     Spacer()
                 }
 
-                Text(announcement.body)
+                bodyText
                     .font(.caption)
                     .foregroundStyle(XomperColors.textSecondary)
                     .multilineTextAlignment(.leading)
@@ -105,10 +123,28 @@ private struct AnnouncementRow: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(announcement.priority == .critical ? "Critical: " : "")\(announcement.title). \(announcement.body)")
     }
+
+    /// Markdown-aware body. `AttributedString(markdown:)` honours
+    /// **bold**, _italic_, [links](url), and inline code. On parse
+    /// failure (malformed input), fall back to plain `Text` so a
+    /// single bad row doesn't blank the card.
+    @ViewBuilder
+    private var bodyText: some View {
+        if let attributed = try? AttributedString(
+            markdown: announcement.body,
+            options: AttributedString.MarkdownParsingOptions(
+                interpretedSyntax: .inlineOnlyPreservingWhitespace
+            )
+        ) {
+            Text(attributed)
+        } else {
+            Text(announcement.body)
+        }
+    }
 }
 
 #Preview {
-    AnnouncementsCard()
+    AnnouncementsCard(store: AnnouncementsStore())
         .padding()
         .background(XomperColors.bgDark)
         .preferredColorScheme(.dark)

--- a/Xomper/Features/Landing/LandingView.swift
+++ b/Xomper/Features/Landing/LandingView.swift
@@ -38,6 +38,7 @@ struct LandingView: View {
     var authStore: AuthStore
     var nflStateStore: NflStateStore
     var aiReviewStore: AIReviewStore
+    var announcementsStore: AnnouncementsStore
     var navStore: NavigationStore
     var router: AppRouter
 
@@ -52,7 +53,7 @@ struct LandingView: View {
                     router: router
                 )
 
-                AnnouncementsCard()
+                AnnouncementsCard(store: announcementsStore)
 
                 StandingsScrollBar(
                     leagueStore: leagueStore,
@@ -96,8 +97,9 @@ struct LandingView: View {
         async let ai:       () = aiReviewStore.refresh()
         async let nfl:      () = nflStateStore.fetchState()
         async let league:   () = leagueStore.loadMyLeague()
+        async let ann:      () = announcementsStore.load(force: true)
         async let matchups: () = matchupsController.bumpAndWait()
-        _ = await (ai, nfl, league, matchups)
+        _ = await (ai, nfl, league, ann, matchups)
     }
 }
 
@@ -108,6 +110,7 @@ struct LandingView: View {
             authStore: AuthStore(),
             nflStateStore: NflStateStore(),
             aiReviewStore: AIReviewStore(),
+            announcementsStore: AnnouncementsStore(),
             navStore: NavigationStore(),
             router: AppRouter()
         )

--- a/Xomper/Features/Landing/LeagueAnnouncement.swift
+++ b/Xomper/Features/Landing/LeagueAnnouncement.swift
@@ -1,16 +1,34 @@
 import Foundation
 
 /// A single league announcement surfaced on the Landing page's
-/// `AnnouncementsCard`. v1 is a hardcoded list (see
-/// `LeagueAnnouncements.current` below); v2 may move this to Supabase.
+/// `AnnouncementsCard`.
+///
+/// v2 (announcements feature): backed by Supabase `league_announcements`
+/// table via the public `GET /announcements` endpoint and the four
+/// admin CRUD endpoints. `LeagueAnnouncements.current` is retained as
+/// a fallback array for when the public read fails — the Landing page
+/// never blanks (acceptance criterion).
 ///
 /// `expiresAt` is consulted at render time — entries past their
 /// expiry are filtered out by `AnnouncementsCard`. `nil` means the
 /// entry is permanent until removed manually.
-struct LeagueAnnouncement: Identifiable, Sendable {
-    enum Priority: Sendable {
+///
+/// `displayOrder` is a secondary sort key behind priority (critical
+/// first), used by the admin to nudge ordering within a priority
+/// bucket without changing the priority itself.
+struct LeagueAnnouncement: Identifiable, Sendable, Hashable, Codable {
+    enum Priority: String, Sendable, Codable, CaseIterable {
         case critical
         case info
+
+        /// Unknown / unrecognised wire string → default to `.info`.
+        /// Keeps the decoder resilient if the backend adds a new
+        /// priority before the iOS app rolls out support.
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let raw = (try? container.decode(String.self)) ?? "info"
+            self = Priority(rawValue: raw) ?? .info
+        }
     }
 
     let id: UUID
@@ -20,24 +38,125 @@ struct LeagueAnnouncement: Identifiable, Sendable {
     /// Hard cutoff — when `Date() >= expiresAt`, the entry is filtered
     /// out by the card. `nil` = always visible.
     let expiresAt: Date?
+    /// True when the row is visible to non-admin readers. Admin list
+    /// surfaces all rows regardless. Public read only returns rows
+    /// where `is_active = true`.
+    let isActive: Bool
+    /// Secondary sort key behind priority. Lower numbers float to the
+    /// top of a priority bucket. Defaults to 0 for fallback rows.
+    let displayOrder: Int
+    /// Server timestamps — informational only on the admin list, not
+    /// rendered on the public card.
+    let createdAt: Date?
+    let updatedAt: Date?
 
     init(
         id: UUID = UUID(),
         title: String,
         body: String,
         priority: Priority,
-        expiresAt: Date? = nil
+        expiresAt: Date? = nil,
+        isActive: Bool = true,
+        displayOrder: Int = 0,
+        createdAt: Date? = nil,
+        updatedAt: Date? = nil
     ) {
         self.id = id
         self.title = title
         self.body = body
         self.priority = priority
         self.expiresAt = expiresAt
+        self.isActive = isActive
+        self.displayOrder = displayOrder
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    // MARK: - Codable
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case body
+        case priority
+        case expiresAt = "expires_at"
+        case isActive = "is_active"
+        case displayOrder = "display_order"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        // `id` may arrive as a UUID string; default to a fresh one on
+        // decode failure to avoid crashing the list — the row is still
+        // displayable, just not addressable by stable id.
+        if let raw = try? c.decode(String.self, forKey: .id),
+           let uuid = UUID(uuidString: raw) {
+            self.id = uuid
+        } else {
+            self.id = UUID()
+        }
+        self.title = (try? c.decode(String.self, forKey: .title)) ?? ""
+        self.body = (try? c.decode(String.self, forKey: .body)) ?? ""
+        self.priority = (try? c.decode(Priority.self, forKey: .priority)) ?? .info
+        self.expiresAt = Self.decodeISODate(c, key: .expiresAt)
+        self.isActive = (try? c.decode(Bool.self, forKey: .isActive)) ?? true
+        self.displayOrder = (try? c.decode(Int.self, forKey: .displayOrder)) ?? 0
+        self.createdAt = Self.decodeISODate(c, key: .createdAt)
+        self.updatedAt = Self.decodeISODate(c, key: .updatedAt)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id.uuidString, forKey: .id)
+        try c.encode(title, forKey: .title)
+        try c.encode(body, forKey: .body)
+        try c.encode(priority.rawValue, forKey: .priority)
+        try c.encodeIfPresent(expiresAt.map(Self.iso8601Formatter.string(from:)), forKey: .expiresAt)
+        try c.encode(isActive, forKey: .isActive)
+        try c.encode(displayOrder, forKey: .displayOrder)
+        try c.encodeIfPresent(createdAt.map(Self.iso8601Formatter.string(from:)), forKey: .createdAt)
+        try c.encodeIfPresent(updatedAt.map(Self.iso8601Formatter.string(from:)), forKey: .updatedAt)
+    }
+
+    // MARK: - ISO8601 helpers
+
+    /// Backend writes ISO8601 UTC timestamps. Accept both with and
+    /// without fractional seconds (Postgres `timestamptz` can serialise
+    /// either way depending on column type). `ISO8601DateFormatter` is
+    /// thread-safe for read-only access once configured; the
+    /// `nonisolated(unsafe)` annotation acknowledges Swift 6 strict
+    /// concurrency without forcing every caller through `@MainActor`.
+    nonisolated(unsafe) private static let iso8601Formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    nonisolated(unsafe) private static let iso8601FormatterFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static func decodeISODate(
+        _ container: KeyedDecodingContainer<CodingKeys>,
+        key: CodingKeys
+    ) -> Date? {
+        guard let raw = try? container.decodeIfPresent(String.self, forKey: key),
+              !raw.isEmpty else { return nil }
+        if let date = iso8601Formatter.date(from: raw) {
+            return date
+        }
+        return iso8601FormatterFractional.date(from: raw)
     }
 }
 
-/// Hardcoded league announcements for v1. Edit this array to add or
-/// retire entries — there is no admin UI for v1.
+/// Hardcoded league announcements used as fallback when the public
+/// `/announcements` read fails (acceptance criterion: Landing never
+/// blanks). The store uses this list when `announcements.isEmpty` and
+/// `error != nil`.
 ///
 /// Filtering + sorting (critical first) happens at render time in
 /// `AnnouncementsCard.visible`.

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -48,6 +48,12 @@ struct MainShell: View {
     /// Single-instance to keep optimistic toggles + pending-row state
     /// stable across re-renders during the in-flight POST.
     @State private var cronSettingsStore = CronSettingsStore()
+    /// announcements: drives the Landing → Announcements card (public
+    /// read) and the Admin → Announcements sub-screen (admin CRUD).
+    /// Single instance so optimistic admin mutations land on the same
+    /// public-read array the Landing card observes — saves a refetch
+    /// after a successful save.
+    @State private var announcementsStore = AnnouncementsStore()
 
     // MARK: - Body
 
@@ -148,6 +154,7 @@ struct MainShell: View {
                     authStore: authStore,
                     nflStateStore: nflStateStore,
                     aiReviewStore: aiReviewStore,
+                    announcementsStore: announcementsStore,
                     navStore: navStore,
                     router: router
                 )
@@ -538,6 +545,12 @@ struct MainShell: View {
 
         case .adminCronSettings:
             CronSettingsView(store: cronSettingsStore)
+
+        case .adminAnnouncements:
+            AnnouncementsListView(store: announcementsStore, router: router)
+
+        case .adminAnnouncementEdit(let id):
+            AnnouncementEditView(id: id, store: announcementsStore, router: router)
 
         case .adminAIReviewPreview(let reportType):
             AIReviewPreviewView(

--- a/Xomper/Navigation/AppRouter.swift
+++ b/Xomper/Navigation/AppRouter.swift
@@ -68,6 +68,15 @@ enum AppRoute: Hashable {
     /// sub-screen (per-lambda kill switch + test-mode toggles).
     case adminCronSettings
 
+    /// Pushed from `AdminView`'s menu — opens the Announcements
+    /// admin list (all rows including inactive + expired).
+    case adminAnnouncements
+
+    /// Pushed from `AnnouncementsListView` — typed edit form for one
+    /// `league_announcements` row. `id == nil` means create a new row;
+    /// otherwise edit the row with that uuid.
+    case adminAnnouncementEdit(id: UUID?)
+
     // MARK: - Admin Portal (F4)
 
     /// Pushed from `TablesSubScreenView` — list of all

--- a/XomperTests/AIReviewStoreTests.swift
+++ b/XomperTests/AIReviewStoreTests.swift
@@ -372,6 +372,14 @@ final class MockXomperAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
     func fetchCronSettings() async throws -> CronSettingsListResponse { throw Unsupported.method }
     func updateCronSetting(cronKey: String, enabled: Bool?, testMode: Bool?) async throws -> CronSettingUpdateResponse { throw Unsupported.method }
 
+    // MARK: - announcements — unused here.
+
+    func fetchAnnouncements() async throws -> AnnouncementsListResponse { throw Unsupported.method }
+    func fetchAdminAnnouncements() async throws -> AdminAnnouncementsListResponse { throw Unsupported.method }
+    func createAnnouncement(title: String, body: String, priority: String, expiresAt: Date?, isActive: Bool, displayOrder: Int) async throws -> AnnouncementMutationResponse { throw Unsupported.method }
+    func updateAnnouncement(id: UUID, fields: [String: AdminFieldValue]) async throws -> AnnouncementMutationResponse { throw Unsupported.method }
+    func deleteAnnouncement(id: UUID) async throws -> AnnouncementMutationResponse { throw Unsupported.method }
+
     enum Unsupported: Error { case method }
 }
 

--- a/XomperTests/AdminStoreTests.swift
+++ b/XomperTests/AdminStoreTests.swift
@@ -310,6 +310,13 @@ final class MockAdminAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
     // admin-cron-settings — unused here.
     func fetchCronSettings() async throws -> CronSettingsListResponse { throw MockError.unsupported }
     func updateCronSetting(cronKey: String, enabled: Bool?, testMode: Bool?) async throws -> CronSettingUpdateResponse { throw MockError.unsupported }
+
+    // announcements — unused here.
+    func fetchAnnouncements() async throws -> AnnouncementsListResponse { throw MockError.unsupported }
+    func fetchAdminAnnouncements() async throws -> AdminAnnouncementsListResponse { throw MockError.unsupported }
+    func createAnnouncement(title: String, body: String, priority: String, expiresAt: Date?, isActive: Bool, displayOrder: Int) async throws -> AnnouncementMutationResponse { throw MockError.unsupported }
+    func updateAnnouncement(id: UUID, fields: [String: AdminFieldValue]) async throws -> AnnouncementMutationResponse { throw MockError.unsupported }
+    func deleteAnnouncement(id: UUID) async throws -> AnnouncementMutationResponse { throw MockError.unsupported }
 }
 
 enum MockError: Error, LocalizedError {

--- a/XomperTests/AdminTablesStoreTests.swift
+++ b/XomperTests/AdminTablesStoreTests.swift
@@ -436,6 +436,11 @@ final class MockAdminTablesAPIClient: XomperAPIClientProtocol, @unchecked Sendab
     func fetchLogEvents(logGroup: LogGroup, level: LogLevel?, search: String?, limit: Int, cursor: String?) async throws -> LogsQueryResponse { throw AdminTablesMockError.unsupported }
     func fetchCronSettings() async throws -> CronSettingsListResponse { throw AdminTablesMockError.unsupported }
     func updateCronSetting(cronKey: String, enabled: Bool?, testMode: Bool?) async throws -> CronSettingUpdateResponse { throw AdminTablesMockError.unsupported }
+    func fetchAnnouncements() async throws -> AnnouncementsListResponse { throw AdminTablesMockError.unsupported }
+    func fetchAdminAnnouncements() async throws -> AdminAnnouncementsListResponse { throw AdminTablesMockError.unsupported }
+    func createAnnouncement(title: String, body: String, priority: String, expiresAt: Date?, isActive: Bool, displayOrder: Int) async throws -> AnnouncementMutationResponse { throw AdminTablesMockError.unsupported }
+    func updateAnnouncement(id: UUID, fields: [String: AdminFieldValue]) async throws -> AnnouncementMutationResponse { throw AdminTablesMockError.unsupported }
+    func deleteAnnouncement(id: UUID) async throws -> AnnouncementMutationResponse { throw AdminTablesMockError.unsupported }
 }
 
 enum AdminTablesMockError: Error, LocalizedError {

--- a/XomperTests/AnnouncementsStoreTests.swift
+++ b/XomperTests/AnnouncementsStoreTests.swift
@@ -1,0 +1,396 @@
+import XCTest
+@testable import Xomper
+
+/// Drives `AnnouncementsStore` through its public-read + admin CRUD
+/// paths using a mock `XomperAPIClientProtocol`. Covers:
+/// happy-path load, 5-min cache hit, fallback to
+/// `LeagueAnnouncements.current` on error, admin loadAdmin + tableMissing,
+/// optimistic create/update/delete, revert on error.
+@MainActor
+final class AnnouncementsStoreTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeAnnouncement(
+        id: UUID = UUID(),
+        title: String = "Test",
+        priority: LeagueAnnouncement.Priority = .info,
+        expiresAt: Date? = nil,
+        isActive: Bool = true,
+        displayOrder: Int = 0
+    ) -> LeagueAnnouncement {
+        LeagueAnnouncement(
+            id: id,
+            title: title,
+            body: "body",
+            priority: priority,
+            expiresAt: expiresAt,
+            isActive: isActive,
+            displayOrder: displayOrder
+        )
+    }
+
+    // MARK: - Public load
+
+    func test_load_populatesFromMock() async {
+        let row = makeAnnouncement(title: "Draft is July 6", priority: .critical)
+        let mock = MockAnnouncementsAPIClient(
+            publicResponse: AnnouncementsListResponse(success: true, count: 1, rows: [row])
+        )
+        let store = AnnouncementsStore(apiClient: mock)
+
+        await store.load()
+
+        XCTAssertEqual(store.announcements.count, 1)
+        XCTAssertEqual(store.announcements.first?.title, "Draft is July 6")
+        XCTAssertNil(store.error)
+        XCTAssertNotNil(store.lastLoadedAt)
+    }
+
+    func test_load_cacheShortCircuitsWithinFiveMinutes() async {
+        let row = makeAnnouncement(title: "Cached")
+        let mock = MockAnnouncementsAPIClient(
+            publicResponse: AnnouncementsListResponse(success: true, count: 1, rows: [row])
+        )
+        let store = AnnouncementsStore(apiClient: mock)
+
+        await store.load()
+        XCTAssertEqual(mock.publicCallCount, 1)
+
+        // Second call within 5 min should be a no-op.
+        await store.load()
+        XCTAssertEqual(mock.publicCallCount, 1, "Second load within cache window should be a no-op.")
+    }
+
+    func test_load_forceBypassesCache() async {
+        let row = makeAnnouncement(title: "Bypass")
+        let mock = MockAnnouncementsAPIClient(
+            publicResponse: AnnouncementsListResponse(success: true, count: 1, rows: [row])
+        )
+        let store = AnnouncementsStore(apiClient: mock)
+
+        await store.load()
+        await store.load(force: true)
+
+        XCTAssertEqual(mock.publicCallCount, 2)
+    }
+
+    func test_load_apiFailureFallsBackToHardcodedList() async {
+        let mock = MockAnnouncementsAPIClient(publicError: MockAnnouncementError.boom)
+        let store = AnnouncementsStore(apiClient: mock)
+
+        await store.load()
+
+        XCTAssertNotNil(store.error)
+        XCTAssertFalse(store.announcements.isEmpty, "Should fall back to LeagueAnnouncements.current.")
+        XCTAssertEqual(store.announcements.count, LeagueAnnouncements.current.count)
+    }
+
+    func test_load_apiFailurePreservesExistingRowsWhenNonEmpty() async {
+        // Successful first load, then a forced failing reload should keep
+        // the existing rows on screen (no fallback overwrite).
+        let row = makeAnnouncement(title: "Existing")
+        let mock = MockAnnouncementsAPIClient(
+            publicResponse: AnnouncementsListResponse(success: true, count: 1, rows: [row])
+        )
+        let store = AnnouncementsStore(apiClient: mock)
+        await store.load()
+        XCTAssertEqual(store.announcements.first?.title, "Existing")
+
+        mock.publicError = MockAnnouncementError.boom
+        await store.load(force: true)
+
+        XCTAssertNotNil(store.error)
+        XCTAssertEqual(store.announcements.first?.title, "Existing")
+    }
+
+    // MARK: - Admin load
+
+    func test_loadAdmin_populatesIncludesAllRows() async {
+        let active = makeAnnouncement(title: "Live", isActive: true)
+        let inactive = makeAnnouncement(title: "Archived", isActive: false)
+        let mock = MockAnnouncementsAPIClient(
+            adminResponse: AdminAnnouncementsListResponse(success: true, count: 2, rows: [active, inactive], tableMissing: false)
+        )
+        let store = AnnouncementsStore(apiClient: mock)
+
+        await store.loadAdmin()
+
+        XCTAssertEqual(store.adminAnnouncements.count, 2)
+        XCTAssertFalse(store.tableMissing)
+    }
+
+    func test_loadAdmin_tableMissingFlagsEmptyState() async {
+        let mock = MockAnnouncementsAPIClient(
+            adminResponse: AdminAnnouncementsListResponse(success: true, count: 0, rows: [], tableMissing: true)
+        )
+        let store = AnnouncementsStore(apiClient: mock)
+
+        await store.loadAdmin()
+
+        XCTAssertTrue(store.adminAnnouncements.isEmpty)
+        XCTAssertTrue(store.tableMissing)
+    }
+
+    // MARK: - Admin create
+
+    func test_create_optimisticAndReplacesWithServerRow() async throws {
+        let serverRow = makeAnnouncement(title: "Server-resolved")
+        let mock = MockAnnouncementsAPIClient(
+            mutationResponse: AnnouncementMutationResponse(success: true, row: serverRow)
+        )
+        let store = AnnouncementsStore(apiClient: mock)
+
+        let result = try await store.create(
+            title: "Server-resolved",
+            body: "body",
+            priority: .info,
+            expiresAt: nil,
+            isActive: true,
+            displayOrder: 0
+        )
+
+        XCTAssertEqual(result.id, serverRow.id)
+        XCTAssertEqual(store.adminAnnouncements.count, 1)
+        XCTAssertEqual(store.adminAnnouncements.first?.id, serverRow.id)
+        // Active row should also have appeared on the public list.
+        XCTAssertEqual(store.announcements.count, 1)
+    }
+
+    func test_create_revertsOnError() async {
+        let mock = MockAnnouncementsAPIClient(mutationError: MockAnnouncementError.boom)
+        let store = AnnouncementsStore(apiClient: mock)
+
+        do {
+            _ = try await store.create(
+                title: "Will fail",
+                body: "body",
+                priority: .info,
+                expiresAt: nil,
+                isActive: true,
+                displayOrder: 0
+            )
+            XCTFail("create should throw on backend error")
+        } catch {
+            XCTAssertTrue(store.adminAnnouncements.isEmpty, "Optimistic insert should be reverted.")
+            XCTAssertNotNil(store.lastWriteError)
+        }
+    }
+
+    // MARK: - Admin update
+
+    func test_update_optimisticAndReconcile() async throws {
+        let originalId = UUID()
+        let original = makeAnnouncement(id: originalId, title: "Old")
+        let server = LeagueAnnouncement(
+            id: originalId,
+            title: "New",
+            body: original.body,
+            priority: original.priority,
+            expiresAt: original.expiresAt,
+            isActive: original.isActive,
+            displayOrder: original.displayOrder
+        )
+        let mock = MockAnnouncementsAPIClient(
+            adminResponse: AdminAnnouncementsListResponse(success: true, count: 1, rows: [original], tableMissing: false),
+            mutationResponse: AnnouncementMutationResponse(success: true, row: server)
+        )
+        let store = AnnouncementsStore(apiClient: mock)
+        await store.loadAdmin()
+
+        _ = try await store.update(id: originalId, fields: ["title": .string("New")])
+
+        XCTAssertEqual(store.adminAnnouncements.first?.title, "New")
+    }
+
+    func test_update_revertsOnError() async {
+        let originalId = UUID()
+        let original = makeAnnouncement(id: originalId, title: "Old")
+        let mock = MockAnnouncementsAPIClient(
+            adminResponse: AdminAnnouncementsListResponse(success: true, count: 1, rows: [original], tableMissing: false),
+            mutationError: MockAnnouncementError.boom
+        )
+        let store = AnnouncementsStore(apiClient: mock)
+        await store.loadAdmin()
+
+        do {
+            _ = try await store.update(id: originalId, fields: ["title": .string("New")])
+            XCTFail("update should throw")
+        } catch {
+            XCTAssertEqual(store.adminAnnouncements.first?.title, "Old", "Optimistic mutation should revert.")
+            XCTAssertNotNil(store.lastWriteError)
+        }
+    }
+
+    func test_update_unknownIdThrows() async {
+        let store = AnnouncementsStore(apiClient: MockAnnouncementsAPIClient())
+
+        do {
+            _ = try await store.update(id: UUID(), fields: ["title": .string("nope")])
+            XCTFail("update with unknown id should throw")
+        } catch {
+            XCTAssertTrue(error is AnnouncementsStoreError)
+        }
+    }
+
+    // MARK: - Admin delete
+
+    func test_delete_softFlipAndDropsFromPublic() async throws {
+        let id = UUID()
+        let original = makeAnnouncement(id: id, isActive: true)
+        let deleted = LeagueAnnouncement(
+            id: id,
+            title: original.title,
+            body: original.body,
+            priority: original.priority,
+            expiresAt: original.expiresAt,
+            isActive: false,
+            displayOrder: original.displayOrder
+        )
+        let mock = MockAnnouncementsAPIClient(
+            publicResponse: AnnouncementsListResponse(success: true, count: 1, rows: [original]),
+            adminResponse: AdminAnnouncementsListResponse(success: true, count: 1, rows: [original], tableMissing: false),
+            mutationResponse: AnnouncementMutationResponse(success: true, row: deleted)
+        )
+        let store = AnnouncementsStore(apiClient: mock)
+        await store.load()
+        await store.loadAdmin()
+        XCTAssertEqual(store.announcements.count, 1)
+
+        try await store.delete(id: id)
+
+        XCTAssertEqual(store.adminAnnouncements.first?.isActive, false)
+        XCTAssertTrue(store.announcements.isEmpty, "Public list should drop the deleted row.")
+    }
+
+    func test_delete_revertsOnError() async {
+        let id = UUID()
+        let original = makeAnnouncement(id: id, isActive: true)
+        let mock = MockAnnouncementsAPIClient(
+            publicResponse: AnnouncementsListResponse(success: true, count: 1, rows: [original]),
+            adminResponse: AdminAnnouncementsListResponse(success: true, count: 1, rows: [original], tableMissing: false),
+            mutationError: MockAnnouncementError.boom
+        )
+        let store = AnnouncementsStore(apiClient: mock)
+        await store.load()
+        await store.loadAdmin()
+
+        do {
+            try await store.delete(id: id)
+            XCTFail("delete should throw")
+        } catch {
+            XCTAssertEqual(store.adminAnnouncements.first?.isActive, true, "Soft-delete flip should revert.")
+            XCTAssertEqual(store.announcements.count, 1, "Public list should be restored.")
+            XCTAssertNotNil(store.lastWriteError)
+        }
+    }
+}
+
+// MARK: - Mock
+
+final class MockAnnouncementsAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
+    var publicResponse: AnnouncementsListResponse?
+    var publicError: Error?
+    var adminResponse: AdminAnnouncementsListResponse?
+    var adminError: Error?
+    var mutationResponse: AnnouncementMutationResponse?
+    var mutationError: Error?
+
+    private(set) var publicCallCount: Int = 0
+    private(set) var adminCallCount: Int = 0
+    private(set) var createCalls: [(title: String, body: String, priority: String, expiresAt: Date?, isActive: Bool, displayOrder: Int)] = []
+    private(set) var updateCalls: [(id: UUID, fields: [String: AdminFieldValue])] = []
+    private(set) var deleteCalls: [UUID] = []
+
+    init(
+        publicResponse: AnnouncementsListResponse? = nil,
+        publicError: Error? = nil,
+        adminResponse: AdminAnnouncementsListResponse? = nil,
+        adminError: Error? = nil,
+        mutationResponse: AnnouncementMutationResponse? = nil,
+        mutationError: Error? = nil
+    ) {
+        self.publicResponse = publicResponse
+        self.publicError = publicError
+        self.adminResponse = adminResponse
+        self.adminError = adminError
+        self.mutationResponse = mutationResponse
+        self.mutationError = mutationError
+    }
+
+    func fetchAnnouncements() async throws -> AnnouncementsListResponse {
+        publicCallCount += 1
+        if let err = publicError { throw err }
+        return publicResponse ?? AnnouncementsListResponse(success: true, count: 0, rows: [])
+    }
+
+    func fetchAdminAnnouncements() async throws -> AdminAnnouncementsListResponse {
+        adminCallCount += 1
+        if let err = adminError { throw err }
+        return adminResponse ?? AdminAnnouncementsListResponse(success: true, count: 0, rows: [], tableMissing: false)
+    }
+
+    func createAnnouncement(title: String, body: String, priority: String, expiresAt: Date?, isActive: Bool, displayOrder: Int) async throws -> AnnouncementMutationResponse {
+        createCalls.append((title, body, priority, expiresAt, isActive, displayOrder))
+        if let err = mutationError { throw err }
+        guard let response = mutationResponse else { throw MockAnnouncementError.notConfigured }
+        return response
+    }
+
+    func updateAnnouncement(id: UUID, fields: [String: AdminFieldValue]) async throws -> AnnouncementMutationResponse {
+        updateCalls.append((id, fields))
+        if let err = mutationError { throw err }
+        guard let response = mutationResponse else { throw MockAnnouncementError.notConfigured }
+        return response
+    }
+
+    func deleteAnnouncement(id: UUID) async throws -> AnnouncementMutationResponse {
+        deleteCalls.append(id)
+        if let err = mutationError { throw err }
+        guard let response = mutationResponse else { throw MockAnnouncementError.notConfigured }
+        return response
+    }
+
+    // MARK: - Unused protocol surface
+
+    func sendRuleProposalEmail(proposal: RuleProposalEmailPayload, recipients: [String], userIds: [String]) async throws { throw MockAnnouncementError.unsupported }
+    func sendRuleAcceptedEmail(proposal: RuleProposalEmailPayload, approvedBy: [String], rejectedBy: [String], recipients: [String], userIds: [String]) async throws { throw MockAnnouncementError.unsupported }
+    func sendRuleDeniedEmail(proposal: RuleProposalEmailPayload, approvedBy: [String], rejectedBy: [String], recipients: [String], userIds: [String]) async throws { throw MockAnnouncementError.unsupported }
+    func sendTaxiStealEmail(stealer: TaxiStealerPayload, player: TaxiPlayerPayload, owner: TaxiOwnerPayload, recipients: [String], userIds: [String], leagueName: String) async throws { throw MockAnnouncementError.unsupported }
+    func registerDevice(userId: String, deviceToken: String) async throws { throw MockAnnouncementError.unsupported }
+    func unregisterDevice(userId: String, deviceToken: String) async throws { throw MockAnnouncementError.unsupported }
+    func adminListNotifications(sleeperUserId: String, daysBack: Int, kind: String?, status: String?, limit: Int) async throws -> AdminNotificationsResponse { throw MockAnnouncementError.unsupported }
+    func adminTestSend(sleeperUserId: String, email: String?, kind: String, channels: [String]) async throws -> AdminTestSendResponse { throw MockAnnouncementError.unsupported }
+    func fetchTestEmailRecipients() async throws -> [TestEmailRecipient] { throw MockAnnouncementError.unsupported }
+    func sendTestEmail(recipientSleeperUserId: String, reportId: String) async throws -> TestEmailResponse { throw MockAnnouncementError.unsupported }
+    func fetchLatestAIReport(type: AIReportType) async throws -> AIReport? { nil }
+    func fetchAIReportsList(type: AIReportType?, limit: Int, cursor: String?) async throws -> AIReportsListResponse { AIReportsListResponse(rows: [], nextCursor: nil) }
+    func fetchAIReportByPeriod(type: AIReportType, period: String) async throws -> AIReport? { nil }
+    func fetchMockDrafts() async throws -> [AIReport] { [] }
+    func triggerPostDraftAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw MockAnnouncementError.unsupported }
+    func triggerPreseasonAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw MockAnnouncementError.unsupported }
+    func triggerWeeklyAIReview(week: Int?, dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse { throw MockAnnouncementError.unsupported }
+    func setReportFlag(leagueId: String, reportType: AIReportType, period: String, flag: ReportFlag, value: Bool) async throws -> ReportFlagResponse { throw MockAnnouncementError.unsupported }
+    func fetchWhitelistedUsers() async throws -> [WhitelistedUser] { throw MockAnnouncementError.unsupported }
+    func updateWhitelistedUser(userId: String, fields: [String: AdminFieldValue]) async throws -> UserUpdateResponse { throw MockAnnouncementError.unsupported }
+    func fetchAdminWhitelistedLeagues() async throws -> [WhitelistedLeague] { throw MockAnnouncementError.unsupported }
+    func updateWhitelistedLeague(leagueId: String, fields: [String: AdminFieldValue]) async throws -> LeagueUpdateResponse { throw MockAnnouncementError.unsupported }
+    func fetchAuditEntries(limit: Int, cursor: String?) async throws -> AuditListResponse { throw MockAnnouncementError.unsupported }
+    func fetchLogEvents(logGroup: LogGroup, level: LogLevel?, search: String?, limit: Int, cursor: String?) async throws -> LogsQueryResponse { throw MockAnnouncementError.unsupported }
+    func fetchCronSettings() async throws -> CronSettingsListResponse { throw MockAnnouncementError.unsupported }
+    func updateCronSetting(cronKey: String, enabled: Bool?, testMode: Bool?) async throws -> CronSettingUpdateResponse { throw MockAnnouncementError.unsupported }
+}
+
+enum MockAnnouncementError: Error, LocalizedError {
+    case boom
+    case unsupported
+    case notConfigured
+
+    var errorDescription: String? {
+        switch self {
+        case .boom: "boom"
+        case .unsupported: "mock method not supported"
+        case .notConfigured: "mock response not configured"
+        }
+    }
+}

--- a/XomperTests/CronSettingsStoreTests.swift
+++ b/XomperTests/CronSettingsStoreTests.swift
@@ -290,6 +290,11 @@ final class MockCronSettingsAPIClient: XomperAPIClientProtocol, @unchecked Senda
     func updateWhitelistedLeague(leagueId: String, fields: [String: AdminFieldValue]) async throws -> LeagueUpdateResponse { throw CronMockError.unsupported }
     func fetchAuditEntries(limit: Int, cursor: String?) async throws -> AuditListResponse { throw CronMockError.unsupported }
     func fetchLogEvents(logGroup: LogGroup, level: LogLevel?, search: String?, limit: Int, cursor: String?) async throws -> LogsQueryResponse { throw CronMockError.unsupported }
+    func fetchAnnouncements() async throws -> AnnouncementsListResponse { throw CronMockError.unsupported }
+    func fetchAdminAnnouncements() async throws -> AdminAnnouncementsListResponse { throw CronMockError.unsupported }
+    func createAnnouncement(title: String, body: String, priority: String, expiresAt: Date?, isActive: Bool, displayOrder: Int) async throws -> AnnouncementMutationResponse { throw CronMockError.unsupported }
+    func updateAnnouncement(id: UUID, fields: [String: AdminFieldValue]) async throws -> AnnouncementMutationResponse { throw CronMockError.unsupported }
+    func deleteAnnouncement(id: UUID) async throws -> AnnouncementMutationResponse { throw CronMockError.unsupported }
 }
 
 enum CronMockError: Error, LocalizedError {

--- a/XomperTests/LandingViewTests.swift
+++ b/XomperTests/LandingViewTests.swift
@@ -70,6 +70,7 @@ final class LandingViewTests: XCTestCase {
             authStore: AuthStore(),
             nflStateStore: NflStateStore(),
             aiReviewStore: AIReviewStore(),
+            announcementsStore: AnnouncementsStore(),
             navStore: NavigationStore(),
             router: AppRouter()
         )

--- a/XomperTests/LeagueAnnouncementDecoderTests.swift
+++ b/XomperTests/LeagueAnnouncementDecoderTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+@testable import Xomper
+
+/// Wire-decode tests for `LeagueAnnouncement`. Covers the public-read
+/// shape from `/announcements` and the admin shape from
+/// `/admin/announcements-list`. Backend serialises ISO8601 UTC strings
+/// (with or without fractional seconds) for `expires_at`,
+/// `created_at`, `updated_at` and emits `null` for missing expiries.
+final class LeagueAnnouncementDecoderTests: XCTestCase {
+
+    // MARK: - Happy path
+
+    func test_decode_allFields() throws {
+        let json = """
+        {
+          "id": "11111111-2222-3333-4444-555555555555",
+          "title": "Draft is July 6",
+          "body": "6:30pm ET sharp.",
+          "priority": "critical",
+          "expires_at": "2026-07-07T00:00:00Z",
+          "is_active": true,
+          "display_order": 0,
+          "created_at": "2026-06-01T12:00:00Z",
+          "updated_at": "2026-06-01T12:00:00Z"
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+
+        let decoded = try JSONDecoder().decode(LeagueAnnouncement.self, from: data)
+
+        XCTAssertEqual(decoded.id.uuidString.lowercased(), "11111111-2222-3333-4444-555555555555")
+        XCTAssertEqual(decoded.title, "Draft is July 6")
+        XCTAssertEqual(decoded.body, "6:30pm ET sharp.")
+        XCTAssertEqual(decoded.priority, .critical)
+        XCTAssertNotNil(decoded.expiresAt)
+        XCTAssertTrue(decoded.isActive)
+        XCTAssertEqual(decoded.displayOrder, 0)
+        XCTAssertNotNil(decoded.createdAt)
+        XCTAssertNotNil(decoded.updatedAt)
+    }
+
+    // MARK: - Null + missing fields
+
+    func test_decode_nullExpiresAt() throws {
+        let json = """
+        {
+          "id": "11111111-2222-3333-4444-555555555555",
+          "title": "No expiry",
+          "body": "Body",
+          "priority": "info",
+          "expires_at": null,
+          "is_active": true,
+          "display_order": 1
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+
+        let decoded = try JSONDecoder().decode(LeagueAnnouncement.self, from: data)
+
+        XCTAssertNil(decoded.expiresAt)
+        XCTAssertNil(decoded.createdAt)
+        XCTAssertNil(decoded.updatedAt)
+        XCTAssertEqual(decoded.priority, .info)
+    }
+
+    func test_decode_missingOptionalFields() throws {
+        // Backend may omit display_order entirely when seeding. Decoder
+        // should default to 0 + treat the row as active.
+        let json = """
+        {
+          "id": "11111111-2222-3333-4444-555555555555",
+          "title": "Minimal",
+          "body": "Body",
+          "priority": "info"
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+
+        let decoded = try JSONDecoder().decode(LeagueAnnouncement.self, from: data)
+
+        XCTAssertEqual(decoded.displayOrder, 0)
+        XCTAssertTrue(decoded.isActive)
+    }
+
+    // MARK: - Priority enum resiliency
+
+    func test_decode_unknownPriorityFallsBackToInfo() throws {
+        // Defensive — if the backend adds a new priority before iOS
+        // ships support, the decoder should default to `.info` rather
+        // than throwing and blanking the card.
+        let json = """
+        {
+          "id": "11111111-2222-3333-4444-555555555555",
+          "title": "Future priority",
+          "body": "Body",
+          "priority": "URGENT",
+          "is_active": true,
+          "display_order": 0
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+
+        let decoded = try JSONDecoder().decode(LeagueAnnouncement.self, from: data)
+
+        XCTAssertEqual(decoded.priority, .info)
+    }
+
+    func test_decode_acceptsFractionalSecondTimestamps() throws {
+        // Postgres timestamptz can serialise with fractional seconds.
+        // Decoder accepts both shapes.
+        let json = """
+        {
+          "id": "11111111-2222-3333-4444-555555555555",
+          "title": "Frac",
+          "body": "Body",
+          "priority": "info",
+          "expires_at": "2026-07-07T12:34:56.789Z",
+          "is_active": true,
+          "display_order": 0
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+
+        let decoded = try JSONDecoder().decode(LeagueAnnouncement.self, from: data)
+
+        XCTAssertNotNil(decoded.expiresAt)
+    }
+
+    // MARK: - List response
+
+    func test_decode_publicListResponse() throws {
+        let json = """
+        {
+          "Success": true,
+          "count": 2,
+          "rows": [
+            {
+              "id": "11111111-2222-3333-4444-555555555555",
+              "title": "A",
+              "body": "Body A",
+              "priority": "critical",
+              "expires_at": null,
+              "is_active": true,
+              "display_order": 0
+            },
+            {
+              "id": "66666666-7777-8888-9999-aaaaaaaaaaaa",
+              "title": "B",
+              "body": "Body B",
+              "priority": "info",
+              "expires_at": null,
+              "is_active": true,
+              "display_order": 1
+            }
+          ]
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+
+        let response = try JSONDecoder().decode(AnnouncementsListResponse.self, from: data)
+
+        XCTAssertTrue(response.success)
+        XCTAssertEqual(response.count, 2)
+        XCTAssertEqual(response.rows.count, 2)
+        XCTAssertEqual(response.rows.first?.priority, .critical)
+    }
+
+    func test_decode_adminListWithTableMissing() throws {
+        let json = """
+        {
+          "Success": true,
+          "count": 0,
+          "rows": [],
+          "table_missing": true
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+
+        let response = try JSONDecoder().decode(AdminAnnouncementsListResponse.self, from: data)
+
+        XCTAssertTrue(response.tableMissing)
+        XCTAssertTrue(response.rows.isEmpty)
+    }
+}

--- a/XomperTests/LogsStoreTests.swift
+++ b/XomperTests/LogsStoreTests.swift
@@ -293,6 +293,11 @@ final class MockLogsAPIClient: XomperAPIClientProtocol, @unchecked Sendable {
     func fetchAuditEntries(limit: Int, cursor: String?) async throws -> AuditListResponse { throw LogsMockError.unsupported }
     func fetchCronSettings() async throws -> CronSettingsListResponse { throw LogsMockError.unsupported }
     func updateCronSetting(cronKey: String, enabled: Bool?, testMode: Bool?) async throws -> CronSettingUpdateResponse { throw LogsMockError.unsupported }
+    func fetchAnnouncements() async throws -> AnnouncementsListResponse { throw LogsMockError.unsupported }
+    func fetchAdminAnnouncements() async throws -> AdminAnnouncementsListResponse { throw LogsMockError.unsupported }
+    func createAnnouncement(title: String, body: String, priority: String, expiresAt: Date?, isActive: Bool, displayOrder: Int) async throws -> AnnouncementMutationResponse { throw LogsMockError.unsupported }
+    func updateAnnouncement(id: UUID, fields: [String: AdminFieldValue]) async throws -> AnnouncementMutationResponse { throw LogsMockError.unsupported }
+    func deleteAnnouncement(id: UUID) async throws -> AnnouncementMutationResponse { throw LogsMockError.unsupported }
 }
 
 enum LogsMockError: Error, LocalizedError {

--- a/XomperTests/TestEmailStoreTests.swift
+++ b/XomperTests/TestEmailStoreTests.swift
@@ -295,6 +295,13 @@ final class MockTestEmailAPIClient: XomperAPIClientProtocol, @unchecked Sendable
     // admin-cron-settings — unused here.
     func fetchCronSettings() async throws -> CronSettingsListResponse { throw TestEmailMockError.unsupported }
     func updateCronSetting(cronKey: String, enabled: Bool?, testMode: Bool?) async throws -> CronSettingUpdateResponse { throw TestEmailMockError.unsupported }
+
+    // announcements — unused here.
+    func fetchAnnouncements() async throws -> AnnouncementsListResponse { throw TestEmailMockError.unsupported }
+    func fetchAdminAnnouncements() async throws -> AdminAnnouncementsListResponse { throw TestEmailMockError.unsupported }
+    func createAnnouncement(title: String, body: String, priority: String, expiresAt: Date?, isActive: Bool, displayOrder: Int) async throws -> AnnouncementMutationResponse { throw TestEmailMockError.unsupported }
+    func updateAnnouncement(id: UUID, fields: [String: AdminFieldValue]) async throws -> AnnouncementMutationResponse { throw TestEmailMockError.unsupported }
+    func deleteAnnouncement(id: UUID) async throws -> AnnouncementMutationResponse { throw TestEmailMockError.unsupported }
 }
 
 enum TestEmailMockError: Error, LocalizedError {

--- a/docs/features/announcements/PLAN.md
+++ b/docs/features/announcements/PLAN.md
@@ -1,0 +1,245 @@
+# Plan: Admin-Editable League Announcements
+
+**Status**: Ready
+**Created**: 2026-06-01
+**Last updated**: 2026-06-01
+**Issue**: #100
+**Repos touched**: xomper-back-end (infra + backend), xomper-ios (UI + store)
+
+---
+
+## Summary
+
+Replace the hardcoded `LeagueAnnouncements.current` array (shipped in Season Refocus F2) with a Supabase-backed `league_announcements` table, four admin-gated CRUD endpoints, and one public-read endpoint. Add an admin sub-screen for create/edit/soft-delete. iOS Landing reads from a new `AnnouncementsStore`; on API failure, falls back to the existing hardcoded list so the Landing page never blanks.
+
+Success = commissioner adds/edits/expires announcements without an app deploy, league members see them on Landing within one cache refresh, and the audit trail captures every admin write.
+
+---
+
+## Approach
+
+Mirror the F4 admin pattern (users/leagues edit forms) on the iOS side and the F4 backend pattern (typed CRUD lambdas + `admin_audit` writes via `require_admin`) on the backend side. Add one new public-read endpoint that is JWT-gated but not admin-gated — any signed-in league member can read announcements.
+
+Soft delete only (`is_active=false`) — preserves audit trail. Hard delete is a Supabase dashboard chore if it ever comes up.
+
+Markdown support in body — small lift via `AttributedString(markdown:)` on iOS, lets the commissioner bold key dates.
+
+3 coordinated PRs:
+1. **Infra** — `terraform/lambdas_api.tf` with 5 new routes (1 public + 4 admin).
+2. **Backend** — migration, `announcements_store.py`, 5 lambda handlers, tests.
+3. **iOS** — `AnnouncementsStore`, API client methods, admin sub-screen, Landing card swap, feature flag, tests.
+
+PRs land in that order because backend depends on the infra routes, and iOS depends on the deployed backend.
+
+---
+
+## Affected Files / Components
+
+### xomper-back-end
+
+| File | Change | Why |
+|------|--------|-----|
+| `sql/announcements_migration.sql` | New — table + index + 3 seed rows | Manual-apply migration (same pattern as F4 `admin_audit` + `admin_cron_settings`). Seeds match current hardcoded entries so Landing content is preserved on cutover. |
+| `lambdas/common/announcements_store.py` | New — `list_active`, `list_all`, `create`, `update`, `delete` helpers | Single source of truth for query/filter/sort logic. Mirrors `cron_settings_store.py` shape. |
+| `lambdas/api_announcements/handler.py` | New — public read | Filters `is_active=true AND (expires_at IS NULL OR expires_at > now())`, sorted critical-first then `display_order`. JWT-gated but not admin-gated. |
+| `lambdas/api_admin_announcements_list/handler.py` | New — admin list (all rows) | Returns inactive + expired so admin can manage them. |
+| `lambdas/api_admin_announcements_create/handler.py` | New — admin create | Writes row + `admin_audit` entry (action=`announcements.create`). |
+| `lambdas/api_admin_announcements_update/handler.py` | New — admin update | Partial update via `fields` dict. Writes `admin_audit` (action=`announcements.update`) with before/after. |
+| `lambdas/api_admin_announcements_delete/handler.py` | New — admin soft delete | Sets `is_active=false`. Writes `admin_audit` (action=`announcements.delete`). |
+| `tests/test_announcements_store.py` | New | Unit-test store helpers (filter, sort, partial-update merge). |
+| `tests/test_api_announcements.py` | New | Integration-test public-read filter + sort. |
+| `tests/test_api_admin_announcements_*.py` | New (4 files) | Test each admin handler including admin gate + audit-row writes. |
+
+### terraform
+
+| File | Change | Why |
+|------|--------|-----|
+| `terraform/lambdas_api.tf` | Add 5 entries to lambda+route module list | 1 public (`GET /announcements`) + 4 admin (`GET /admin/announcements-list`, `POST /admin/announcements-create`, `POST /admin/announcements-update`, `POST /admin/announcements-delete`). Path-flattened per existing convention. |
+
+### xomper-ios
+
+| File | Change | Why |
+|------|--------|-----|
+| `Xomper/Features/Landing/LeagueAnnouncement.swift` | Modify — add `displayOrder: Int`, change `id` to `String` (or keep UUID and add separate `serverId: String?`), add `Codable` for wire decode | Match wire shape from `/announcements`. Keep `LeagueAnnouncements.current` as fallback. |
+| `Xomper/Core/Stores/AnnouncementsStore.swift` | New — `@Observable @MainActor` | Public surface state + admin CRUD. 5-min freshness cache for Landing reads. |
+| `Xomper/Core/Networking/XomperAPIClient.swift` | Modify — add `fetchAnnouncements()`, `adminListAnnouncements()`, `adminCreateAnnouncement(…)`, `adminUpdateAnnouncement(id:fields:)`, `adminDeleteAnnouncement(id:)` | Wire 5 new endpoints into protocol + impl. |
+| `Xomper/Features/Landing/AnnouncementsCard.swift` | Modify — read from `AnnouncementsStore`, render markdown body, fallback to hardcoded list on API error or while loading first time | Drop direct `LeagueAnnouncements.current` reference. Keep shimmer briefly on first load. |
+| `Xomper/Features/Admin/AnnouncementsListView.swift` | New | Lists all rows with status chips (ACTIVE/INACTIVE/EXPIRED) + priority chip. "+ New" button top-right pushes empty edit form. Swipe-to-delete on rows. |
+| `Xomper/Features/Admin/AnnouncementEditView.swift` | New | Form: title `TextField`, body `TextEditor`, priority `Picker`, `expires_at` `DatePicker` with "no expiry" toggle, `is_active` `Toggle`, `display_order` `Stepper`. Save → create or update. |
+| `Xomper/Features/Admin/AdminView.swift` | Modify — add menu row "Announcements" between AI Review and Tables (after Test Email / Cron Settings, before Tables) | Gated by `Config.AdminFlags.showAnnouncements`. |
+| `Xomper/Navigation/AppRouter.swift` | Modify — add `.adminAnnouncements` + `.adminAnnouncementEdit(id: String?)` cases | Two new routes; `id == nil` means new row. |
+| `Xomper/Features/Shell/MainShell.swift` | Modify — instantiate `AnnouncementsStore`, route `.adminAnnouncements` / `.adminAnnouncementEdit(id:)`, pass store to Landing + admin sub-screens | Single owner of the store; pass by reference per existing pattern. |
+| `Xomper/Config/Config.swift.template` | Modify — add `static let showAnnouncements: Bool = true` to `AdminFlags` | Match other admin flags. |
+| `Xomper/Config/Config.swift` | Modify (local) — same | Local copy. |
+| `.github/workflows/testflight-deploy.yml` | Modify — extend Config heredoc with new `showAnnouncements` flag | Keep CI Config in sync. |
+| `XomperTests/AnnouncementsStoreTests.swift` | New | Load happy path, API failure → fallback, 5-min cache hit, admin CRUD optimism. |
+| `XomperTests/LeagueAnnouncementDecoderTests.swift` | New | Wire decode + nullable `expires_at` handling + priority enum mapping. |
+
+---
+
+## Implementation Steps
+
+### Phase 1 — Infra (PR 1)
+
+- [ ] Add 5 lambda+route entries to `terraform/lambdas_api.tf`:
+  - [ ] `GET /announcements` (auth: jwt, not admin)
+  - [ ] `GET /admin/announcements-list` (auth: jwt + require_admin)
+  - [ ] `POST /admin/announcements-create` (auth: jwt + require_admin)
+  - [ ] `POST /admin/announcements-update` (auth: jwt + require_admin)
+  - [ ] `POST /admin/announcements-delete` (auth: jwt + require_admin)
+- [ ] `terraform plan` → confirm 5 lambdas, 5 routes, 5 integrations, 5 log groups
+- [ ] Merge + apply via existing TF GitHub Action
+
+### Phase 2 — Backend (PR 2)
+
+- [ ] Write `sql/announcements_migration.sql` with table + index + 3 seed rows (matching current hardcoded entries — draft date, rule proposals, season start)
+- [ ] Apply migration manually via Supabase dashboard SQL editor
+- [ ] Verify rows seeded via `SELECT * FROM league_announcements`
+- [ ] Write `lambdas/common/announcements_store.py`:
+  - [ ] `list_active() -> list[dict]` — apply filter + sort in SQL
+  - [ ] `list_all() -> list[dict]` — no filter, sort by `created_at DESC`
+  - [ ] `create(title, body, priority='info', expires_at=None, is_active=True, display_order=0) -> dict`
+  - [ ] `update(id, fields: dict) -> dict` — raise `NotFoundError` if no row matches
+  - [ ] `delete(id) -> dict` — soft delete via `is_active=false`
+- [ ] Write 5 handlers (each ~40 lines, mirror `api_admin_cron_settings_update/handler.py` shape):
+  - [ ] `api_announcements` — public read, no admin check
+  - [ ] `api_admin_announcements_list` — `require_admin`, returns all rows
+  - [ ] `api_admin_announcements_create` — `require_admin`, audit write
+  - [ ] `api_admin_announcements_update` — `require_admin`, partial fields, audit write with before/after
+  - [ ] `api_admin_announcements_delete` — `require_admin`, soft delete, audit write
+- [ ] Write tests:
+  - [ ] `test_announcements_store.py` — filter/sort/update-merge unit tests
+  - [ ] `test_api_announcements.py` — public-read filter behavior
+  - [ ] `test_api_admin_announcements_list.py` — admin gate + returns inactive
+  - [ ] `test_api_admin_announcements_create.py` — happy path + audit write
+  - [ ] `test_api_admin_announcements_update.py` — partial update + audit before/after
+  - [ ] `test_api_admin_announcements_delete.py` — soft delete + audit
+- [ ] Run full backend test suite, confirm green
+- [ ] Smoke-test `/announcements` against staging from Postman/curl with a real JWT
+- [ ] Merge PR
+
+### Phase 3 — iOS (PR 3)
+
+- [ ] Extend `LeagueAnnouncement.swift`:
+  - [ ] Conform to `Codable` with `CodingKeys` mapping snake_case → camelCase
+  - [ ] Add `displayOrder: Int` (default 0 for hardcoded fallback)
+  - [ ] Keep `LeagueAnnouncements.current` array intact (used as fallback)
+- [ ] Build `AnnouncementsStore`:
+  - [ ] State: `announcements: [LeagueAnnouncement]`, `isLoading`, `error`, `lastLoadedAt: Date?`
+  - [ ] Admin state: `adminRows: [LeagueAnnouncement]`, `isLoadingAdmin`, `adminError`, `pendingIds: Set<String>`, `lastWriteError`
+  - [ ] `func load(force: Bool = false) async` — 5-min freshness gate, falls back to `LeagueAnnouncements.current` on failure
+  - [ ] `func loadAdmin() async`
+  - [ ] `func create(…) async throws -> LeagueAnnouncement`
+  - [ ] `func update(id:fields:) async throws -> LeagueAnnouncement`
+  - [ ] `func delete(id:) async throws` — optimistic flip then refetch
+- [ ] Add 5 methods to `XomperAPIClientProtocol` + impl with proper request/response codables
+- [ ] Modify `AnnouncementsCard.swift`:
+  - [ ] Take `store: AnnouncementsStore` parameter
+  - [ ] `visible` reads `store.announcements` (post-fallback)
+  - [ ] First-load shimmer (3 placeholder rows) — only when `isLoading && announcements.isEmpty`
+  - [ ] Render body via `AttributedString(markdown:)` with fallback to plain Text on parse failure
+- [ ] Build `AnnouncementsListView`:
+  - [ ] List of all rows from `store.adminRows`
+  - [ ] Each row: title + priority chip (red for critical) + status chips (ACTIVE/INACTIVE/EXPIRED)
+  - [ ] Top-trailing toolbar "+ New" → `router.navigate(to: .adminAnnouncementEdit(id: nil))`
+  - [ ] Swipe-to-delete calls `store.delete(id:)` with confirmation alert
+  - [ ] Pull-to-refresh
+  - [ ] Loading/error/empty states matching `LeagueEditView` chrome
+- [ ] Build `AnnouncementEditView`:
+  - [ ] If `id == nil` → empty form; else load row from `store.adminRows`
+  - [ ] Title `TextField`, body `TextEditor` (min height 120pt), priority `Picker` (info/critical), `expires_at` row (Toggle "Has expiry" + `DatePicker`), `is_active` `Toggle`, `display_order` `Stepper`
+  - [ ] Save button → call `store.create` or `store.update`, pop on success, inline error on failure
+  - [ ] Disabled save button while title or body empty
+- [ ] Add 2 routes to `AppRouter.swift`:
+  - [ ] `.adminAnnouncements`
+  - [ ] `.adminAnnouncementEdit(id: String?)`
+- [ ] Wire routes in `MainShell.swift`:
+  - [ ] Instantiate `AnnouncementsStore` at `MainShell` level
+  - [ ] Pass to `AnnouncementsCard` + admin sub-screens
+  - [ ] Add `.navigationDestination` cases for both routes
+- [ ] Add `AdminView` menu row "Announcements" between AI Review and Tables (icon: `megaphone.fill`)
+- [ ] Add `Config.AdminFlags.showAnnouncements = true` to template + local + CI heredoc
+- [ ] Write `AnnouncementsStoreTests.swift`:
+  - [ ] Happy load → populates `announcements`
+  - [ ] API error → falls back to `LeagueAnnouncements.current`
+  - [ ] 5-min cache short-circuits
+  - [ ] `force: true` bypasses cache
+  - [ ] Admin create/update/delete happy paths
+- [ ] Write `LeagueAnnouncementDecoderTests.swift`:
+  - [ ] Valid JSON with all fields
+  - [ ] Null `expires_at`
+  - [ ] Unknown priority string → default to `.info`
+- [ ] `xcodegen generate` + build for iPhone 17 Pro simulator
+- [ ] Manual QA against deployed backend:
+  - [ ] Landing renders DB rows (not hardcoded array)
+  - [ ] Markdown bolding works
+  - [ ] Admin create → appears in list + Landing after refresh
+  - [ ] Admin edit → reflects on Landing
+  - [ ] Admin soft delete → disappears from Landing, still visible in admin list with INACTIVE chip
+  - [ ] Expired entry — filtered from Landing, EXPIRED chip in admin list
+  - [ ] Kill backend → Landing still shows hardcoded fallback
+- [ ] Merge PR
+
+---
+
+## Out of Scope
+
+- Hard delete from app UI — Supabase dashboard only
+- Multi-league announcement scoping — single league (Charlotte Dynasty) for v1, no `league_id` column
+- Rich-text editor beyond markdown — markdown is plain `TextEditor`, no formatting toolbar
+- Push notification on new announcement creation — explicitly punted; could be a follow-up
+- Announcement scheduling (`publish_at`) — only `expires_at`; if you need to schedule, just create when ready
+- Image/attachment support — text-only
+- Per-user dismissal / read state — every member sees every active announcement
+- Real-time updates (Supabase Realtime) — 5-min poll is fine for announcement volume
+
+---
+
+## Risks / Tradeoffs
+
+- **Risk**: API outage blanks Landing. **Mitigation**: hardcoded `LeagueAnnouncements.current` fallback survives indefinitely. Worth accepting that fallback may go stale if API is down for >24h.
+- **Risk**: Admin accidentally hard-deletes a row from Supabase dashboard and breaks audit trail. **Mitigation**: documented soft-delete-only pattern; Supabase dashboard access is already gated to commissioner.
+- **Risk**: Markdown parse failure crashes the row. **Mitigation**: wrap `AttributedString(markdown:)` in `try?` and fall back to plain `Text(body)` on failure.
+- **Risk**: 5-min cache means an admin's fresh announcement may not appear on Landing for up to 5 minutes. **Tradeoff accepted**: announcements are not time-critical at the minute granularity. Admin can pull-to-refresh on Landing to force.
+- **Risk**: Seed migration runs twice → duplicate rows. **Mitigation**: gate seed inserts with `ON CONFLICT DO NOTHING` on a deterministic key (use fixed UUIDs in the seed rows).
+- **Risk**: `expires_at` timezone confusion (UTC stored vs local DatePicker). **Mitigation**: always store + transmit as ISO8601 UTC; iOS `DatePicker` reads/writes `Date` which is timezone-neutral.
+
+---
+
+## Open Questions
+
+- [ ] Should the admin list show count of total/active/expired in a header chip? (Nice-to-have, low cost — recommend yes)
+- [ ] Should "+ New" button live in the list's nav bar trailing or as a top card row in the list body? (Recommend nav bar trailing — matches iOS patterns)
+- [ ] Confirm seed-row UUIDs: do we want deterministic strings (e.g. `00000000-0000-0000-0000-000000000001`) or just `gen_random_uuid()`? Deterministic is safer for repeat migrations — recommend deterministic.
+- [ ] Markdown render — should we also support links (`[text](url)`)? `AttributedString(markdown:)` supports it out of the box; recommend yes, no extra work.
+- [ ] Does the 5-min cache TTL belong as a `Config` constant or a store-internal const? Recommend store-internal — no other consumer needs it.
+
+---
+
+## Acceptance Checklist
+
+Tied to issue #100. All must be checked to merge PR 3 / close issue.
+
+- [ ] Table `league_announcements` exists in Supabase with index + 3 seed rows
+- [ ] `GET /announcements` returns active rows ordered critical-first then `display_order`
+- [ ] `GET /admin/announcements-list` returns all rows (including inactive/expired) and rejects non-admin
+- [ ] `POST /admin/announcements-create|update|delete` work + write to `admin_audit`
+- [ ] Landing page reads from backend (verified by editing a row in Supabase and seeing it reflect after refresh)
+- [ ] Markdown bolding in body renders correctly
+- [ ] Backend down → Landing shows hardcoded fallback (test by pointing iOS to a dead URL)
+- [ ] Admin sub-screen menu row visible in `AdminView`
+- [ ] Admin can create, edit, soft-delete announcements end-to-end
+- [ ] Status chips render correctly (ACTIVE / INACTIVE / EXPIRED)
+- [ ] All new unit tests pass (backend + iOS)
+- [ ] `Config.AdminFlags.showAnnouncements` flag wired in template + local + CI heredoc
+- [ ] No regression on Landing page layout (visual diff with current build)
+
+---
+
+## Skills / Agents to Use
+
+- **swift-engineer**: build `AnnouncementsStore`, `AnnouncementsCard` rewire, admin views — owns the iOS PR
+- **backend-engineer**: write `announcements_store.py`, 5 lambda handlers + tests — owns the backend PR
+- **terraform-engineer**: extend `lambdas_api.tf` — owns the infra PR
+- **test-writer**: backend pytest suite + iOS `AnnouncementsStoreTests` / `LeagueAnnouncementDecoderTests`
+- **qa-runner**: final end-to-end manual QA pass on simulator against staging


### PR DESCRIPTION
## Summary

Replaces the hardcoded `LeagueAnnouncements.current` array (shipped in Season Refocus F2) with a Supabase-backed surface using the four admin endpoints + one public read endpoint that landed in backend PR #72 / infra PR #115. Admin can now add / edit / soft-delete announcements without an app deploy.

Closes #100.

### What's included

**Model + store**
- `LeagueAnnouncement` now `Codable` with snake_case `CodingKeys`. Added `displayOrder`, `isActive`, `createdAt`, `updatedAt`. Priority decode is permissive (unknown strings → `.info`).
- New `AnnouncementsStore` (`@Observable @MainActor`) with separate public + admin state machines. 5-min freshness cache on public read. Optimistic create/update/delete with revert-on-error.
- `LeagueAnnouncements.current` retained as fallback array — public read failure populates from it so the Landing page never blanks.

**API client**
- `fetchAnnouncements` (public)
- `fetchAdminAnnouncements`, `createAnnouncement`, `updateAnnouncement`, `deleteAnnouncement` (admin)
- `AdminFieldValue` extended with `.int` and `.null` cases for `display_order` and explicit `expires_at` clears

**Views**
- New `AnnouncementsListView` — list with priority chip + status chips (ACTIVE / INACTIVE / EXPIRED), swipe-to-delete + confirmation, "+ New" toolbar
- New `AnnouncementEditView` — title / body (TextEditor) / priority Picker / expires_at DatePicker with "Has expiry" toggle / is_active / display_order Stepper
- `AnnouncementsCard` rewired to read from `AnnouncementsStore.announcements`; body renders via `AttributedString(markdown:)` with plain-`Text` fallback

**Routes + wiring**
- `.adminAnnouncements` + `.adminAnnouncementEdit(id: UUID?)` added to `AppRouter`
- `MainShell` owns the single `AnnouncementsStore` instance; passed to Landing + admin sub-screens
- New "Announcements" admin menu row (gated by `Config.AdminFlags.showAnnouncements`)

**Config (PR #113 lesson)**
- Flag added to `Config.swift.template`, local `Config.swift`, AND the CI workflow heredoc

**Tests** — 21 new, all green
- `LeagueAnnouncementDecoderTests` (7): happy path, null expiry, missing optional fields, unknown priority fallback, fractional-second timestamps, public list, admin list with `tableMissing`
- `AnnouncementsStoreTests` (14): load + 5-min cache hit + force bypass + API failure → hardcoded fallback + preserves existing rows on transient errors + admin load + tableMissing + create optimistic + create revert + update optimistic + update revert + update unknown-id throws + delete optimistic + delete revert

**Build + tests**
- xcodegen regenerated
- Build clean on iPhone 17 Pro simulator (only pre-existing warnings)
- 235/235 tests pass

### Dependencies

- Backend PR #72 — five lambdas + handlers (deployed)
- Infra PR #115 — five new API GW routes (live)
- Manual Supabase migration applying `league_announcements` table — backend returns `tableMissing: true` until applied; admin list renders a friendly empty state in that case

### Test plan

- [ ] Build clean on iPhone 17 Pro simulator
- [ ] Apply backend Supabase migration (`league_announcements` table)
- [ ] Smoke `/announcements` against deployed backend with a real JWT
- [ ] Verify Landing page reads from DB (edit a row in Supabase, refresh)
- [ ] Verify markdown bolding renders in announcement body
- [ ] Admin: create → appears in list + Landing
- [ ] Admin: edit → reflects on Landing
- [ ] Admin: soft-delete → disappears from Landing, INACTIVE chip in admin list
- [ ] Expired entry — filtered from Landing, EXPIRED chip in admin list
- [ ] Kill backend (point iOS to dead URL) → Landing still shows hardcoded fallback
- [ ] Confirm Audit feed shows `announcements.create / .update / .delete` rows after each write