### PR TITLE
feat(week-preview): seasons_back toggle on iOS trigger card

### DIFF
--- a/Xomper/Core/Networking/XomperAPIClient.swift
+++ b/Xomper/Core/Networking/XomperAPIClient.swift
@@ -25,7 +25,7 @@ protocol XomperAPIClientProtocol: Sendable {
     func triggerPostDraftAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse
     func triggerPreseasonAIReview(dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse
     func triggerWeeklyAIReview(week: Int?, dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse
-    func triggerWeekPreviewAIReview(week: Int?, dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse
+    func triggerWeekPreviewAIReview(week: Int?, dryRun: Bool, force: Bool, seasonsBack: Int?) async throws -> AIReviewTriggerResponse
 
     // Admin: report metadata flags (F3)
     func setReportFlag(
@@ -135,11 +135,24 @@ struct WeeklyTriggerRequest: Encodable, Sendable {
     let week: Int?
     let dryRun: Bool
     let force: Bool
+    /// Walk previous_league_id N times from the active league.
+    /// 0 = current season. Useful for backfill / offseason previews
+    /// against last year's data. `encodeIfPresent` so `nil` omits the
+    /// key entirely (backend treats absent as 0).
+    let seasonsBack: Int?
 
     enum CodingKeys: String, CodingKey {
         case week
         case dryRun = "dry_run"
         case force
+        case seasonsBack = "seasons_back"
+    }
+
+    init(week: Int?, dryRun: Bool, force: Bool, seasonsBack: Int? = nil) {
+        self.week = week
+        self.dryRun = dryRun
+        self.force = force
+        self.seasonsBack = seasonsBack
     }
 
     func encode(to encoder: Encoder) throws {
@@ -147,6 +160,7 @@ struct WeeklyTriggerRequest: Encodable, Sendable {
         try container.encodeIfPresent(week, forKey: .week)
         try container.encode(dryRun, forKey: .dryRun)
         try container.encode(force, forKey: .force)
+        try container.encodeIfPresent(seasonsBack, forKey: .seasonsBack)
     }
 }
 
@@ -1034,9 +1048,15 @@ final class XomperAPIClient: XomperAPIClientProtocol {
     func triggerWeekPreviewAIReview(
         week: Int?,
         dryRun: Bool,
-        force: Bool
+        force: Bool,
+        seasonsBack: Int?
     ) async throws -> AIReviewTriggerResponse {
-        let payload = WeeklyTriggerRequest(week: week, dryRun: dryRun, force: force)
+        let payload = WeeklyTriggerRequest(
+            week: week,
+            dryRun: dryRun,
+            force: force,
+            seasonsBack: seasonsBack
+        )
         return try await postEncodableDecoding(
             "/admin/ai-review-week-preview-trigger",
             body: payload

--- a/Xomper/Core/Stores/AdminStore.swift
+++ b/Xomper/Core/Stores/AdminStore.swift
@@ -93,6 +93,10 @@ final class AdminStore {
     /// when nil the backend resolves the upcoming week from
     /// `nfl_state.week`.
     var weekPreviewWeekOverride: Int?
+    /// When > 0, the trigger walks previous_league_id N times AND
+    /// bypasses the season_type gate. Lets admin fire the live
+    /// pipeline against last year's data while in offseason.
+    var weekPreviewSeasonsBack: Int = 0
 
     // MARK: - F2 Email Previews
 
@@ -342,7 +346,8 @@ final class AdminStore {
     func triggerWeekPreview(
         week: Int?,
         dryRun: Bool,
-        force: Bool
+        force: Bool,
+        seasonsBack: Int? = nil
     ) async throws -> AIReviewTriggerResponse {
         isTriggeringWeekPreview = true
         weekPreviewError = nil
@@ -353,7 +358,8 @@ final class AdminStore {
             let response = try await apiClient.triggerWeekPreviewAIReview(
                 week: week,
                 dryRun: dryRun,
-                force: force
+                force: force,
+                seasonsBack: seasonsBack
             )
             weekPreviewResult = response
             if let previews = response.previews {

--- a/Xomper/Features/Admin/AIReviewPreviewView.swift
+++ b/Xomper/Features/Admin/AIReviewPreviewView.swift
@@ -323,7 +323,8 @@ struct AIReviewPreviewView: View {
                 _ = try await adminStore.triggerWeekPreview(
                     week: adminStore.weekPreviewWeekOverride,
                     dryRun: false,
-                    force: true
+                    force: true,
+                    seasonsBack: adminStore.weekPreviewSeasonsBack > 0 ? adminStore.weekPreviewSeasonsBack : nil
                 )
             case .mock:
                 broadcastError = "Mock drafts can't be broadcast from this screen."

--- a/Xomper/Features/Admin/AIReviewSubScreen.swift
+++ b/Xomper/Features/Admin/AIReviewSubScreen.swift
@@ -602,6 +602,15 @@ struct AIReviewSubScreen: View {
             .tint(XomperColors.errorRed)
             .disabled(store.isTriggeringWeekPreview)
 
+            Toggle(isOn: weekPreviewLastSeasonBinding) {
+                Text("Use last season's data (offseason preview)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.textPrimary)
+            }
+            .toggleStyle(.switch)
+            .tint(XomperColors.errorRed)
+            .disabled(store.isTriggeringWeekPreview)
+
             Toggle(isOn: weekPreviewOverrideEnabled) {
                 Text("Override week (default = upcoming)")
                     .font(.caption.weight(.semibold))
@@ -720,6 +729,18 @@ struct AIReviewSubScreen: View {
         )
     }
 
+    /// One-step "use last season" toggle that maps onto
+    /// `seasonsBack`. 0 = current, 1 = last. Multi-season backfill
+    /// isn't needed yet — easy to extend later.
+    private var weekPreviewLastSeasonBinding: Binding<Bool> {
+        Binding(
+            get: { store.weekPreviewSeasonsBack > 0 },
+            set: { newValue in
+                store.weekPreviewSeasonsBack = newValue ? 1 : 0
+            }
+        )
+    }
+
     private var weekPreviewStatusLine: String {
         if let latest = store.weekPreviewLatest {
             return "Last preview: \(latest.period) · \(formattedShortDate(latest.createdAt))"
@@ -743,10 +764,15 @@ struct AIReviewSubScreen: View {
 
     private func triggerWeekPreview(force: Bool) async {
         do {
+            // Send seasons_back only when > 0 so a clean current-season
+            // call leaves the key omitted entirely (backend default
+            // path is sturdier that way).
+            let sb: Int? = store.weekPreviewSeasonsBack > 0 ? store.weekPreviewSeasonsBack : nil
             _ = try await store.triggerWeekPreview(
                 week: store.weekPreviewWeekOverride,
                 dryRun: store.weekPreviewDryRun,
-                force: force
+                force: force,
+                seasonsBack: sb
             )
         } catch {
             // Error already surfaced via store.weekPreviewError.


### PR DESCRIPTION
Adds 'Use last season's data' toggle. When on, fires the production AI pipeline against last year's matchups.