### PR TITLE
refactor(ios): condense drawer from 6 sections to 4

### DIFF
--- a/Xomper/Features/Shell/DrawerView.swift
+++ b/Xomper/Features/Shell/DrawerView.swift
@@ -24,31 +24,31 @@ struct DrawerView: View {
     /// Drawer sections (top-to-bottom). `Settings` is pinned separately to the
     /// bottom of the panel and is not in this list. `Admin` is appended at
     /// runtime when `isAdmin == true`.
+    /// Drawer is grouped into 4 sections (down from 6) plus pinned
+    /// Settings + optional Admin. Items kept stable so existing routes
+    /// and deep links don't break — this is purely a regrouping.
+    ///
+    /// - Play:    landing, standings, matchups, playoffs
+    /// - Team:    myTeam, taxiSquad, teamAnalyzer
+    /// - History: draftHistory, matchupHistory, worldCup, aiReview, archive
+    /// - League:  rulebook, scoring, leagueSettings, payouts, ruleProposals, draftOrder
     private var sections: [TraySection] {
         var out: [TraySection] = [
             TraySection(
-                title: "Home",
-                entries: [.landing]
+                title: "Play",
+                entries: [.landing, .standings, .matchups, .playoffs]
             ),
             TraySection(
-                title: "Compete",
-                entries: [.standings, .matchups, .playoffs]
-            ),
-            TraySection(
-                title: "History",
-                entries: [.draftHistory, .matchupHistory, .worldCup]
-            ),
-            TraySection(
-                title: "Roster",
+                title: "Team",
                 entries: [.myTeam, .taxiSquad, .teamAnalyzer]
             ),
             TraySection(
-                title: "League",
-                entries: [.payouts, .aiReview, .rulebook, .scoring, .leagueSettings, .ruleProposals, .draftOrder]
+                title: "History",
+                entries: [.draftHistory, .matchupHistory, .worldCup, .aiReview, .archive]
             ),
             TraySection(
-                title: "Archive",
-                entries: [.archive]
+                title: "League",
+                entries: [.rulebook, .scoring, .leagueSettings, .payouts, .ruleProposals, .draftOrder]
             ),
         ]
         if isAdmin {

--- a/Xomper/Features/Shell/TrayDestination.swift
+++ b/Xomper/Features/Shell/TrayDestination.swift
@@ -3,13 +3,11 @@ import Foundation
 /// Top-level navigation targets reachable from the slide-out drawer.
 /// `currentDestination` on `NavigationStore` is always one of these.
 ///
-/// Cases are grouped logically by the drawer sections:
-/// - Home:     landing
-/// - Compete:  standings, matchups, playoffs
-/// - History:  draftHistory, matchupHistory, worldCup
-/// - Roster:   myTeam, taxiSquad
-/// - Rules:    rulebook, scoring, leagueSettings, ruleProposals
-/// - Archive:  archive (hubs past standings + past matchups + past drafts)
+/// Cases are grouped logically by the drawer sections (see DrawerView):
+/// - Play:    landing, standings, matchups, playoffs
+/// - Team:    myTeam, taxiSquad, teamAnalyzer
+/// - History: draftHistory, matchupHistory, worldCup, aiReview, archive
+/// - League:  rulebook, scoring, leagueSettings, payouts, ruleProposals, draftOrder
 /// - Profile/Settings are surfaced via the profile card and pinned footer.
 enum TrayDestination: Hashable {
     case landing


### PR DESCRIPTION
Same 18 destinations, regrouped:

- **Play**: landing, standings, matchups, playoffs
- **Team**: myTeam, taxiSquad, teamAnalyzer
- **History**: draftHistory, matchupHistory, worldCup, aiReview, archive
- **League**: rulebook, scoring, leagueSettings, payouts, ruleProposals, draftOrder

Pure regrouping — no item removed, no enum cases changed, so deep links keep working. Largest section drops 7 → 6.