### PR TITLE
feat(email-archive): iOS list + detail + resend screens

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		007B11207486956897981421 /* LandingViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F3E6606D89CF3AEB320314 /* LandingViewTests.swift */; };
 		021A039E220940CD2E12304A /* NavigationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840D50097382434B0D123ACB /* NavigationStore.swift */; };
 		02AC6FBAE68011749AA17644 /* ClinchCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3893B13276074EF6033CEA2 /* ClinchCalculatorTests.swift */; };
+		02B230B210B4BFC6DEE151C4 /* EmailArchiveStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F01A41F93A3CE34A49D23D /* EmailArchiveStore.swift */; };
 		04C5B75AA224E7ED8314FBA5 /* AIReviewHomeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12507ED13C57EFA8B240301 /* AIReviewHomeCard.swift */; };
 		063FCD6AA342CA5D64ED79ED /* HistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F013CD37874EFB0FA1CB4261 /* HistoryStore.swift */; };
 		08251EFB3181B634553CDCE1 /* TaxiSquadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57940AEB84889A20016648F2 /* TaxiSquadView.swift */; };
@@ -61,6 +62,7 @@
 		42F9C81AF6338A720FE0BC12 /* ArchiveNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E65C159F2C84E48B61A9A8 /* ArchiveNavigationTests.swift */; };
 		440A44095AD70A8D3D273EEE /* StandingsScrollBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1A7B1219575171DA3ABAB7 /* StandingsScrollBar.swift */; };
 		4A321187068EEBA8C4E75EFE /* PayoutProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E3BE36BCEA1A7722157C37 /* PayoutProjection.swift */; };
+		4AFF52CDFE011C65E819946A /* EmailArchiveListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52633D7C9BB49C28288B36A6 /* EmailArchiveListView.swift */; };
 		4B629DB100C96EB68A6A9A41 /* SearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323F422F2D0E1C2BA5D46C0A /* SearchResults.swift */; };
 		4DA6A8F315E4AFF217B5C7F5 /* MockDraftStoreFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7589768F3AF9DB478D8E0419 /* MockDraftStoreFallbackTests.swift */; };
 		4DB9374CF45A69E97C02FC94 /* PlayerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC44D14381C74E97D8AF868F /* PlayerDetailView.swift */; };
@@ -191,6 +193,7 @@
 		EE987501F73209179D5CEEB4 /* TestEmailStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E98CD5B3ECB6292B6D7637B /* TestEmailStore.swift */; };
 		F118537BB85C27688E57C703 /* CronSettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4C60C4B1F35CD6B056AC29 /* CronSettingsStoreTests.swift */; };
 		F201A3A40D624F6AAA0C0CC1 /* PlayoffBracket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */; };
+		F282749973A1BEB62909498F /* EmailArchiveDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19CAA19890E461D00B644AA0 /* EmailArchiveDetailView.swift */; };
 		F2CDF62D6ED30924FD44F37A /* MarkdownReflow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24B1B312AA1DD24D8453822 /* MarkdownReflow.swift */; };
 		F57132F0D80EAB60AC0E07F3 /* WhitelistedLeague.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747C6FC769C117588F8A93E /* WhitelistedLeague.swift */; };
 		F5AC0E08C9F82995736A62EF /* LogsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B38051DBBEE34C89E9446FE /* LogsView.swift */; };
@@ -227,6 +230,7 @@
 		1687307C5353DC42503BD721 /* AuditDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditDetailView.swift; sourceTree = "<group>"; };
 		16CD7928EAED8A9ADA1C683B /* EngineMockedPick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineMockedPick.swift; sourceTree = "<group>"; };
 		18383A0375F5728A9E3FE065 /* Championship.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Championship.swift; sourceTree = "<group>"; };
+		19CAA19890E461D00B644AA0 /* EmailArchiveDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailArchiveDetailView.swift; sourceTree = "<group>"; };
 		1A884A785F461C755979D421 /* AnnouncementsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsStoreTests.swift; sourceTree = "<group>"; };
 		1AD376EFB7AD4A192FAB3E8F /* RecordBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordBadge.swift; sourceTree = "<group>"; };
 		1D61FC118C0250CA87BDF647 /* ReportFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportFlagTests.swift; sourceTree = "<group>"; };
@@ -267,6 +271,7 @@
 		4D0F4D0BBA2C48A0232C43FF /* EmailPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailPreviewTests.swift; sourceTree = "<group>"; };
 		501B8FD2B915B3BD6568F42C /* HexagonChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HexagonChartView.swift; sourceTree = "<group>"; };
 		50D86A1E276C98E0A3D5070F /* MocksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MocksView.swift; sourceTree = "<group>"; };
+		52633D7C9BB49C28288B36A6 /* EmailArchiveListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailArchiveListView.swift; sourceTree = "<group>"; };
 		536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthStore.swift; sourceTree = "<group>"; };
 		539C1490E2B5B3B9C4FAB735 /* MockDraftResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftResult.swift; sourceTree = "<group>"; };
 		558164667DF7D89C4DF2F32E /* MyProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyProfileView.swift; sourceTree = "<group>"; };
@@ -407,6 +412,7 @@
 		F1E7D0FD804723AC6A3E4298 /* HeaderBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderBar.swift; sourceTree = "<group>"; };
 		F2452A5AEC270BE14CC085E1 /* URL+Sleeper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Sleeper.swift"; sourceTree = "<group>"; };
 		F26DB16948AD7EE81EF91B47 /* MockDraftModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftModels.swift; sourceTree = "<group>"; };
+		F2F01A41F93A3CE34A49D23D /* EmailArchiveStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailArchiveStore.swift; sourceTree = "<group>"; };
 		F3443191E5EED3E2888F8757 /* PayoutsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayoutsView.swift; sourceTree = "<group>"; };
 		F4A254D17EF062523E09C9D4 /* MainShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainShell.swift; sourceTree = "<group>"; };
 		F51CC9357B13AB7ADD9C8586 /* TeamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamView.swift; sourceTree = "<group>"; };
@@ -815,6 +821,8 @@
 				1687307C5353DC42503BD721 /* AuditDetailView.swift */,
 				B1358E97D2A18E9A5440D8CC /* AuditFeedView.swift */,
 				C7474B2C8F1F2B14821F4539 /* CronSettingsView.swift */,
+				19CAA19890E461D00B644AA0 /* EmailArchiveDetailView.swift */,
+				52633D7C9BB49C28288B36A6 /* EmailArchiveListView.swift */,
 				9E8B04D9DD0B2952BBABAB46 /* LeagueEditView.swift */,
 				BC0B516C6EF1C2084E204E8E /* LeaguesListView.swift */,
 				B67C55260D2B14215D920245 /* LogsRowView.swift */,
@@ -837,6 +845,7 @@
 				536B3E71286A0BC3A7CD8DA6 /* AuthStore.swift */,
 				3728C5F6BEF61FE509A3EA32 /* ClinchCalculator.swift */,
 				B1B9527EA5CA26FE5197FCF5 /* CronSettingsStore.swift */,
+				F2F01A41F93A3CE34A49D23D /* EmailArchiveStore.swift */,
 				F013CD37874EFB0FA1CB4261 /* HistoryStore.swift */,
 				56BB91320E3D5EBE1F777838 /* LeagueStore.swift */,
 				A3AF6560D898E487AD13DA35 /* LogsStore.swift */,
@@ -1089,6 +1098,9 @@
 				6D833D6D3E53E0913363925C /* DraftSubTabBar.swift in Sources */,
 				3B1DDBCA7B19B8703FAF717E /* DrawerScrim.swift in Sources */,
 				817EEBDA82021E74A830E1B3 /* DrawerView.swift in Sources */,
+				F282749973A1BEB62909498F /* EmailArchiveDetailView.swift in Sources */,
+				4AFF52CDFE011C65E819946A /* EmailArchiveListView.swift in Sources */,
+				02B230B210B4BFC6DEE151C4 /* EmailArchiveStore.swift in Sources */,
 				C1B45AB2AF3DC33FE9B511AF /* EmailPreview.swift in Sources */,
 				72FF7B4516B2DCDAE4683B9D /* EmptyStateView.swift in Sources */,
 				10F252D05E75C513A5780FD8 /* EngineMockedPick.swift in Sources */,

--- a/Xomper/Core/Networking/XomperAPIClient.swift
+++ b/Xomper/Core/Networking/XomperAPIClient.swift
@@ -27,6 +27,11 @@ protocol XomperAPIClientProtocol: Sendable {
     func triggerWeeklyAIReview(week: Int?, dryRun: Bool, force: Bool) async throws -> AIReviewTriggerResponse
     func triggerWeekPreviewAIReview(week: Int?, dryRun: Bool, force: Bool, seasonsBack: Int?) async throws -> AIReviewTriggerResponse
 
+    // Email Archive (Phase 3)
+    func fetchEmailArchive(limit: Int, cursor: String?, recipient: String?, template: String?) async throws -> EmailArchiveListResponse
+    func fetchEmailArchiveDetail(id: String) async throws -> EmailArchiveEntry
+    func resendArchivedEmail(id: String, toEmail: String) async throws -> ResendEmailResponse
+
     // Admin: report metadata flags (F3)
     func setReportFlag(
         leagueId: String,
@@ -346,6 +351,70 @@ struct TestEmailTemplateResponse: Codable, Sendable {
         case sentAt = "sent_at"
         case subject
     }
+}
+
+// MARK: - Email Archive (Phase 3)
+
+/// Wraps `GET /admin/emails-list`. Backend returns paginated metadata
+/// (HTML/text bodies omitted) plus a `next_cursor` for the next page.
+struct EmailArchiveListResponse: Decodable, Sendable {
+    let rows: [EmailArchiveEntry]
+    let nextCursor: String?
+
+    enum CodingKeys: String, CodingKey {
+        case rows
+        case nextCursor = "next_cursor"
+    }
+}
+
+/// One row from `email_archive`. Used for both the list (where
+/// htmlBody/textBody are nil) and the detail fetch (where they're
+/// populated). All fields are leniently decoded because the table
+/// schema is mostly nullable.
+struct EmailArchiveEntry: Decodable, Identifiable, Sendable, Hashable {
+    let id: String
+    let sentAt: String
+    let template: String?
+    let subject: String
+    let recipientEmail: String
+    let messageId: String?
+    let htmlBody: String?
+    let textBody: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case sentAt = "sent_at"
+        case template
+        case subject
+        case recipientEmail = "recipient_email"
+        case messageId = "message_id"
+        case htmlBody = "html_body"
+        case textBody = "text_body"
+    }
+}
+
+/// Response from `POST /admin/emails-resend`.
+struct ResendEmailResponse: Decodable, Sendable {
+    let sourceId: String
+    let recipientEmail: String
+    let subject: String
+    let template: String?
+    let messageId: String?
+    let sentAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case sourceId = "source_id"
+        case recipientEmail = "recipient_email"
+        case subject
+        case template
+        case messageId = "message_id"
+        case sentAt = "sent_at"
+    }
+}
+
+/// Wrapper for `GET /admin/emails-detail` — backend nests the row.
+private struct EmailArchiveDetailEnvelope: Decodable, Sendable {
+    let row: EmailArchiveEntry
 }
 
 // MARK: - Admin Tables + Audit (F4)
@@ -869,6 +938,46 @@ final class XomperAPIClient: XomperAPIClientProtocol {
             "report_id": reportId,
         ]
         return try await postDecoding("/admin/email-test", body: body)
+    }
+
+    // MARK: - Email Archive (Phase 3)
+
+    func fetchEmailArchive(
+        limit: Int,
+        cursor: String?,
+        recipient: String?,
+        template: String?
+    ) async throws -> EmailArchiveListResponse {
+        var items: [URLQueryItem] = [URLQueryItem(name: "limit", value: String(limit))]
+        if let cursor, !cursor.isEmpty {
+            items.append(URLQueryItem(name: "cursor", value: cursor))
+        }
+        if let recipient, !recipient.isEmpty {
+            items.append(URLQueryItem(name: "recipient", value: recipient))
+        }
+        if let template, !template.isEmpty {
+            items.append(URLQueryItem(name: "template", value: template))
+        }
+        return try await get("/admin/emails-list", queryItems: items)
+    }
+
+    func fetchEmailArchiveDetail(id: String) async throws -> EmailArchiveEntry {
+        let response: EmailArchiveDetailEnvelope = try await get(
+            "/admin/emails-detail",
+            queryItems: [URLQueryItem(name: "id", value: id)]
+        )
+        return response.row
+    }
+
+    func resendArchivedEmail(
+        id: String,
+        toEmail: String
+    ) async throws -> ResendEmailResponse {
+        let body: [String: Any] = [
+            "id": id,
+            "to_email": toEmail,
+        ]
+        return try await postDecoding("/admin/emails-resend", body: body)
     }
 
     /// Send a sample non-AI-Review email template to a single

--- a/Xomper/Core/Stores/EmailArchiveStore.swift
+++ b/Xomper/Core/Stores/EmailArchiveStore.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+/// Drives the admin Email Archive list + detail + resend flow.
+///
+/// Owns:
+/// - `rows` — the paginated list, newest-first
+/// - `selectedDetail` — full row for the currently-open detail view
+/// - `isLoading` / `error` for the list path
+/// - `isLoadingDetail` / `detailError` for the detail path
+/// - `isResending` / `resendResult` / `resendError` for the resend form
+///
+/// All API calls go through the shared `XomperAPIClientProtocol`;
+/// tests swap a mock via the init.
+@Observable
+@MainActor
+final class EmailArchiveStore {
+
+    // MARK: - State
+
+    private(set) var rows: [EmailArchiveEntry] = []
+    private(set) var nextCursor: String?
+    private(set) var isLoading = false
+    private(set) var error: String?
+
+    private(set) var selectedDetail: EmailArchiveEntry?
+    private(set) var isLoadingDetail = false
+    private(set) var detailError: String?
+
+    private(set) var isResending = false
+    private(set) var resendResult: ResendEmailResponse?
+    private(set) var resendError: String?
+
+    // MARK: - Dependencies
+
+    private let apiClient: XomperAPIClientProtocol
+    private let pageSize: Int
+
+    init(apiClient: XomperAPIClientProtocol = XomperAPIClient(), pageSize: Int = 25) {
+        self.apiClient = apiClient
+        self.pageSize = pageSize
+    }
+
+    // MARK: - List
+
+    /// Wholesale reload — used on first appearance + pull-to-refresh.
+    func reload() async {
+        guard !isLoading else { return }
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+
+        do {
+            let response = try await apiClient.fetchEmailArchive(
+                limit: pageSize,
+                cursor: nil,
+                recipient: nil,
+                template: nil
+            )
+            rows = response.rows
+            nextCursor = response.nextCursor
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    /// Append-page — called when the last list row appears so the
+    /// admin can scroll back through history.
+    func loadMore() async {
+        guard !isLoading, let cursor = nextCursor else { return }
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let response = try await apiClient.fetchEmailArchive(
+                limit: pageSize,
+                cursor: cursor,
+                recipient: nil,
+                template: nil
+            )
+            rows.append(contentsOf: response.rows)
+            nextCursor = response.nextCursor
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    // MARK: - Detail
+
+    func loadDetail(id: String) async {
+        guard !isLoadingDetail else { return }
+        isLoadingDetail = true
+        detailError = nil
+        selectedDetail = nil
+        defer { isLoadingDetail = false }
+
+        do {
+            selectedDetail = try await apiClient.fetchEmailArchiveDetail(id: id)
+        } catch {
+            detailError = error.localizedDescription
+        }
+    }
+
+    // MARK: - Resend
+
+    /// Fire `POST /admin/emails-resend` against the loaded detail row
+    /// to a typed-in recipient. Surfaces success in `resendResult`,
+    /// failure in `resendError`. Clears previous result/error on each
+    /// call so the toast UI is always current.
+    func resend(toEmail: String) async {
+        guard let detail = selectedDetail else { return }
+        guard !isResending else { return }
+        let trimmed = toEmail.trimmingCharacters(in: .whitespaces)
+        guard trimmed.contains("@") else {
+            resendError = "Enter a valid email address."
+            return
+        }
+        isResending = true
+        resendError = nil
+        resendResult = nil
+        defer { isResending = false }
+
+        do {
+            let response = try await apiClient.resendArchivedEmail(
+                id: detail.id,
+                toEmail: trimmed
+            )
+            resendResult = response
+        } catch {
+            resendError = error.localizedDescription
+        }
+    }
+
+    /// Reset state when navigating away from the detail screen so
+    /// the next tap doesn't show stale resend toast.
+    func clearDetailState() {
+        selectedDetail = nil
+        detailError = nil
+        isLoadingDetail = false
+        resendResult = nil
+        resendError = nil
+        isResending = false
+    }
+}

--- a/Xomper/Features/Admin/AdminView.swift
+++ b/Xomper/Features/Admin/AdminView.swift
@@ -74,6 +74,13 @@ struct AdminView: View {
                     )
                 }
 
+                AdminMenuRow(
+                    icon: "tray.full",
+                    title: "Email Archive",
+                    subtitle: "View every send. Resend to a typed-in address.",
+                    action: { router.navigate(to: .adminEmailArchive) }
+                )
+
                 if Config.AdminFlags.showTables {
                     AdminMenuRow(
                         icon: "tablecells",

--- a/Xomper/Features/Admin/EmailArchiveDetailView.swift
+++ b/Xomper/Features/Admin/EmailArchiveDetailView.swift
@@ -1,0 +1,215 @@
+import SwiftUI
+import WebKit
+
+/// Detail screen for one archived email. Renders the HTML body via
+/// WKWebView (sandbox + no JavaScript) so what you see is what was
+/// actually sent. Below the preview, a resend form takes a typed-in
+/// recipient and fires `POST /admin/emails-resend`.
+struct EmailArchiveDetailView: View {
+    let id: String
+    var store: EmailArchiveStore
+    var router: AppRouter
+
+    @State private var resendInput: String = ""
+
+    var body: some View {
+        content
+            .background(XomperColors.bgDark.ignoresSafeArea())
+            .navigationTitle("Email Detail")
+            .navigationBarTitleDisplayMode(.inline)
+            .task {
+                if store.selectedDetail?.id != id {
+                    await store.loadDetail(id: id)
+                }
+            }
+            .onDisappear {
+                store.clearDetailState()
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if store.isLoadingDetail {
+            LoadingView(message: "Loading email…")
+        } else if let error = store.detailError {
+            ErrorView(message: error) {
+                Task { await store.loadDetail(id: id) }
+            }
+        } else if let detail = store.selectedDetail {
+            ScrollView {
+                VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
+                    metadataCard(detail)
+                    htmlPreview(detail)
+                    resendCard(detail)
+                }
+                .padding(.horizontal, XomperTheme.Spacing.md)
+                .padding(.vertical, XomperTheme.Spacing.sm)
+            }
+        } else {
+            EmptyView()
+        }
+    }
+
+    // MARK: - Metadata card
+
+    private func metadataCard(_ detail: EmailArchiveEntry) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            if let template = detail.template, !template.isEmpty {
+                Text(template.uppercased())
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(XomperColors.bgDark)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(XomperColors.championGold)
+                    .clipShape(Capsule())
+            }
+            Text(detail.subject)
+                .font(.headline.weight(.bold))
+                .foregroundStyle(XomperColors.textPrimary)
+            Text("Sent to \(detail.recipientEmail)")
+                .font(.caption)
+                .foregroundStyle(XomperColors.textSecondary)
+            Text(detail.sentAt)
+                .font(.caption2)
+                .foregroundStyle(XomperColors.textMuted)
+                .monospacedDigit()
+            if let messageId = detail.messageId, !messageId.isEmpty {
+                Text("SES \(messageId)")
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.textMuted)
+                    .lineLimit(1)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+    }
+
+    // MARK: - HTML preview
+
+    @ViewBuilder
+    private func htmlPreview(_ detail: EmailArchiveEntry) -> some View {
+        if let html = detail.htmlBody, !html.isEmpty {
+            EmailHTMLPreview(html: html)
+                .frame(height: 520)
+                .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+        } else if let text = detail.textBody, !text.isEmpty {
+            ScrollView {
+                Text(text)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(XomperTheme.Spacing.md)
+            }
+            .frame(height: 520)
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+        } else {
+            EmptyStateView(
+                icon: "doc",
+                title: "No body stored",
+                message: "This row was archived without an HTML or text body."
+            )
+        }
+    }
+
+    // MARK: - Resend card
+
+    private func resendCard(_ detail: EmailArchiveEntry) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            Text("Resend to")
+                .font(.subheadline.weight(.bold))
+                .foregroundStyle(XomperColors.championGold)
+            Text("Re-fires this exact email (no re-rendering) to a typed-in address. The new send is also archived.")
+                .font(.caption)
+                .foregroundStyle(XomperColors.textSecondary)
+
+            TextField("name@example.com", text: $resendInput)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .keyboardType(.emailAddress)
+                .padding(.horizontal, XomperTheme.Spacing.sm)
+                .padding(.vertical, XomperTheme.Spacing.xs)
+                .frame(minHeight: XomperTheme.minTouchTarget)
+                .background(XomperColors.bgDark)
+                .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+                .foregroundStyle(XomperColors.textPrimary)
+                .disabled(store.isResending)
+
+            Button {
+                Task {
+                    let generator = UIImpactFeedbackGenerator(style: .medium)
+                    generator.impactOccurred()
+                    await store.resend(toEmail: resendInput)
+                }
+            } label: {
+                HStack(spacing: XomperTheme.Spacing.xs) {
+                    if store.isResending {
+                        ProgressView()
+                            .scaleEffect(0.7)
+                            .tint(XomperColors.bgDark)
+                    } else {
+                        Image(systemName: "paperplane.fill")
+                            .font(.caption2)
+                    }
+                    Text(store.isResending ? "Sending…" : "Resend")
+                        .font(.subheadline.weight(.bold))
+                }
+                .foregroundStyle(XomperColors.bgDark)
+                .padding(.horizontal, XomperTheme.Spacing.md)
+                .padding(.vertical, XomperTheme.Spacing.sm)
+                .frame(maxWidth: .infinity, minHeight: XomperTheme.minTouchTarget)
+                .background(canResend ? XomperColors.championGold : XomperColors.championGold.opacity(0.4))
+                .clipShape(Capsule())
+            }
+            .buttonStyle(.pressableCard)
+            .disabled(!canResend)
+
+            if let result = store.resendResult {
+                Text("✓ Sent to \(result.recipientEmail)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.successGreen)
+            } else if let error = store.resendError {
+                Text("✗ \(error)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.errorRed)
+                    .lineLimit(2)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    private var canResend: Bool {
+        !store.isResending && resendInput.contains("@") && resendInput.count > 3
+    }
+}
+
+// MARK: - HTML rendering host
+
+/// Minimal WKWebView wrapper for rendering the archived HTML. No JS,
+/// no remote loads — we just dump the stored string into a sandbox.
+private struct EmailHTMLPreview: UIViewRepresentable {
+    let html: String
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.preferences.javaScriptEnabled = false
+        let view = WKWebView(frame: .zero, configuration: config)
+        view.backgroundColor = UIColor.black
+        view.isOpaque = false
+        view.scrollView.indicatorStyle = .white
+        return view
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        uiView.loadHTMLString(html, baseURL: nil)
+    }
+}

--- a/Xomper/Features/Admin/EmailArchiveListView.swift
+++ b/Xomper/Features/Admin/EmailArchiveListView.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+/// Admin → Email Archive list. Newest-first paginated list of every
+/// SES send the backend has archived. Tap a row to push the detail
+/// view (with HTML preview + resend form).
+///
+/// Empty state when no rows yet; error inline with a retry button.
+struct EmailArchiveListView: View {
+    var store: EmailArchiveStore
+    var router: AppRouter
+
+    var body: some View {
+        content
+            .background(XomperColors.bgDark.ignoresSafeArea())
+            .navigationTitle("Email Archive")
+            .navigationBarTitleDisplayMode(.inline)
+            .task {
+                if store.rows.isEmpty {
+                    await store.reload()
+                }
+            }
+            .refreshable {
+                await store.reload()
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if store.isLoading && store.rows.isEmpty {
+            LoadingView(message: "Loading emails…")
+        } else if let error = store.error, store.rows.isEmpty {
+            ErrorView(message: error) {
+                Task { await store.reload() }
+            }
+        } else if store.rows.isEmpty {
+            EmptyStateView(
+                icon: "tray",
+                title: "No archived emails",
+                message: "Every successful send shows up here once the new archive table is live."
+            )
+        } else {
+            ScrollView {
+                LazyVStack(spacing: XomperTheme.Spacing.sm) {
+                    ForEach(store.rows) { entry in
+                        Button {
+                            router.navigate(to: .adminEmailArchiveDetail(id: entry.id))
+                        } label: {
+                            row(entry)
+                        }
+                        .buttonStyle(.pressableCard)
+                        .onAppear {
+                            // Trigger pagination when the last row appears.
+                            if entry.id == store.rows.last?.id,
+                               store.nextCursor != nil {
+                                Task { await store.loadMore() }
+                            }
+                        }
+                    }
+
+                    if store.isLoading {
+                        ProgressView()
+                            .tint(XomperColors.championGold)
+                            .padding(.vertical, XomperTheme.Spacing.sm)
+                    }
+                }
+                .padding(.horizontal, XomperTheme.Spacing.md)
+                .padding(.vertical, XomperTheme.Spacing.sm)
+            }
+        }
+    }
+
+    private func row(_ entry: EmailArchiveEntry) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                if let template = entry.template, !template.isEmpty {
+                    Text(template.uppercased())
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(XomperColors.bgDark)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(XomperColors.championGold)
+                        .clipShape(Capsule())
+                }
+                Spacer(minLength: 0)
+                Text(formattedSentAt(entry.sentAt))
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.textMuted)
+                    .monospacedDigit()
+            }
+            Text(entry.subject)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(XomperColors.textPrimary)
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
+            Text(entry.recipientEmail)
+                .font(.caption)
+                .foregroundStyle(XomperColors.textSecondary)
+                .lineLimit(1)
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+    }
+
+    private func formattedSentAt(_ raw: String) -> String {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = f.date(from: raw) ?? ISO8601DateFormatter().date(from: raw) {
+            let out = DateFormatter()
+            out.dateFormat = "MMM d, h:mm a"
+            return out.string(from: date)
+        }
+        return raw
+    }
+}

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -48,6 +48,7 @@ struct MainShell: View {
     /// Single-instance to keep optimistic toggles + pending-row state
     /// stable across re-renders during the in-flight POST.
     @State private var cronSettingsStore = CronSettingsStore()
+    @State private var emailArchiveStore = EmailArchiveStore()
     /// announcements: drives the Landing → Announcements card (public
     /// read) and the Admin → Announcements sub-screen (admin CRUD).
     /// Single instance so optimistic admin mutations land on the same
@@ -545,6 +546,12 @@ struct MainShell: View {
 
         case .adminCronSettings:
             CronSettingsView(store: cronSettingsStore)
+
+        case .adminEmailArchive:
+            EmailArchiveListView(store: emailArchiveStore, router: router)
+
+        case .adminEmailArchiveDetail(let id):
+            EmailArchiveDetailView(id: id, store: emailArchiveStore, router: router)
 
         case .adminAnnouncements:
             AnnouncementsListView(store: announcementsStore, router: router)

--- a/Xomper/Navigation/AppRouter.swift
+++ b/Xomper/Navigation/AppRouter.swift
@@ -68,6 +68,14 @@ enum AppRoute: Hashable {
     /// sub-screen (per-lambda kill switch + test-mode toggles).
     case adminCronSettings
 
+    /// Pushed from `AdminView`'s menu — opens the Email Archive list
+    /// (every successful SES send is archived; admin can view + resend).
+    case adminEmailArchive
+
+    /// Pushed from `EmailArchiveListView` — full detail for one row
+    /// with HTML preview + resend form.
+    case adminEmailArchiveDetail(id: String)
+
     /// Pushed from `AdminView`'s menu — opens the Announcements
     /// admin list (all rows including inactive + expired).
     case adminAnnouncements

--- a/docs/migrations/2026-06-03-email-archive.sql
+++ b/docs/migrations/2026-06-03-email-archive.sql
@@ -1,0 +1,31 @@
+-- Migration: email_archive table for admin view + resend.
+-- Every successful SES send writes one row here (best-effort — failures
+-- are swallowed by ses_helper.send_email so a Supabase outage doesn't
+-- break email delivery).
+--
+-- Run in Supabase dashboard SQL editor. Idempotent — uses IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS email_archive (
+    id                uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    sent_at           timestamptz NOT NULL DEFAULT NOW(),
+    template          text,                   -- e.g. weekly_recap, week_preview, ai_review_test
+    subject           text        NOT NULL,
+    recipient_email   text        NOT NULL,
+    html_body         text,                   -- can be ~50kb for AI Review payloads
+    text_body         text,
+    message_id        text,                   -- SES response message id
+    metadata          jsonb       NOT NULL DEFAULT '{}'::jsonb
+);
+
+-- Index by recipient + date for the admin list query (recent first,
+-- optionally filtered to a specific user).
+CREATE INDEX IF NOT EXISTS email_archive_sent_at_desc
+    ON email_archive (sent_at DESC);
+
+CREATE INDEX IF NOT EXISTS email_archive_recipient_sent_at
+    ON email_archive (recipient_email, sent_at DESC);
+
+-- Row-level security: only the service role (which the backend lambdas
+-- use) can read/write. Admin lambdas authenticate as the service role
+-- via SUPABASE_SERVICE_KEY.
+ALTER TABLE email_archive ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
Pairs with xomper-back-end PR (handlers) + xomper-infrastructure PR (routes). Admin → Email Archive shows every successful SES send, opens WKWebView preview, and resend form fires to any typed-in recipient.