### PR TITLE
refactor(ios): reflow AI recap markdown + admin-only AI Review tray

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -190,6 +190,7 @@
 		EE987501F73209179D5CEEB4 /* TestEmailStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E98CD5B3ECB6292B6D7637B /* TestEmailStore.swift */; };
 		F118537BB85C27688E57C703 /* CronSettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4C60C4B1F35CD6B056AC29 /* CronSettingsStoreTests.swift */; };
 		F201A3A40D624F6AAA0C0CC1 /* PlayoffBracket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */; };
+		F2CDF62D6ED30924FD44F37A /* MarkdownReflow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24B1B312AA1DD24D8453822 /* MarkdownReflow.swift */; };
 		F57132F0D80EAB60AC0E07F3 /* WhitelistedLeague.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747C6FC769C117588F8A93E /* WhitelistedLeague.swift */; };
 		F5AC0E08C9F82995736A62EF /* LogsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B38051DBBEE34C89E9446FE /* LogsView.swift */; };
 		F5AD059EF52A068C469AFB6E /* URL+Sleeper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2452A5AEC270BE14CC085E1 /* URL+Sleeper.swift */; };
@@ -372,6 +373,7 @@
 		CEAEC7A4917990425085AE71 /* PushNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationManager.swift; sourceTree = "<group>"; };
 		CFB439DD73C2D26421BE97E7 /* CronSettingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronSettingTests.swift; sourceTree = "<group>"; };
 		D12507ED13C57EFA8B240301 /* AIReviewHomeCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewHomeCard.swift; sourceTree = "<group>"; };
+		D24B1B312AA1DD24D8453822 /* MarkdownReflow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownReflow.swift; sourceTree = "<group>"; };
 		D34E8D4C4B1A29FC412EBA41 /* StandingsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsListView.swift; sourceTree = "<group>"; };
 		D36829F2AD0FD089788B9CE1 /* PlayerPointsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerPointsStore.swift; sourceTree = "<group>"; };
 		D7F3E6606D89CF3AEB320314 /* LandingViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingViewTests.swift; sourceTree = "<group>"; };
@@ -793,6 +795,7 @@
 			children = (
 				669A80C2A9F46A0C4612388C /* Double+Formatting.swift */,
 				6504EE31A645398C41BC2ED1 /* EnvironmentValues+Season.swift */,
+				D24B1B312AA1DD24D8453822 /* MarkdownReflow.swift */,
 				F2452A5AEC270BE14CC085E1 /* URL+Sleeper.swift */,
 			);
 			path = Extensions;
@@ -1113,6 +1116,7 @@
 				DBD18478CCB04AC17621725D /* LogsStore.swift in Sources */,
 				F5AC0E08C9F82995736A62EF /* LogsView.swift in Sources */,
 				2F60B09D13BABD5E49B3DCBF /* MainShell.swift in Sources */,
+				F2CDF62D6ED30924FD44F37A /* MarkdownReflow.swift in Sources */,
 				D106F60A597D780F32FFA5E8 /* Matchup.swift in Sources */,
 				D09FC43EBE71A0DFF28B83D2 /* MatchupDetailView.swift in Sources */,
 				2378DF41F2BB3933117897A7 /* MatchupHistory.swift in Sources */,

--- a/Xomper/Core/Extensions/MarkdownReflow.swift
+++ b/Xomper/Core/Extensions/MarkdownReflow.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Lightweight markdown post-processor that injects paragraph breaks
+/// into AI Review report bodies. Claude generates these recaps as one
+/// long run with bold + em-dash markers but no `\n\n` between sections,
+/// which renders as a wall of text. We can't re-flow at generation time
+/// for content already in DynamoDB, and we want this to work uniformly
+/// across postDraft / weekly / preseason — so we reflow at render time.
+///
+/// Rules applied in order, each idempotent:
+/// 1. Insert `\n\n` before the AI's first body sentence when it
+///    immediately follows the title (`...Recap**The 2025...` ->
+///    `...Recap**\n\nThe 2025...`).
+/// 2. Insert `\n\n` before per-team / per-section bold headers like
+///    `**ktatich (Kyle)** —` and `**Round 2**` and `**Final standings:**`.
+/// 3. Insert `\n\n` before headline patterns that hug a previous
+///    sentence: `Round N`, `Week N`, `Final ... standings`, numbered
+///    list-y stems (`1.01`, `2.07`) when glued to a prior word.
+/// 4. Collapse 3+ consecutive newlines to exactly two so we don't
+///    over-pad after multiple inserts.
+enum MarkdownReflow {
+
+    static func paragraphs(_ raw: String) -> String {
+        guard !raw.isEmpty else { return raw }
+
+        var out = raw
+
+        // 1. Detach a leading title from the body. The AI emits a bold
+        //    or plain header glued to the first sentence — e.g.
+        //    "2025 Rookie Draft RecapThe 2025 class…" or
+        //    "Week 17 Recap — 2025 — Championship + Final Standings🏆 CHAMPIONSHIP:…"
+        //    Look for a transition from a "Recap"/"Standings"-y token
+        //    directly into a capital letter or emoji.
+        out = out.replacingOccurrences(
+            of: #"(Recap|Standings|Summary)([A-Z🏆🥇🥈🥉⚡️])"#,
+            with: "$1\n\n$2",
+            options: .regularExpression
+        )
+
+        // 2. Break before any bold section header followed by an em-dash
+        //    intro, e.g. "**ktatich (Kyle)** — Picks 1.02…".
+        //    Allow a leading period to absorb the previous sentence end.
+        out = out.replacingOccurrences(
+            of: #"(?<=[\.\!\?\)])\s*(\*\*[^*]+\*\*\s*—)"#,
+            with: "\n\n$1",
+            options: .regularExpression
+        )
+
+        // 3. Break before "Round N" / "Week N" / "Final ... standings"
+        //    when glued to a prior word.
+        out = out.replacingOccurrences(
+            of: #"(?<=[a-z\)\.])(\s*)((?:Round|Week)\s+\d+|Final[^.\n]{0,40}?standings)"#,
+            with: "\n\n$2",
+            options: .regularExpression
+        )
+
+        // 4. Break before pick numbers that hug prior text:
+        //    "Connor's a hero.Pat Bryant 4.01" -> two paragraphs.
+        out = out.replacingOccurrences(
+            of: #"(?<=[\.\!\?])(?=[A-Z][a-zA-Z' ]+\s\d+\.\d{2}\b)"#,
+            with: "\n\n",
+            options: .regularExpression
+        )
+
+        // 5. Normalize whitespace — collapse 3+ newlines and trim
+        //    trailing whitespace on each line so SwiftUI's
+        //    AttributedString(markdown:) sees clean input.
+        out = out.replacingOccurrences(
+            of: #"\n{3,}"#,
+            with: "\n\n",
+            options: .regularExpression
+        )
+
+        return out
+    }
+}

--- a/Xomper/Features/AIReview/AIReviewDetailView.swift
+++ b/Xomper/Features/AIReview/AIReviewDetailView.swift
@@ -87,15 +87,17 @@ struct AIReviewDetailView: View {
     /// to a plain Text if the markdown is malformed.
     private var renderedMarkdown: some View {
         Group {
+            let reflowed = MarkdownReflow.paragraphs(report.bodyMarkdown)
             if let attributed = try? AttributedString(
-                markdown: report.bodyMarkdown,
+                markdown: reflowed,
                 options: AttributedString.MarkdownParsingOptions(
                     interpretedSyntax: .full
                 )
             ) {
                 Text(attributed)
+                    .lineSpacing(4)
             } else {
-                Text(report.bodyMarkdown)
+                Text(reflowed)
             }
         }
     }

--- a/Xomper/Features/DraftHistory/Draft/DraftRecapView.swift
+++ b/Xomper/Features/DraftHistory/Draft/DraftRecapView.swift
@@ -143,15 +143,17 @@ struct DraftRecapView: View {
     /// the markdown is malformed.
     @ViewBuilder
     private func renderedMarkdown(_ report: AIReport) -> some View {
+        let reflowed = MarkdownReflow.paragraphs(report.bodyMarkdown)
         if let attributed = try? AttributedString(
-            markdown: report.bodyMarkdown,
+            markdown: reflowed,
             options: AttributedString.MarkdownParsingOptions(
                 interpretedSyntax: .full
             )
         ) {
             Text(attributed)
+                .lineSpacing(4)
         } else {
-            Text(report.bodyMarkdown)
+            Text(reflowed)
         }
     }
 

--- a/Xomper/Features/League/WeeklyRecapHeaderCard.swift
+++ b/Xomper/Features/League/WeeklyRecapHeaderCard.swift
@@ -81,15 +81,17 @@ struct WeeklyRecapHeaderCard: View {
     /// AI-generated body always renders, even on parse failure.
     @ViewBuilder
     private var renderedMarkdown: some View {
+        let reflowed = MarkdownReflow.paragraphs(report.bodyMarkdown)
         if let attributed = try? AttributedString(
-            markdown: report.bodyMarkdown,
+            markdown: reflowed,
             options: AttributedString.MarkdownParsingOptions(
                 interpretedSyntax: .full
             )
         ) {
             Text(attributed)
+                .lineSpacing(4)
         } else {
-            Text(report.bodyMarkdown)
+            Text(reflowed)
         }
     }
 }

--- a/Xomper/Features/Shell/DrawerView.swift
+++ b/Xomper/Features/Shell/DrawerView.swift
@@ -24,14 +24,19 @@ struct DrawerView: View {
     /// Drawer sections (top-to-bottom). `Settings` is pinned separately to the
     /// bottom of the panel and is not in this list. `Admin` is appended at
     /// runtime when `isAdmin == true`.
-    /// Drawer is grouped into 4 sections (down from 6) plus pinned
-    /// Settings + optional Admin. Items kept stable so existing routes
-    /// and deep links don't break — this is purely a regrouping.
+    /// Drawer sections plus pinned Settings + optional Admin.
     ///
     /// - Play:    landing, standings, matchups, playoffs
     /// - Team:    myTeam, taxiSquad, teamAnalyzer
-    /// - History: draftHistory, matchupHistory, worldCup, aiReview, archive
+    /// - History: draftHistory, matchupHistory, worldCup
     /// - League:  rulebook, scoring, leagueSettings, payouts, ruleProposals, draftOrder
+    /// - Admin:   aiReview (full archive), admin (only when isAdmin)
+    ///
+    /// `aiReview` is admin-only because it's the long-form archive
+    /// surface; regular users get AI content via the Landing card and
+    /// the inline recap on `DraftRecapView` / `MatchupsView`.
+    /// `archive` is dropped — its sub-destinations are reachable via
+    /// each season's per-tab past-history flow.
     private var sections: [TraySection] {
         var out: [TraySection] = [
             TraySection(
@@ -44,7 +49,7 @@ struct DrawerView: View {
             ),
             TraySection(
                 title: "History",
-                entries: [.draftHistory, .matchupHistory, .worldCup, .aiReview, .archive]
+                entries: [.draftHistory, .matchupHistory, .worldCup]
             ),
             TraySection(
                 title: "League",
@@ -52,7 +57,7 @@ struct DrawerView: View {
             ),
         ]
         if isAdmin {
-            out.append(TraySection(title: "Admin", entries: [.admin]))
+            out.append(TraySection(title: "Admin", entries: [.aiReview, .admin]))
         }
         return out
     }


### PR DESCRIPTION
## Changes
1. **MarkdownReflow utility** — Claude generates the recap body without paragraph breaks (one long run with bold markers). Reflow inserts `\n\n` before per-team headers, round headers, and pick-number stems at render time.
2. Wire reflow + `lineSpacing(4)` into `DraftRecapView`, `WeeklyRecapHeaderCard`, `AIReviewDetailView`.
3. **Drawer cleanup**: hide `aiReview` from non-admin (long-form archive surface — regular users get AI via Landing card + inline recaps). Drop `archive` section entirely (sub-destinations are reachable via per-season tabs).