### PR TITLE
feat(ios): live countdown + all 5 rounds on upcoming-draft board

### DIFF
--- a/Xomper/Features/DraftHistory/Draft/LiveDraftView.swift
+++ b/Xomper/Features/DraftHistory/Draft/LiveDraftView.swift
@@ -16,6 +16,9 @@ struct LiveDraftView: View {
     var userStore: UserStore
     var nflStateStore: NflStateStore
 
+    /// Drives the live countdown in the header. SwiftUI's
+    /// `TimelineView(.periodic:)` re-evaluates every interval so we
+    /// don't need a manual Timer.
     var body: some View {
         Group {
             if historyStore.isLoadingUpcoming && historyStore.upcomingDraft == nil {
@@ -56,16 +59,21 @@ struct LiveDraftView: View {
             VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
                 liveHeaderCard(draft: draft, totalPicks: totalPicks, firstPick: firstPick)
 
-                sectionHeader("Round 1 order (\(slots.count) slots)")
-                ForEach(slots, id: \.self) { slot in
-                    let team = teamsBySlot[slot]
-                    let isMine = team?.userId != nil && team?.userId == myUserId
-                    liveRow(
-                        slot: slot,
-                        team: team,
-                        isMine: isMine,
-                        pickDate: pickDate(firstPick: firstPick, pickNo: slot)
-                    )
+                ForEach(1...rounds, id: \.self) { round in
+                    sectionHeader("Round \(round)")
+                    ForEach(slots, id: \.self) { slot in
+                        let pickNo = (round - 1) * slots.count + slot
+                        let team = teamsBySlot[slot]
+                        let isMine = team?.userId != nil && team?.userId == myUserId
+                        liveRow(
+                            round: round,
+                            slot: slot,
+                            pickNo: pickNo,
+                            team: team,
+                            isMine: isMine,
+                            pickDate: pickDate(firstPick: firstPick, pickNo: pickNo)
+                        )
+                    }
                 }
             }
             .padding(.horizontal, XomperTheme.Spacing.md)
@@ -92,6 +100,11 @@ struct LiveDraftView: View {
                 Text("Starts \(formatted(firstPick))")
                     .font(.caption)
                     .foregroundStyle(XomperColors.textSecondary)
+                // Live countdown — re-evaluates every second via
+                // TimelineView so we don't manage our own Timer.
+                TimelineView(.periodic(from: .now, by: 1)) { context in
+                    countdownLine(target: firstPick, now: context.date)
+                }
             } else {
                 Text("Slot order is locked. No start time set in Sleeper yet.")
                     .font(.caption)
@@ -115,12 +128,44 @@ struct LiveDraftView: View {
         )
     }
 
-    private func liveRow(slot: Int, team: UpcomingDraftTeam?, isMine: Bool, pickDate: Date?) -> some View {
+    /// "Starts in 34d 5h 12m 09s" / "Drafting now" once `target` passes.
+    @ViewBuilder
+    private func countdownLine(target: Date, now: Date) -> some View {
+        let remaining = target.timeIntervalSince(now)
+        if remaining <= 0 {
+            Text("Draft is live")
+                .font(.subheadline.weight(.bold))
+                .foregroundStyle(XomperColors.championGold)
+                .monospacedDigit()
+        } else {
+            Text(formatRemaining(remaining))
+                .font(.subheadline.weight(.bold))
+                .foregroundStyle(XomperColors.championGold)
+                .monospacedDigit()
+        }
+    }
+
+    private func formatRemaining(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds)
+        let days = total / 86400
+        let hours = (total % 86400) / 3600
+        let minutes = (total % 3600) / 60
+        let secs = total % 60
+        if days > 0 {
+            return String(format: "%dd %02dh %02dm %02ds until first pick", days, hours, minutes, secs)
+        } else if hours > 0 {
+            return String(format: "%dh %02dm %02ds until first pick", hours, minutes, secs)
+        } else {
+            return String(format: "%dm %02ds until first pick", minutes, secs)
+        }
+    }
+
+    private func liveRow(round: Int, slot: Int, pickNo: Int, team: UpcomingDraftTeam?, isMine: Bool, pickDate: Date?) -> some View {
         HStack(spacing: XomperTheme.Spacing.md) {
-            Text("\(slot)")
+            Text(String(format: "%d.%02d", round, slot))
                 .font(.title3.weight(.bold))
                 .foregroundStyle(isMine ? XomperColors.championGold : XomperColors.textSecondary)
-                .frame(width: 36, alignment: .leading)
+                .frame(width: 52, alignment: .leading)
                 .monospacedDigit()
 
             VStack(alignment: .leading, spacing: 2) {
@@ -129,12 +174,12 @@ struct LiveDraftView: View {
                     .foregroundStyle(XomperColors.textPrimary)
                     .lineLimit(1)
                 if let pickDate {
-                    Text("Pick #\(slot) · ~\(formattedShort(pickDate))")
+                    Text("Pick #\(pickNo) · ~\(formattedShort(pickDate))")
                         .font(.caption2)
                         .foregroundStyle(XomperColors.textMuted)
                         .monospacedDigit()
                 } else {
-                    Text("Pick #\(slot)")
+                    Text("Pick #\(pickNo)")
                         .font(.caption2)
                         .foregroundStyle(XomperColors.textMuted)
                         .monospacedDigit()

--- a/docs/migrations/2026-06-02-add-sleeper-user-id.sql
+++ b/docs/migrations/2026-06-02-add-sleeper-user-id.sql
@@ -1,0 +1,26 @@
+-- Migration: add sleeper_user_id column to whitelisted_users + backfill all
+-- 12 active rows from Sleeper API (resolved 2026-06-02).
+--
+-- Run in Supabase dashboard SQL editor. Idempotent — uses
+-- `ADD COLUMN IF NOT EXISTS` and email-keyed UPDATEs that no-op when
+-- already set to the same value.
+--
+-- Why: admin_email_test_recipients / admin_users_update / admin_gate
+-- all expect this column. The test-email picker stays empty until
+-- this is populated.
+
+ALTER TABLE whitelisted_users
+  ADD COLUMN IF NOT EXISTS sleeper_user_id text;
+
+UPDATE whitelisted_users SET sleeper_user_id = '418511574492270592'  WHERE email = 'reesedgriffin@gmail.com';
+UPDATE whitelisted_users SET sleeper_user_id = '741140723985997824'  WHERE email = 'duncan';
+UPDATE whitelisted_users SET sleeper_user_id = '866444821185843200'  WHERE email = 'jim';
+UPDATE whitelisted_users SET sleeper_user_id = '992955241630896128'  WHERE email = 'tibor';
+UPDATE whitelisted_users SET sleeper_user_id = '1001254799347658752' WHERE email = 'mike';
+UPDATE whitelisted_users SET sleeper_user_id = '1127420529155227648' WHERE email = 'tony';
+UPDATE whitelisted_users SET sleeper_user_id = '1132215311643787264' WHERE email = 'kyle';
+UPDATE whitelisted_users SET sleeper_user_id = '609168618525110272'  WHERE email = 'alex';
+UPDATE whitelisted_users SET sleeper_user_id = '867213779035906048'  WHERE email = 'luke.novak10@gmail.com';
+UPDATE whitelisted_users SET sleeper_user_id = '865328062403870720'  WHERE email = 'connorfolk@gmail.com';
+UPDATE whitelisted_users SET sleeper_user_id = '867213342836711424'  WHERE email = 'gtatich@gmail.com';
+UPDATE whitelisted_users SET sleeper_user_id = '594625531702460416' WHERE email = 'dominickj.giordano@gmail.com';


### PR DESCRIPTION
## Changes
- **Live countdown** in the LIVE card header. `TimelineView(.periodic(by: 1))` re-evaluates every second; format auto-shrinks (`34d 05h 12m 09s` -> `5h 12m 09s` -> `12m 09s`). Flips to **"Draft is live"** once `start_time` passes.
- **All 5 rounds** rendered, not just Round 1. Each row uses the `round.slot` label (e.g. `1.08`, `2.08`) and the absolute `pickNo` for the ~1 day/pick estimate so picks across rounds get accurate ETA labels.
- Bundles the `sleeper_user_id` backfill SQL at `docs/migrations/2026-06-02-add-sleeper-user-id.sql` so you have a stable reference.

## Tested against real Sleeper data
- league 1317249551823814656, draft 1317249551836413952
- start_time 2026-07-06T22:30:42 UTC (= July 6 6:30pm ET)
- 12 teams, 5 rounds, linear, 24h pick timer, reversal_round=3
- All 12 user_id -> slot mappings resolved against `whitelisted_users` rows