### PR TITLE
feat(ios): styled markdown blocks + period titles + drop History sidebar

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		08251EFB3181B634553CDCE1 /* TaxiSquadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57940AEB84889A20016648F2 /* TaxiSquadView.swift */; };
 		087C52AE54EBC054E36E696B /* CronSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B9527EA5CA26FE5197FCF5 /* CronSettingsStore.swift */; };
 		0905D6C3E336782530E5F4B4 /* LogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99981051F598B42534DE81CB /* LogLevel.swift */; };
+		095CA7262F4A1EE9C03CEBF1 /* StyledMarkdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41FCF228AB87F9E3417ECB6 /* StyledMarkdownView.swift */; };
 		0A87A5226863819FF3884F6C /* AnnouncementsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCF4387BA57375E04A8940B /* AnnouncementsCard.swift */; };
 		0C2B77E0A46ECE55AE8CE46F /* DivisionBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B670A3A0762D22FB3202E1E /* DivisionBadge.swift */; };
 		10F252D05E75C513A5780FD8 /* EngineMockedPick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CD7928EAED8A9ADA1C683B /* EngineMockedPick.swift */; };
@@ -397,6 +398,7 @@
 		E1A497DF9DD9066BD24A1E19 /* TraySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraySection.swift; sourceTree = "<group>"; };
 		E1E5A60EE78F668F02CF63C0 /* NflState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NflState.swift; sourceTree = "<group>"; };
 		E257076F7FE641947D1DC978 /* AdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminView.swift; sourceTree = "<group>"; };
+		E41FCF228AB87F9E3417ECB6 /* StyledMarkdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyledMarkdownView.swift; sourceTree = "<group>"; };
 		E6A47FD1CF3BE7AE0B940DEC /* StandingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsView.swift; sourceTree = "<group>"; };
 		E70E04168BDBA7D3372BB605 /* TrayDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayDestination.swift; sourceTree = "<group>"; };
 		E767CD5492176E84C2092B0F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -805,6 +807,7 @@
 				669A80C2A9F46A0C4612388C /* Double+Formatting.swift */,
 				6504EE31A645398C41BC2ED1 /* EnvironmentValues+Season.swift */,
 				D24B1B312AA1DD24D8453822 /* MarkdownReflow.swift */,
+				E41FCF228AB87F9E3417ECB6 /* StyledMarkdownView.swift */,
 				F2452A5AEC270BE14CC085E1 /* URL+Sleeper.swift */,
 			);
 			path = Extensions;
@@ -1189,6 +1192,7 @@
 				B48B9F6061A67CFC74A096CC /* StandingsStore.swift in Sources */,
 				7607DB7C775FCCC3B7C3377B /* StandingsTeam.swift in Sources */,
 				98F895FBCECB23325658339C /* StandingsView.swift in Sources */,
+				095CA7262F4A1EE9C03CEBF1 /* StyledMarkdownView.swift in Sources */,
 				BDD14CA33B905F7A31910B1D /* SupabaseManager.swift in Sources */,
 				F783C9073E40497F1D4BA48D /* TablesSubScreenView.swift in Sources */,
 				1D74425C19EE5C00589214C3 /* TaxiSquadPlayer.swift in Sources */,

--- a/Xomper/Core/Extensions/StyledMarkdownView.swift
+++ b/Xomper/Core/Extensions/StyledMarkdownView.swift
@@ -1,0 +1,161 @@
+import SwiftUI
+
+/// SwiftUI view that parses Claude-generated markdown into typed
+/// blocks and renders each block with the same visual hierarchy our
+/// email templates use:
+///
+/// - `#`   → big white title
+/// - `##`  → red uppercase divider bar (matches email h2)
+/// - `###` → gold subheader (matches email h3)
+/// - blockquote → emerald-tinted callout
+/// - paragraph → body text with `**bold**` inline + paragraph spacing
+///
+/// Replaces the old `AttributedString(markdown:)` pipeline, which
+/// collapsed every heading into a same-size bold line and produced
+/// the wall-of-text that landed in the inbox.
+///
+/// Body string is run through `MarkdownReflow.paragraphs(_:)` first
+/// so legacy stored content (no `\n\n` between sections) still
+/// resolves cleanly.
+struct StyledMarkdownView: View {
+    let markdown: String
+
+    private var blocks: [MarkdownBlock] {
+        MarkdownBlockParser.parse(MarkdownReflow.paragraphs(markdown))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
+                render(block)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func render(_ block: MarkdownBlock) -> some View {
+        switch block {
+        case .h1(let text):
+            Text(text)
+                .font(.title2.weight(.bold))
+                .foregroundStyle(XomperColors.textPrimary)
+                .padding(.top, 12)
+                .padding(.bottom, 8)
+
+        case .h2(let text):
+            VStack(alignment: .leading, spacing: 0) {
+                Rectangle()
+                    .fill(XomperColors.errorRed)
+                    .frame(height: 3)
+                    .frame(maxWidth: .infinity)
+                Text(text.uppercased())
+                    .font(.title3.weight(.heavy))
+                    .foregroundStyle(XomperColors.errorRed)
+                    .tracking(2)
+                    .padding(.top, 12)
+            }
+            .padding(.top, 28)
+            .padding(.bottom, 10)
+
+        case .h3(let text):
+            Text(text)
+                .font(.headline.weight(.bold))
+                .foregroundStyle(XomperColors.championGold)
+                .padding(.top, 14)
+                .padding(.bottom, 4)
+
+        case .quote(let text):
+            HStack(alignment: .top, spacing: 10) {
+                Rectangle()
+                    .fill(XomperColors.championGold)
+                    .frame(width: 3)
+                inlineText(text)
+                    .font(.body.italic())
+                    .foregroundStyle(XomperColors.textSecondary)
+            }
+            .padding(.vertical, 8)
+
+        case .paragraph(let text):
+            inlineText(text)
+                .font(.body)
+                .foregroundStyle(XomperColors.textPrimary)
+                .lineSpacing(5)
+                .padding(.bottom, 12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .textSelection(.enabled)
+        }
+    }
+
+    /// Inline `**bold**` rendering on top of plain text. Built as an
+    /// `AttributedString` so we can mark just the bold spans with
+    /// `.font(.body.weight(.bold))` and `.foregroundStyle(textPrimary)`
+    /// without losing the surrounding paragraph styling.
+    private func inlineText(_ raw: String) -> Text {
+        var attr = AttributedString(raw)
+        // Manually parse **...** pairs and apply bold.
+        var working = raw
+        var attrOut = AttributedString("")
+        while let openRange = working.range(of: "**") {
+            let before = String(working[working.startIndex..<openRange.lowerBound])
+            attrOut.append(AttributedString(before))
+            let afterOpen = working[openRange.upperBound...]
+            if let closeRange = afterOpen.range(of: "**") {
+                let boldText = String(afterOpen[afterOpen.startIndex..<closeRange.lowerBound])
+                var boldAttr = AttributedString(boldText)
+                boldAttr.inlinePresentationIntent = .stronglyEmphasized
+                attrOut.append(boldAttr)
+                working = String(afterOpen[closeRange.upperBound...])
+            } else {
+                attrOut.append(AttributedString("**" + String(afterOpen)))
+                working = ""
+                break
+            }
+        }
+        attrOut.append(AttributedString(working))
+        attr = attrOut
+        return Text(attr)
+    }
+}
+
+// MARK: - Block model + parser
+
+enum MarkdownBlock: Hashable {
+    case h1(String)
+    case h2(String)
+    case h3(String)
+    case quote(String)
+    case paragraph(String)
+}
+
+enum MarkdownBlockParser {
+    /// Split `md` into typed blocks by `\n\n` separators. Each block's
+    /// leading `# / ## / ### / >` token decides its type; everything
+    /// else is a paragraph. Pre-reflowed content (via `MarkdownReflow`)
+    /// is expected.
+    static func parse(_ md: String) -> [MarkdownBlock] {
+        let chunks = md.components(separatedBy: "\n\n")
+        return chunks.compactMap { chunk in
+            let trimmed = chunk.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            if trimmed.hasPrefix("### ") {
+                return .h3(String(trimmed.dropFirst(4)).trimmingCharacters(in: .whitespaces))
+            }
+            if trimmed.hasPrefix("## ") {
+                return .h2(String(trimmed.dropFirst(3)).trimmingCharacters(in: .whitespaces))
+            }
+            if trimmed.hasPrefix("# ") {
+                return .h1(String(trimmed.dropFirst(2)).trimmingCharacters(in: .whitespaces))
+            }
+            if trimmed.hasPrefix("> ") {
+                return .quote(String(trimmed.dropFirst(2)).trimmingCharacters(in: .whitespaces))
+            }
+            // Paragraph — collapse internal newlines into spaces so a
+            // wrapped paragraph from the AI doesn't render with hard
+            // line breaks. Real paragraph breaks are at the `\n\n`
+            // boundary above.
+            let joined = trimmed.replacingOccurrences(of: "\n", with: " ")
+            return .paragraph(joined)
+        }
+    }
+}

--- a/Xomper/Core/Models/AIReport.swift
+++ b/Xomper/Core/Models/AIReport.swift
@@ -263,6 +263,19 @@ enum AIReportType: String, Codable, Sendable, CaseIterable, Hashable {
         case .mock:        XomperColors.championGold
         }
     }
+
+    /// Pretty-print a stored `period` string. Weekly periods come in
+    /// as `2025W17` — render them as `Week 17 — 2025` so the inline
+    /// recap headers are readable instead of looking like a SKU.
+    /// Other types just return the period unchanged (post-draft is
+    /// already a clean year like "2025").
+    static func formattedPeriod(_ period: String) -> String {
+        guard let wRange = period.range(of: "W") else { return period }
+        let season = String(period[period.startIndex..<wRange.lowerBound])
+        let weekRaw = String(period[wRange.upperBound...])
+        guard let week = Int(weekRaw), !season.isEmpty else { return period }
+        return "Week \(week) — \(season)"
+    }
 }
 
 // MARK: - Trigger Response

--- a/Xomper/Features/AIReview/AIReviewDetailView.swift
+++ b/Xomper/Features/AIReview/AIReviewDetailView.swift
@@ -37,7 +37,7 @@ struct AIReviewDetailView: View {
                     .monospacedDigit()
             }
 
-            Text(report.period)
+            Text(AIReportType.formattedPeriod(report.period))
                 .font(.title2.weight(.bold))
                 .foregroundStyle(XomperColors.textPrimary)
         }
@@ -82,24 +82,10 @@ struct AIReviewDetailView: View {
         .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
     }
 
-    /// Native iOS 17 `AttributedString(markdown:)` with full
-    /// interpreted syntax (headings, lists, bold, links). Falls back
-    /// to a plain Text if the markdown is malformed.
+    /// Hand-styled markdown renderer (blocks-based, mirrors email
+    /// styling). See `StyledMarkdownView`.
     private var renderedMarkdown: some View {
-        Group {
-            let reflowed = MarkdownReflow.paragraphs(report.bodyMarkdown)
-            if let attributed = try? AttributedString(
-                markdown: reflowed,
-                options: AttributedString.MarkdownParsingOptions(
-                    interpretedSyntax: .full
-                )
-            ) {
-                Text(attributed)
-                    .lineSpacing(4)
-            } else {
-                Text(reflowed)
-            }
-        }
+        StyledMarkdownView(markdown: report.bodyMarkdown)
     }
 
     // MARK: - Footer

--- a/Xomper/Features/DraftHistory/Draft/DraftRecapView.swift
+++ b/Xomper/Features/DraftHistory/Draft/DraftRecapView.swift
@@ -97,7 +97,7 @@ struct DraftRecapView: View {
     private func headerCard(_ report: AIReport) -> some View {
         VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
             HStack(spacing: XomperTheme.Spacing.xs) {
-                Text("RECAP")
+                Text("DRAFT RECAP")
                     .font(.caption2.weight(.bold))
                     .foregroundStyle(XomperColors.bgDark)
                     .padding(.horizontal, XomperTheme.Spacing.xs)
@@ -107,6 +107,7 @@ struct DraftRecapView: View {
                 Text(report.period)
                     .font(.subheadline.weight(.bold))
                     .foregroundStyle(XomperColors.championGold)
+                    .monospacedDigit()
                 Spacer()
                 Text(formattedDate(report.createdAt))
                     .font(.caption2.weight(.semibold))
@@ -141,20 +142,8 @@ struct DraftRecapView: View {
     /// iOS 17 `AttributedString(markdown:)` with full interpreted
     /// syntax (headings, lists, bold). Falls back to plain text if
     /// the markdown is malformed.
-    @ViewBuilder
     private func renderedMarkdown(_ report: AIReport) -> some View {
-        let reflowed = MarkdownReflow.paragraphs(report.bodyMarkdown)
-        if let attributed = try? AttributedString(
-            markdown: reflowed,
-            options: AttributedString.MarkdownParsingOptions(
-                interpretedSyntax: .full
-            )
-        ) {
-            Text(attributed)
-                .lineSpacing(4)
-        } else {
-            Text(reflowed)
-        }
+        StyledMarkdownView(markdown: report.bodyMarkdown)
     }
 
     // MARK: - Helpers

--- a/Xomper/Features/League/WeeklyRecapHeaderCard.swift
+++ b/Xomper/Features/League/WeeklyRecapHeaderCard.swift
@@ -63,7 +63,7 @@ struct WeeklyRecapHeaderCard: View {
                 .background(XomperColors.championGold)
                 .clipShape(Capsule())
 
-            Text(report.period)
+            Text(AIReportType.formattedPeriod(report.period))
                 .font(.subheadline.weight(.bold))
                 .foregroundStyle(XomperColors.championGold)
                 .monospacedDigit()
@@ -75,24 +75,8 @@ struct WeeklyRecapHeaderCard: View {
 
     // MARK: - Markdown
 
-    /// iOS 17 `AttributedString(markdown:)` with full interpreted
-    /// syntax (headings, lists, bold). Matches `DraftRecapView`. Falls
-    /// back to plain text if the markdown is malformed so the
-    /// AI-generated body always renders, even on parse failure.
-    @ViewBuilder
     private var renderedMarkdown: some View {
-        let reflowed = MarkdownReflow.paragraphs(report.bodyMarkdown)
-        if let attributed = try? AttributedString(
-            markdown: reflowed,
-            options: AttributedString.MarkdownParsingOptions(
-                interpretedSyntax: .full
-            )
-        ) {
-            Text(attributed)
-                .lineSpacing(4)
-        } else {
-            Text(reflowed)
-        }
+        StyledMarkdownView(markdown: report.bodyMarkdown)
     }
 }
 

--- a/Xomper/Features/Shell/DrawerView.swift
+++ b/Xomper/Features/Shell/DrawerView.swift
@@ -26,30 +26,26 @@ struct DrawerView: View {
     /// runtime when `isAdmin == true`.
     /// Drawer sections plus pinned Settings + optional Admin.
     ///
-    /// - Play:    landing, standings, matchups, playoffs
+    /// - Play:    landing, standings, matchups, playoffs, draftHistory, worldCup
     /// - Team:    myTeam, taxiSquad, teamAnalyzer
-    /// - History: draftHistory, matchupHistory, worldCup
     /// - League:  rulebook, scoring, leagueSettings, payouts, ruleProposals, draftOrder
     /// - Admin:   aiReview (full archive), admin (only when isAdmin)
     ///
-    /// `aiReview` is admin-only because it's the long-form archive
-    /// surface; regular users get AI content via the Landing card and
-    /// the inline recap on `DraftRecapView` / `MatchupsView`.
-    /// `archive` is dropped — its sub-destinations are reachable via
-    /// each season's per-tab past-history flow.
+    /// The old "History" section was dropped — `matchupHistory` is
+    /// already reachable from `MatchupsView` (per-season chip), so a
+    /// dedicated tray entry was redundant. Draft + World Cup moved
+    /// into Play since both are active surfaces, not archive flows.
+    /// `archive` was already dropped — its sub-destinations are
+    /// reachable via each season's per-tab past-history flow.
     private var sections: [TraySection] {
         var out: [TraySection] = [
             TraySection(
                 title: "Play",
-                entries: [.landing, .standings, .matchups, .playoffs]
+                entries: [.landing, .standings, .matchups, .playoffs, .draftHistory, .worldCup]
             ),
             TraySection(
                 title: "Team",
                 entries: [.myTeam, .taxiSquad, .teamAnalyzer]
-            ),
-            TraySection(
-                title: "History",
-                entries: [.draftHistory, .matchupHistory, .worldCup]
             ),
             TraySection(
                 title: "League",


### PR DESCRIPTION
Three fixes from screenshot review:
- Real markdown styling — replaces AttributedString(markdown:) with a block-based renderer matching email styling
- Period titles - '2025W17' -> 'Week 17 — 2025' across recap surfaces
- Sidebar: drop 'History' section, move Draft + World Cup into Play, drop Matchup History (redundant with Matchups season chip)