### PR TITLE
feat(ios): kind picker on Test Email — preview all 7 non-AI templates

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		90B62C24495752B9C03F5CE8 /* HighestPossibleCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6D698BC8816DA02019846C /* HighestPossibleCalculatorTests.swift */; };
 		9134D2C8A8737083C9FB8F7F /* ClinchCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3728C5F6BEF61FE509A3EA32 /* ClinchCalculator.swift */; };
 		93D8C8E352B60752D37FD0FF /* PlayerSeasonStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C24A12080AD428D5A40A7E /* PlayerSeasonStats.swift */; };
+		93E069814B933A306E4EA2E3 /* TestEmailKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = C964C2174FEA2E5B4DE790BB /* TestEmailKind.swift */; };
 		95DE1C46E20BF6910D4E5447 /* TrayItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E4EC7FDB93C47A9EE601BA3 /* TrayItem.swift */; };
 		98D5EE595D14742780A47B81 /* ThisWeekMatchupsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C921F3EC29B03A85D9F2A42C /* ThisWeekMatchupsCard.swift */; };
 		98F895FBCECB23325658339C /* StandingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A47FD1CF3BE7AE0B940DEC /* StandingsView.swift */; };
@@ -369,6 +370,7 @@
 		C83EF3C6C93199CF3FCBAE42 /* Matchup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Matchup.swift; sourceTree = "<group>"; };
 		C921F3EC29B03A85D9F2A42C /* ThisWeekMatchupsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThisWeekMatchupsCard.swift; sourceTree = "<group>"; };
 		C9382BCB18DFEB416A50A039 /* RulesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesView.swift; sourceTree = "<group>"; };
+		C964C2174FEA2E5B4DE790BB /* TestEmailKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestEmailKind.swift; sourceTree = "<group>"; };
 		CC3F6B5022E8151683A45F4F /* PlayerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerStore.swift; sourceTree = "<group>"; };
 		CEAEC7A4917990425085AE71 /* PushNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationManager.swift; sourceTree = "<group>"; };
 		CFB439DD73C2D26421BE97E7 /* CronSettingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronSettingTests.swift; sourceTree = "<group>"; };
@@ -741,6 +743,7 @@
 				B29D510D87CD290AE7F76FBF /* StandingsTeam.swift */,
 				A2DA1B65780757E6CC78CD61 /* TaxiSquadPlayer.swift */,
 				FC09DFF48D9AAFEF0A286BAD /* TeamAnalysis.swift */,
+				C964C2174FEA2E5B4DE790BB /* TestEmailKind.swift */,
 				9F49969EE42BDE6462664021 /* TradedPick.swift */,
 				2549566AC9312F44BA381BB6 /* WeeklyRecapMetadata.swift */,
 				3747C6FC769C117588F8A93E /* WhitelistedLeague.swift */,
@@ -1185,6 +1188,7 @@
 				E1E44482FBD2CBBA9ED6E829 /* TeamContext.swift in Sources */,
 				40C507B6FB2EF2A7E647AA3C /* TeamStore.swift in Sources */,
 				B7EB06298BFBF6AC76ABF53E /* TeamView.swift in Sources */,
+				93E069814B933A306E4EA2E3 /* TestEmailKind.swift in Sources */,
 				EE987501F73209179D5CEEB4 /* TestEmailStore.swift in Sources */,
 				825E9A2C109291322461741A /* TestEmailView.swift in Sources */,
 				98D5EE595D14742780A47B81 /* ThisWeekMatchupsCard.swift in Sources */,

--- a/Xomper/Core/Models/TestEmailKind.swift
+++ b/Xomper/Core/Models/TestEmailKind.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Every email template the admin can fire from the Test Email screen.
+///
+/// Three of these (`aiReviewPostDraft`, `aiReviewPreseason`,
+/// `aiReviewWeekly`) route through the existing
+/// `POST /admin/email-test` endpoint which re-sends a stored
+/// `xomper-ai-reports` row. The remaining seven route through
+/// `POST /admin/email-test-template` which composes a fresh sample
+/// against fixture data (the production crons for these gate on NFL
+/// `season_type == regular | post`, so offseason testing has to
+/// bypass the data pipeline).
+///
+/// `wireValue` is the string the backend's `kind` dispatch table
+/// expects. Keep these in sync with
+/// `lambdas/api_admin_email_test_template/handler.py::_BUILDERS`.
+enum TestEmailKind: String, CaseIterable, Identifiable, Hashable {
+    case aiReviewPostDraft
+    case aiReviewPreseason
+    case aiReviewWeekly
+    case weeklyRecap
+    case lineupNotSet
+    case ruleProposed
+    case ruleAccepted
+    case ruleDenied
+    case taxiStealLeague
+    case taxiStealOwner
+
+    var id: String { rawValue }
+
+    /// Whether this kind reuses the existing AI Review test-send path
+    /// (which needs a stored report id) vs. the new template path
+    /// (which sends fixture data).
+    var isAIReview: Bool {
+        switch self {
+        case .aiReviewPostDraft, .aiReviewPreseason, .aiReviewWeekly:
+            true
+        default:
+            false
+        }
+    }
+
+    /// Maps the AI Review variants to the underlying report type so
+    /// the view can look up the latest matching report from
+    /// `AIReviewStore.latestByType`.
+    var aiReportType: AIReportType? {
+        switch self {
+        case .aiReviewPostDraft: .postDraft
+        case .aiReviewPreseason: .preseason
+        case .aiReviewWeekly:    .weekly
+        default: nil
+        }
+    }
+
+    /// Wire value sent to the backend's `kind` field.
+    var wireValue: String {
+        switch self {
+        case .aiReviewPostDraft:  "ai_review_postdraft"
+        case .aiReviewPreseason:  "ai_review_preseason"
+        case .aiReviewWeekly:     "ai_review_weekly"
+        case .weeklyRecap:        "weekly_recap"
+        case .lineupNotSet:       "lineup_not_set"
+        case .ruleProposed:       "rule_proposed"
+        case .ruleAccepted:       "rule_accepted"
+        case .ruleDenied:         "rule_denied"
+        case .taxiStealLeague:    "taxi_steal_league"
+        case .taxiStealOwner:     "taxi_steal_owner"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .aiReviewPostDraft:  "AI Review — Post Draft"
+        case .aiReviewPreseason:  "AI Review — Preseason"
+        case .aiReviewWeekly:     "AI Review — Weekly Recap"
+        case .weeklyRecap:        "Weekly Recap (non-AI)"
+        case .lineupNotSet:       "Lineup Not Set"
+        case .ruleProposed:       "Rule Proposed"
+        case .ruleAccepted:       "Rule Accepted"
+        case .ruleDenied:         "Rule Denied"
+        case .taxiStealLeague:    "Taxi Steal — League"
+        case .taxiStealOwner:     "Taxi Steal — Owner"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .aiReviewPostDraft, .aiReviewPreseason, .aiReviewWeekly:
+            "sparkles"
+        case .weeklyRecap, .lineupNotSet:
+            "calendar.badge.exclamationmark"
+        case .ruleProposed, .ruleAccepted, .ruleDenied:
+            "checkmark.bubble.fill"
+        case .taxiStealLeague, .taxiStealOwner:
+            "bus.fill"
+        }
+    }
+}

--- a/Xomper/Core/Networking/XomperAPIClient.swift
+++ b/Xomper/Core/Networking/XomperAPIClient.swift
@@ -15,6 +15,7 @@ protocol XomperAPIClientProtocol: Sendable {
     func adminTestSend(sleeperUserId: String, email: String?, kind: String, channels: [String]) async throws -> AdminTestSendResponse
     func fetchTestEmailRecipients() async throws -> [TestEmailRecipient]
     func sendTestEmail(recipientSleeperUserId: String, reportId: String) async throws -> TestEmailResponse
+    func sendTestEmailTemplate(kind: String, recipientSleeperUserId: String) async throws -> TestEmailTemplateResponse
 
     // AI Review
     func fetchLatestAIReport(type: AIReportType) async throws -> AIReport?
@@ -308,6 +309,27 @@ struct TestEmailResponse: Codable, Sendable {
         case template
         case reportType = "report_type"
         case reportPeriod = "report_period"
+    }
+}
+
+/// Response from `POST /admin/email-test-template`. Mirrors
+/// `TestEmailResponse` but uses `kind` instead of report_type/period
+/// because the template path doesn't reference a stored report.
+struct TestEmailTemplateResponse: Codable, Sendable {
+    let kind: String
+    let recipientEmail: String
+    let recipientUserId: String
+    let messageId: String?
+    let sentAt: String
+    let subject: String
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case recipientEmail = "recipient_email"
+        case recipientUserId = "recipient_user_id"
+        case messageId = "message_id"
+        case sentAt = "sent_at"
+        case subject
     }
 }
 
@@ -832,6 +854,23 @@ final class XomperAPIClient: XomperAPIClientProtocol {
             "report_id": reportId,
         ]
         return try await postDecoding("/admin/email-test", body: body)
+    }
+
+    /// Send a sample non-AI-Review email template to a single
+    /// whitelisted user. Used by the Test Email screen's kind picker
+    /// to preview transactional + cron emails (weekly_recap,
+    /// lineup_not_set, rule_*, taxi_*) with fixture data. The
+    /// production crons gate on NFL `season_type`, so this is the
+    /// only way to preview them in the offseason.
+    func sendTestEmailTemplate(
+        kind: String,
+        recipientSleeperUserId: String
+    ) async throws -> TestEmailTemplateResponse {
+        let body: [String: Any] = [
+            "kind": kind,
+            "recipient_sleeper_user_id": recipientSleeperUserId,
+        ]
+        return try await postDecoding("/admin/email-test-template", body: body)
     }
 
     // MARK: - AI Review

--- a/Xomper/Core/Stores/TestEmailStore.swift
+++ b/Xomper/Core/Stores/TestEmailStore.swift
@@ -34,11 +34,16 @@ final class TestEmailStore {
     var selectedRecipient: TestEmailRecipient?
 
     /// Two-way bound by the report picker. `nil` until the admin
-    /// taps a row.
+    /// taps a row. Only relevant for AI Review kinds.
     var selectedReport: AIReport?
+
+    /// Two-way bound by the kind picker. Defaults to the AI Review
+    /// weekly recap — the most common test target.
+    var selectedKind: TestEmailKind = .aiReviewWeekly
 
     private(set) var isSending = false
     private(set) var lastResult: TestEmailResponse?
+    private(set) var lastTemplateResult: TestEmailTemplateResponse?
     private(set) var lastError: String?
 
     /// Receipts list — last few notification-log rows whose template
@@ -110,19 +115,29 @@ final class TestEmailStore {
 
     // MARK: - Send
 
-    /// Send the currently-selected report to the currently-selected
-    /// recipient. No-op when either picker is nil. On success, stores
-    /// the response in `lastResult` and refreshes the receipts list
-    /// so the row appears under the button.
+    /// Dispatch on `selectedKind`: AI Review variants reuse the
+    /// existing stored-report endpoint; everything else hits the new
+    /// template endpoint with fixture data. No-op when prerequisites
+    /// aren't met (no recipient picked, or AI Review kind without a
+    /// resolved report).
     func sendTest(sleeperUserId: String) async {
         guard let recipient = selectedRecipient else { return }
-        guard let report = selectedReport else { return }
+        guard !isSending else { return }
 
-        await sendTest(
-            report: report,
-            recipient: recipient,
-            sleeperUserId: sleeperUserId
-        )
+        if selectedKind.isAIReview {
+            guard let report = selectedReport else { return }
+            await sendTest(
+                report: report,
+                recipient: recipient,
+                sleeperUserId: sleeperUserId
+            )
+        } else {
+            await sendTemplate(
+                kind: selectedKind,
+                recipient: recipient,
+                sleeperUserId: sleeperUserId
+            )
+        }
     }
 
     /// Explicit-args overload used by tests and any future call site
@@ -137,6 +152,7 @@ final class TestEmailStore {
         isSending = true
         lastError = nil
         lastResult = nil
+        lastTemplateResult = nil
         defer { isSending = false }
 
         do {
@@ -154,10 +170,39 @@ final class TestEmailStore {
         }
     }
 
+    /// Send a sample of a non-AI-Review template. Composes from
+    /// fixture data on the backend, so no stored report is needed.
+    func sendTemplate(
+        kind: TestEmailKind,
+        recipient: TestEmailRecipient,
+        sleeperUserId: String
+    ) async {
+        guard !isSending else { return }
+        isSending = true
+        lastError = nil
+        lastResult = nil
+        lastTemplateResult = nil
+        defer { isSending = false }
+
+        do {
+            let response = try await apiClient.sendTestEmailTemplate(
+                kind: kind.wireValue,
+                recipientSleeperUserId: recipient.userId
+            )
+            lastTemplateResult = response
+            if !sleeperUserId.isEmpty {
+                await loadRecentSends(sleeperUserId: sleeperUserId)
+            }
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
     /// Clear toast/result state — call when navigating away or
     /// before kicking off a fresh send.
     func reset() {
         lastResult = nil
+        lastTemplateResult = nil
         lastError = nil
     }
 }

--- a/Xomper/Features/Admin/TestEmailView.swift
+++ b/Xomper/Features/Admin/TestEmailView.swift
@@ -58,6 +58,8 @@ struct TestEmailView: View {
 
                 if let result = store.lastResult {
                     successToast(result)
+                } else if let templateResult = store.lastTemplateResult {
+                    templateSuccessToast(templateResult)
                 } else if let error = store.lastError {
                     errorToast(error)
                 }
@@ -79,14 +81,18 @@ struct TestEmailView: View {
                 Text("Test Email")
                     .font(.subheadline.weight(.bold))
                     .foregroundStyle(XomperColors.championGold)
-                Text("Send an existing AI Review report to one whitelisted user. Doesn't touch broadcast state.")
+                Text("Preview any email type against a single whitelisted user. AI Review kinds use a stored report; everything else uses fixture data.")
                     .font(.caption)
                     .foregroundStyle(XomperColors.textSecondary)
             }
 
+            kindPicker
+
             recipientPicker
 
-            reportPicker
+            if store.selectedKind.isAIReview {
+                reportPicker
+            }
         }
         .padding(XomperTheme.Spacing.md)
         .background(XomperColors.bgCard)
@@ -96,6 +102,49 @@ struct TestEmailView: View {
                 .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
         )
         .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    // MARK: - Kind picker
+
+    private var kindPicker: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            Text("Email type")
+                .font(.caption.weight(.bold))
+                .textCase(.uppercase)
+                .tracking(0.5)
+                .foregroundStyle(XomperColors.textMuted)
+
+            Menu {
+                ForEach(TestEmailKind.allCases) { kind in
+                    Button {
+                        store.selectedKind = kind
+                        store.reset()
+                    } label: {
+                        Label(kind.displayName, systemImage: kind.systemImage)
+                    }
+                }
+            } label: {
+                HStack {
+                    Image(systemName: store.selectedKind.systemImage)
+                        .font(.caption)
+                        .foregroundStyle(XomperColors.championGold)
+                    Text(store.selectedKind.displayName)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(XomperColors.textPrimary)
+                        .lineLimit(1)
+                    Spacer()
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(XomperColors.textMuted)
+                }
+                .padding(.horizontal, XomperTheme.Spacing.sm)
+                .padding(.vertical, XomperTheme.Spacing.xs)
+                .frame(minHeight: XomperTheme.minTouchTarget)
+                .background(XomperColors.bgDark)
+                .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+            }
+            .disabled(store.isSending)
+        }
     }
 
     private var recipientPicker: some View {
@@ -259,7 +308,11 @@ struct TestEmailView: View {
     }
 
     private var canSend: Bool {
-        store.selectedRecipient != nil && store.selectedReport != nil && !store.isSending
+        guard !store.isSending, store.selectedRecipient != nil else { return false }
+        if store.selectedKind.isAIReview {
+            return store.selectedReport != nil
+        }
+        return true
     }
 
     // MARK: - Toasts
@@ -278,6 +331,33 @@ struct TestEmailView: View {
             Text("\(result.reportType) · \(result.reportPeriod) · template: \(result.template)")
                 .font(.caption2)
                 .foregroundStyle(XomperColors.textSecondary)
+        }
+        .padding(XomperTheme.Spacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md)
+                .strokeBorder(XomperColors.successGreen.opacity(0.5), lineWidth: 1)
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    private func templateSuccessToast(_ result: TestEmailTemplateResponse) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("✓ Sent to \(result.recipientEmail)")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(XomperColors.successGreen)
+            if let messageId = result.messageId, !messageId.isEmpty {
+                Text("SES message: \(messageId)")
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.textMuted)
+                    .lineLimit(1)
+            }
+            Text("\(result.kind) · \(result.subject)")
+                .font(.caption2)
+                .foregroundStyle(XomperColors.textSecondary)
+                .lineLimit(2)
         }
         .padding(XomperTheme.Spacing.sm)
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
Pairs with xomper-back-end PR #76 + xomper-infrastructure PR #121.

## What's new
- `TestEmailKind` enum with 10 cases (3 AI Review + 7 non-AI)
- Kind picker above recipient picker on Test Email screen
- Report picker only renders for AI Review kinds
- Dispatch in `TestEmailStore.sendTest` routes to the right endpoint based on `selectedKind.isAIReview`
- Template success toast shows the kind + subject

## Not covered
`close_game_alert` and `worldcup_movement` are push-only — no SES template — so they're not in the picker.