### PR TITLE
fix(ios): pass x-user-email so admin endpoints resolve caller

### DIFF
--- a/Xomper/Core/Networking/XomperAPIClient.swift
+++ b/Xomper/Core/Networking/XomperAPIClient.swift
@@ -641,14 +641,17 @@ final class XomperAPIClient: XomperAPIClientProtocol {
         self.encoder = JSONEncoder()
     }
 
-    /// Pulls the current Supabase access token, refreshing it via the
-    /// SDK if expired. Returns nil if the user isn't signed in, in
-    /// which case the request goes out unauthenticated and API GW's
-    /// JWT authorizer will reject it with 401 — surfaced normally as
-    /// an `httpError`, not silently dropped.
+    /// Attaches the Bearer JWT plus the caller's email header.
+    /// The custom API GW authorizer decodes the JWT for an Allow/Deny
+    /// but does NOT forward claims into the integration context, so
+    /// admin endpoints have to receive the identifier separately —
+    /// they read `x-user-email` to gate via `admin_gate.require_admin`.
+    /// Public endpoints ignore the extra header.
     private func attachAuth(_ request: inout URLRequest) async {
-        if let token = try? await supabase.auth.session.accessToken {
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        guard let session = try? await supabase.auth.session else { return }
+        request.setValue("Bearer \(session.accessToken)", forHTTPHeaderField: "Authorization")
+        if let email = session.user.email, !email.isEmpty {
+            request.setValue(email, forHTTPHeaderField: "x-user-email")
         }
     }
 


### PR DESCRIPTION
## Summary
- The custom API GW authorizer decodes the Supabase JWT for an Allow/Deny but does NOT forward claims into the integration context (`event.requestContext.authorizer` is bare).
- \`admin_gate.require_admin\` reads the caller from query/header/body (\`sleeper_user_id\` or \`email\`). With nothing passed, every admin endpoint returned 400 \"missing identifier\" — which explained the 500/403 mix on Audit, Tables, Test Email, Cron Settings, etc.
- Attaching \`x-user-email\` from the Supabase session in \`attachAuth\` lets all admin endpoints gate cleanly. Public endpoints ignore the header.

## Test plan
- [ ] Pull next TestFlight build
- [ ] Admin → Audit loads entries
- [ ] Admin → Tables → Users loads roster (now that infra route exists + this header lands)
- [ ] Admin → Tables → Leagues loads roster
- [ ] Admin → Test Email loads recipients
- [ ] Admin → Cron Settings loads