### PR TITLE
feat(week-preview): iOS kind picker + admin trigger card

### DIFF
--- a/Xomper/Core/Models/AIReport.swift
+++ b/Xomper/Core/Models/AIReport.swift
@@ -226,25 +226,28 @@ enum AIReportType: String, Codable, Sendable, CaseIterable, Hashable {
     case postDraft = "postDraft"
     case preseason = "preseason"
     case weekly = "weekly"
+    case weekPreview = "weekPreview"
     case mock = "mock"
 
     /// Display name used in chips and titles.
     var displayName: String {
         switch self {
-        case .postDraft: "Post-Draft"
-        case .preseason: "Preseason"
-        case .weekly:    "Weekly"
-        case .mock:      "Mock Draft"
+        case .postDraft:   "Post-Draft"
+        case .preseason:   "Preseason"
+        case .weekly:      "Weekly"
+        case .weekPreview: "Week Preview"
+        case .mock:        "Mock Draft"
         }
     }
 
     /// SF Symbol used as the chip glyph.
     var systemImage: String {
         switch self {
-        case .postDraft: "list.clipboard.fill"
-        case .preseason: "calendar"
-        case .weekly:    "sparkles"
-        case .mock:      "wand.and.stars"
+        case .postDraft:   "list.clipboard.fill"
+        case .preseason:   "calendar"
+        case .weekly:      "sparkles"
+        case .weekPreview: "calendar.badge.clock"
+        case .mock:        "wand.and.stars"
         }
     }
 
@@ -253,10 +256,11 @@ enum AIReportType: String, Codable, Sendable, CaseIterable, Hashable {
     /// per the F0 plan.
     var accentColor: Color {
         switch self {
-        case .postDraft: XomperColors.championGold
-        case .preseason: XomperColors.successGreen
-        case .weekly:    XomperColors.championGold
-        case .mock:      XomperColors.championGold
+        case .postDraft:   XomperColors.championGold
+        case .preseason:   XomperColors.successGreen
+        case .weekly:      XomperColors.championGold
+        case .weekPreview: XomperColors.errorRed
+        case .mock:        XomperColors.championGold
         }
     }
 }

--- a/Xomper/Core/Models/TestEmailKind.swift
+++ b/Xomper/Core/Models/TestEmailKind.swift
@@ -19,6 +19,7 @@ enum TestEmailKind: String, CaseIterable, Identifiable, Hashable {
     case aiReviewPreseason
     case aiReviewWeekly
     case weeklyRecap
+    case weekPreview
     case lineupNotSet
     case ruleProposed
     case ruleAccepted
@@ -59,6 +60,7 @@ enum TestEmailKind: String, CaseIterable, Identifiable, Hashable {
         case .aiReviewPreseason:  "ai_review_preseason"
         case .aiReviewWeekly:     "ai_review_weekly"
         case .weeklyRecap:        "weekly_recap"
+        case .weekPreview:        "week_preview"
         case .lineupNotSet:       "lineup_not_set"
         case .ruleProposed:       "rule_proposed"
         case .ruleAccepted:       "rule_accepted"
@@ -74,6 +76,7 @@ enum TestEmailKind: String, CaseIterable, Identifiable, Hashable {
         case .aiReviewPreseason:  "AI Review — Preseason"
         case .aiReviewWeekly:     "AI Review — Weekly Recap"
         case .weeklyRecap:        "Weekly Recap (non-AI)"
+        case .weekPreview:        "Week Preview (Wed newsletter)"
         case .lineupNotSet:       "Lineup Not Set"
         case .ruleProposed:       "Rule Proposed"
         case .ruleAccepted:       "Rule Accepted"
@@ -89,6 +92,8 @@ enum TestEmailKind: String, CaseIterable, Identifiable, Hashable {
             "sparkles"
         case .weeklyRecap, .lineupNotSet:
             "calendar.badge.exclamationmark"
+        case .weekPreview:
+            "calendar.badge.clock"
         case .ruleProposed, .ruleAccepted, .ruleDenied:
             "checkmark.bubble.fill"
         case .taxiStealLeague, .taxiStealOwner:

--- a/Xomper/Core/Networking/XomperAPIClient.swift
+++ b/Xomper/Core/Networking/XomperAPIClient.swift
@@ -25,6 +25,7 @@ protocol XomperAPIClientProtocol: Sendable {
     func triggerPostDraftAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse
     func triggerPreseasonAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse
     func triggerWeeklyAIReview(week: Int?, dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse
+    func triggerWeekPreviewAIReview(week: Int?, dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse
 
     // Admin: report metadata flags (F3)
     func setReportFlag(
@@ -1022,6 +1023,22 @@ final class XomperAPIClient: XomperAPIClientProtocol {
         let payload = WeeklyTriggerRequest(week: week, dryRun: dryRun, force: force)
         return try await postEncodableDecoding(
             "/admin/ai-review-weekly-trigger",
+            body: payload
+        )
+    }
+
+    /// Fire the Wednesday Week Preview newsletter pipeline manually.
+    /// Reuses the same wire shape as the weekly trigger — `week`
+    /// override + dryRun + force.
+    /// Backend route: `/admin/ai-review-week-preview-trigger`.
+    func triggerWeekPreviewAIReview(
+        week: Int?,
+        dryRun: Bool,
+        force: Bool
+    ) async throws -> AIReviewTriggerResponse {
+        let payload = WeeklyTriggerRequest(week: week, dryRun: dryRun, force: force)
+        return try await postEncodableDecoding(
+            "/admin/ai-review-week-preview-trigger",
             body: payload
         )
     }

--- a/Xomper/Core/Stores/AdminStore.swift
+++ b/Xomper/Core/Stores/AdminStore.swift
@@ -81,6 +81,19 @@ final class AdminStore {
     /// Driven by the override toggle + stepper on the weekly card.
     var weeklyWeekOverride: Int?
 
+    // MARK: - Phase 2 Week Preview trigger
+
+    /// Latest week-preview row, mirrors weeklyLatest.
+    private(set) var weekPreviewLatest: AIReport?
+    private(set) var isTriggeringWeekPreview = false
+    private(set) var weekPreviewError: Error?
+    private(set) var weekPreviewResult: AIReviewTriggerResponse?
+    var weekPreviewDryRun: Bool = true
+    /// When non-nil the trigger request includes an explicit `week`;
+    /// when nil the backend resolves the upcoming week from
+    /// `nfl_state.week`.
+    var weekPreviewWeekOverride: Int?
+
     // MARK: - F2 Email Previews
 
     /// In-memory store of rendered email previews per report type.
@@ -318,6 +331,55 @@ final class AdminStore {
         }
     }
 
+    // MARK: - Phase 2 Week Preview trigger
+
+    /// Fire the Wednesday Week Preview pipeline. Same shape as
+    /// `triggerWeekly` — optional week override, dry-run flag, force
+    /// flag. Updates `weekPreviewResult` + `weekPreviewError`. Reloads
+    /// `weekPreviewLatest` so the button label flips to "Regenerate
+    /// (force)" once a row exists for the resolved period.
+    @discardableResult
+    func triggerWeekPreview(
+        week: Int?,
+        dryRun: Bool,
+        force: Bool
+    ) async throws -> AIReviewTriggerResponse {
+        isTriggeringWeekPreview = true
+        weekPreviewError = nil
+        weekPreviewResult = nil
+        defer { isTriggeringWeekPreview = false }
+
+        do {
+            let response = try await apiClient.triggerWeekPreviewAIReview(
+                week: week,
+                dryRun: dryRun,
+                force: force
+            )
+            weekPreviewResult = response
+            if let previews = response.previews {
+                lastPreviewsByType[.weekPreview] = previews
+            }
+            await loadWeekPreviewLatest()
+            return response
+        } catch {
+            weekPreviewError = error
+            throw error
+        }
+    }
+
+    /// Refresh the most-recent week-preview row from
+    /// `/ai-reports/latest`. Idempotent — silent on failure (network
+    /// glitches surface as "no row" UX which is correct).
+    func loadWeekPreviewLatest() async {
+        do {
+            weekPreviewLatest = try await apiClient.fetchLatestAIReport(type: .weekPreview)
+        } catch {
+            // Silent — the trigger card surfaces errors via
+            // `weekPreviewError`; latest-row staleness isn't worth
+            // surfacing on its own.
+        }
+    }
+
     // MARK: - F2 Previews
 
     /// Drops the in-memory preview set for one report type. Used by
@@ -335,10 +397,11 @@ final class AdminStore {
     /// the call site.
     func latest(for reportType: AIReportType) -> AIReport? {
         switch reportType {
-        case .postDraft: return postDraftLatest
-        case .preseason: return preseasonLatest
-        case .weekly:    return weeklyLatest
-        case .mock:      return nil
+        case .postDraft:   return postDraftLatest
+        case .preseason:   return preseasonLatest
+        case .weekly:      return weeklyLatest
+        case .weekPreview: return weekPreviewLatest
+        case .mock:        return nil
         }
     }
 
@@ -367,10 +430,11 @@ final class AdminStore {
         // Refresh the affected latest so trigger card + preview view
         // pick up the flag change without a manual re-fetch.
         switch report.reportType {
-        case .postDraft: await loadPostDraftLatest()
-        case .preseason: await loadPreseasonLatest()
-        case .weekly:    await loadWeeklyLatest()
-        case .mock:      break
+        case .postDraft:   await loadPostDraftLatest()
+        case .preseason:   await loadPreseasonLatest()
+        case .weekly:      await loadWeeklyLatest()
+        case .weekPreview: await loadWeekPreviewLatest()
+        case .mock:        break
         }
         return response.metadata
     }

--- a/Xomper/Features/Admin/AIReviewPreviewView.swift
+++ b/Xomper/Features/Admin/AIReviewPreviewView.swift
@@ -62,10 +62,11 @@ struct AIReviewPreviewView: View {
 
     private var isTriggerInFlight: Bool {
         switch reportType {
-        case .postDraft: return adminStore.isTriggeringPostDraft
-        case .preseason: return adminStore.isTriggeringPreseason
-        case .weekly:    return adminStore.isTriggeringWeekly
-        case .mock:      return false
+        case .postDraft:   return adminStore.isTriggeringPostDraft
+        case .preseason:   return adminStore.isTriggeringPreseason
+        case .weekly:      return adminStore.isTriggeringWeekly
+        case .weekPreview: return adminStore.isTriggeringWeekPreview
+        case .mock:        return false
         }
     }
 
@@ -315,6 +316,12 @@ struct AIReviewPreviewView: View {
             case .weekly:
                 _ = try await adminStore.triggerWeekly(
                     week: adminStore.weeklyWeekOverride,
+                    dryRun: false,
+                    force: true
+                )
+            case .weekPreview:
+                _ = try await adminStore.triggerWeekPreview(
+                    week: adminStore.weekPreviewWeekOverride,
                     dryRun: false,
                     force: true
                 )

--- a/Xomper/Features/Admin/AIReviewSubScreen.swift
+++ b/Xomper/Features/Admin/AIReviewSubScreen.swift
@@ -40,12 +40,14 @@ struct AIReviewSubScreen: View {
                 await store.loadPostDraftLatest()
                 await store.loadPreseasonLatest()
                 await store.loadWeeklyLatest()
+                await store.loadWeekPreviewLatest()
             }
             .refreshable {
                 await store.refresh(sleeperUserId: callerSleeperId)
                 await store.loadPostDraftLatest()
                 await store.loadPreseasonLatest()
                 await store.loadWeeklyLatest()
+                await store.loadWeekPreviewLatest()
             }
     }
 
@@ -67,6 +69,8 @@ struct AIReviewSubScreen: View {
                 preseasonTriggerCard
 
                 weeklyTriggerCard
+
+                weekPreviewTriggerCard
 
                 testSenderCard
 
@@ -573,6 +577,179 @@ struct AIReviewSubScreen: View {
             )
         } catch {
             // Error already surfaced via store.weeklyError.
+        }
+    }
+
+    // MARK: - Phase 2 Week Preview trigger
+
+    private var weekPreviewTriggerCard: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Week Preview (Wed newsletter)")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.errorRed)
+                Text(weekPreviewStatusLine)
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textSecondary)
+            }
+
+            Toggle(isOn: $store.weekPreviewDryRun) {
+                Text("Dry run (admin-only delivery)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.textPrimary)
+            }
+            .toggleStyle(.switch)
+            .tint(XomperColors.errorRed)
+            .disabled(store.isTriggeringWeekPreview)
+
+            Toggle(isOn: weekPreviewOverrideEnabled) {
+                Text("Override week (default = upcoming)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.textPrimary)
+            }
+            .toggleStyle(.switch)
+            .tint(XomperColors.errorRed)
+            .disabled(store.isTriggeringWeekPreview)
+
+            if store.weekPreviewWeekOverride != nil {
+                Stepper(value: weekPreviewWeekBinding, in: 1...18) {
+                    HStack(spacing: XomperTheme.Spacing.xs) {
+                        Text("Week")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(XomperColors.textPrimary)
+                        Text("\(store.weekPreviewWeekOverride ?? 1)")
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(XomperColors.errorRed)
+                            .monospacedDigit()
+                    }
+                }
+                .disabled(store.isTriggeringWeekPreview)
+            }
+
+            HStack(spacing: XomperTheme.Spacing.sm) {
+                Button {
+                    Task { await triggerWeekPreview(force: false) }
+                } label: {
+                    HStack(spacing: XomperTheme.Spacing.xs) {
+                        if store.isTriggeringWeekPreview {
+                            ProgressView()
+                                .scaleEffect(0.7)
+                                .tint(XomperColors.bgDark)
+                        } else {
+                            Image(systemName: "calendar.badge.clock")
+                                .font(.caption2)
+                        }
+                        Text(weekPreviewPrimaryButtonLabel)
+                            .font(.caption.weight(.semibold))
+                    }
+                    .foregroundStyle(XomperColors.bgDark)
+                    .padding(.horizontal, XomperTheme.Spacing.sm)
+                    .padding(.vertical, XomperTheme.Spacing.xs)
+                    .frame(minHeight: 32)
+                    .background(XomperColors.errorRed)
+                    .clipShape(Capsule())
+                }
+                .buttonStyle(.pressableCard)
+                .disabled(store.isTriggeringWeekPreview)
+
+                if store.weekPreviewLatest != nil {
+                    Button {
+                        Task { await triggerWeekPreview(force: true) }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.caption2)
+                            Text("Regenerate (force)")
+                                .font(.caption.weight(.semibold))
+                        }
+                        .foregroundStyle(XomperColors.errorRed)
+                        .padding(.horizontal, XomperTheme.Spacing.sm)
+                        .padding(.vertical, XomperTheme.Spacing.xs)
+                        .frame(minHeight: 32)
+                        .overlay(
+                            Capsule()
+                                .strokeBorder(XomperColors.errorRed.opacity(0.6), lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(.pressableCard)
+                    .disabled(store.isTriggeringWeekPreview)
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            if let result = store.weekPreviewResult {
+                Text(weekPreviewResultLine(result))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.successGreen)
+            } else if let error = store.weekPreviewError {
+                Text("✗ \(error.localizedDescription)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.errorRed)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.errorRed.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    private var weekPreviewOverrideEnabled: Binding<Bool> {
+        Binding(
+            get: { store.weekPreviewWeekOverride != nil },
+            set: { newValue in
+                if newValue {
+                    if store.weekPreviewWeekOverride == nil {
+                        store.weekPreviewWeekOverride = 1
+                    }
+                } else {
+                    store.weekPreviewWeekOverride = nil
+                }
+            }
+        )
+    }
+
+    private var weekPreviewWeekBinding: Binding<Int> {
+        Binding(
+            get: { store.weekPreviewWeekOverride ?? 1 },
+            set: { store.weekPreviewWeekOverride = $0 }
+        )
+    }
+
+    private var weekPreviewStatusLine: String {
+        if let latest = store.weekPreviewLatest {
+            return "Last preview: \(latest.period) · \(formattedShortDate(latest.createdAt))"
+        }
+        return "No week-preview row yet — fires Wed 9am ET in production."
+    }
+
+    private var weekPreviewPrimaryButtonLabel: String {
+        if store.isTriggeringWeekPreview {
+            return "Firing…"
+        }
+        return store.weekPreviewLatest == nil ? "Generate" : "Regenerate"
+    }
+
+    private func weekPreviewResultLine(_ result: AIReviewTriggerResponse) -> String {
+        if result.dryRun {
+            return "✓ Dry run complete — delivered to admin only."
+        }
+        return "✓ Broadcast complete — \(result.deliveryCount) \(result.deliveryCount == 1 ? "email" : "emails") sent."
+    }
+
+    private func triggerWeekPreview(force: Bool) async {
+        do {
+            _ = try await store.triggerWeekPreview(
+                week: store.weekPreviewWeekOverride,
+                dryRun: store.weekPreviewDryRun,
+                force: force
+            )
+        } catch {
+            // Error already surfaced via store.weekPreviewError.
         }
     }
 


### PR DESCRIPTION
Phase 2 PR 3 of 3. iOS surface for the Wednesday Week Preview pipeline shipped in xomper-back-end #85 and xomper-infrastructure #122.

- `AIReportType.weekPreview`
- `TestEmailKind.weekPreview` (picker + dispatch)
- `AdminStore` trigger state + methods
- `AIReviewSubScreen` red-themed trigger card
- `AIReviewPreviewView` switch updates