### PR TITLE
feat(ios): profile avatar fix + landing draft countdown card

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		A45E9B6A2A65059251FB3D76 /* AdminStorePreseasonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD03A165767A043D34A9499 /* AdminStorePreseasonTests.swift */; };
 		A4D93DF4C02A8DE6C695CE4D /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E94170F987E8EFE5C566B9B /* LoginView.swift */; };
 		AB72973CE762675E8087A1C2 /* MockDraftEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5EA1D700C954EFB08B185F2 /* MockDraftEngine.swift */; };
+		ABA1B01D725FCCCEF189D9B4 /* UpcomingDraftCountdownCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231B20212409143CB0FA0108 /* UpcomingDraftCountdownCard.swift */; };
 		AFE044848CB195AC6BC3CA62 /* DraftRecapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5DA384F46CEDA38C9898C14 /* DraftRecapView.swift */; };
 		B24D5DBDDF4C163FCAB52689 /* TeamAnalysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC09DFF48D9AAFEF0A286BAD /* TeamAnalysis.swift */; };
 		B309CAE3F00F954918C09554 /* PlayerValuesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE99E9B095120FB6636FC8A /* PlayerValuesStore.swift */; };
@@ -239,6 +240,7 @@
 		1FBB5433786555EDDBC896C7 /* XomperTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperTheme.swift; sourceTree = "<group>"; };
 		22A99CAA9B57C1A0144DCA22 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 		22D61F12E32D7C81FCA8F8CE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		231B20212409143CB0FA0108 /* UpcomingDraftCountdownCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingDraftCountdownCard.swift; sourceTree = "<group>"; };
 		2549566AC9312F44BA381BB6 /* WeeklyRecapMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapMetadata.swift; sourceTree = "<group>"; };
 		2B670A3A0762D22FB3202E1E /* DivisionBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DivisionBadge.swift; sourceTree = "<group>"; };
 		2B6C68E1131F2BBBE625DEAF /* RuleProposalFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleProposalFormView.swift; sourceTree = "<group>"; };
@@ -486,6 +488,7 @@
 				69B7E5CBAFC3B1281D1134F0 /* LeagueAnnouncement.swift */,
 				DF1A7B1219575171DA3ABAB7 /* StandingsScrollBar.swift */,
 				C921F3EC29B03A85D9F2A42C /* ThisWeekMatchupsCard.swift */,
+				231B20212409143CB0FA0108 /* UpcomingDraftCountdownCard.swift */,
 			);
 			path = Landing;
 			sourceTree = "<group>";
@@ -1216,6 +1219,7 @@
 				775985FFAD33E6481C34174A /* TrophyCaseCard.swift in Sources */,
 				65444EF8D83F3582CE2FC023 /* TrophyCaseSection.swift in Sources */,
 				F5AD059EF52A068C469AFB6E /* URL+Sleeper.swift in Sources */,
+				ABA1B01D725FCCCEF189D9B4 /* UpcomingDraftCountdownCard.swift in Sources */,
 				F7AC235256A88B1877A69345 /* UserEditView.swift in Sources */,
 				E2EC532916CAA2FBB779DB35 /* UserStore.swift in Sources */,
 				629E7B504845E362943D386C /* UsersListView.swift in Sources */,

--- a/Xomper/Features/Landing/LandingView.swift
+++ b/Xomper/Features/Landing/LandingView.swift
@@ -39,6 +39,8 @@ struct LandingView: View {
     var nflStateStore: NflStateStore
     var aiReviewStore: AIReviewStore
     var announcementsStore: AnnouncementsStore
+    var historyStore: HistoryStore
+    var userStore: UserStore
     var navStore: NavigationStore
     var router: AppRouter
 
@@ -49,6 +51,15 @@ struct LandingView: View {
             VStack(spacing: XomperTheme.Spacing.md) {
                 HeadlineAIReportCard(
                     store: aiReviewStore,
+                    navStore: navStore,
+                    router: router
+                )
+
+                UpcomingDraftCountdownCard(
+                    historyStore: historyStore,
+                    leagueStore: leagueStore,
+                    nflStateStore: nflStateStore,
+                    userStore: userStore,
                     navStore: navStore,
                     router: router
                 )
@@ -111,6 +122,8 @@ struct LandingView: View {
             nflStateStore: NflStateStore(),
             aiReviewStore: AIReviewStore(),
             announcementsStore: AnnouncementsStore(),
+            historyStore: HistoryStore(),
+            userStore: UserStore(),
             navStore: NavigationStore(),
             router: AppRouter()
         )

--- a/Xomper/Features/Landing/UpcomingDraftCountdownCard.swift
+++ b/Xomper/Features/Landing/UpcomingDraftCountdownCard.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+
+/// Landing-page card that surfaces an active "pre_draft" or "drafting"
+/// upcoming draft. Renders the start time + a live countdown so the
+/// home screen has something live during the offseason (when standings
+/// + matchups are both empty). Tapping pushes the Draft tray
+/// destination so the user lands on the Live sub-tab.
+///
+/// Hides itself entirely when there's no upcoming draft for the
+/// current season. Reuses `HistoryStore.upcomingDraft` so we don't
+/// duplicate the Sleeper fetch — the Live tab loads the same record.
+struct UpcomingDraftCountdownCard: View {
+    var historyStore: HistoryStore
+    var leagueStore: LeagueStore
+    var nflStateStore: NflStateStore
+    var userStore: UserStore
+    var navStore: NavigationStore
+    var router: AppRouter
+
+    var body: some View {
+        if let draft = historyStore.upcomingDraft,
+           let firstPick = startDate(draft: draft) {
+            Button {
+                navStore.select(.draftHistory, router: router)
+            } label: {
+                content(draft: draft, firstPick: firstPick)
+            }
+            .buttonStyle(.pressableCard)
+            .task(id: leagueStore.myLeague?.leagueId) {
+                await loadIfNeeded()
+            }
+        } else {
+            Color.clear
+                .frame(height: 0)
+                .task(id: leagueStore.myLeague?.leagueId) {
+                    await loadIfNeeded()
+                }
+        }
+    }
+
+    // MARK: - Content
+
+    private func content(draft: Draft, firstPick: Date) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                Image(systemName: "calendar.badge.clock")
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.championGold)
+                Text("UPCOMING DRAFT")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+                    .tracking(0.5)
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.right")
+                    .font(.caption2)
+                    .foregroundStyle(XomperColors.textMuted)
+            }
+
+            Text("\(draft.season) Rookie Draft")
+                .font(.title3.weight(.bold))
+                .foregroundStyle(XomperColors.textPrimary)
+
+            Text("Starts \(formatted(firstPick))")
+                .font(.caption)
+                .foregroundStyle(XomperColors.textSecondary)
+
+            TimelineView(.periodic(from: .now, by: 1)) { context in
+                countdownLine(target: firstPick, now: context.date)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private func countdownLine(target: Date, now: Date) -> some View {
+        let remaining = target.timeIntervalSince(now)
+        if remaining <= 0 {
+            Text("Drafting now")
+                .font(.subheadline.weight(.bold))
+                .foregroundStyle(XomperColors.championGold)
+        } else {
+            Text(formatRemaining(remaining))
+                .font(.subheadline.weight(.bold))
+                .foregroundStyle(XomperColors.championGold)
+                .monospacedDigit()
+        }
+    }
+
+    private func formatRemaining(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds)
+        let days = total / 86400
+        let hours = (total % 86400) / 3600
+        let minutes = (total % 3600) / 60
+        let secs = total % 60
+        if days > 0 {
+            return String(format: "%dd %02dh %02dm %02ds", days, hours, minutes, secs)
+        } else if hours > 0 {
+            return String(format: "%dh %02dm %02ds", hours, minutes, secs)
+        } else {
+            return String(format: "%dm %02ds", minutes, secs)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func startDate(draft: Draft) -> Date? {
+        guard let epochMillis = draft.startTime, epochMillis > 0 else { return nil }
+        return Date(timeIntervalSince1970: TimeInterval(epochMillis) / 1000.0)
+    }
+
+    private func formatted(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "EEE, MMM d 'at' h:mm a zzz"
+        return f.string(from: date)
+    }
+
+    private func loadIfNeeded() async {
+        guard let userId = userStore.myUser?.userId else { return }
+        // Re-use the same loader the Live tab calls — internally
+        // cached per-season so the call is cheap when both surfaces
+        // hit it.
+        let season = nflStateStore.currentSeason.isEmpty
+            ? (leagueStore.myLeague?.season ?? "")
+            : nflStateStore.currentSeason
+        guard !season.isEmpty else { return }
+        await historyStore.loadUpcomingDraft(
+            season: season,
+            homeLeagueName: leagueStore.resolvedHomeLeagueName,
+            userId: userId
+        )
+    }
+}

--- a/Xomper/Features/Shared/AvatarView.swift
+++ b/Xomper/Features/Shared/AvatarView.swift
@@ -5,11 +5,15 @@ struct AvatarView: View {
     var size: CGFloat = XomperTheme.AvatarSize.md
     var isTeam: Bool = false
 
+    /// Sleeper exposes both `/avatars/<id>` (full) and `/avatars/thumbs/<id>`
+    /// (~80px). For the xl profile avatar use the full asset so it
+    /// doesn't render pixelated.
     private var imageURL: URL? {
         guard let avatarID, !avatarID.isEmpty else { return nil }
-
-        let baseURL = "https://sleepercdn.com/avatars/thumbs"
-        return URL(string: "\(baseURL)/\(avatarID)")
+        let path = size >= XomperTheme.AvatarSize.lg
+            ? "https://sleepercdn.com/avatars/\(avatarID)"
+            : "https://sleepercdn.com/avatars/thumbs/\(avatarID)"
+        return URL(string: path)
     }
 
     var body: some View {
@@ -30,6 +34,11 @@ struct AvatarView: View {
                         fallbackIcon
                     }
                 }
+                // Force the AsyncImage state machine to reset when the
+                // URL changes from nil (pre-bootstrap) to a real URL.
+                // Without this, SwiftUI sometimes holds onto the empty
+                // phase and the avatar never appears.
+                .id(imageURL)
             } else {
                 fallbackIcon
             }

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -156,6 +156,8 @@ struct MainShell: View {
                     nflStateStore: nflStateStore,
                     aiReviewStore: aiReviewStore,
                     announcementsStore: announcementsStore,
+                    historyStore: historyStore,
+                    userStore: userStore,
                     navStore: navStore,
                     router: router
                 )


### PR DESCRIPTION
Two from the screenshot review.

- AvatarView now uses the full-size URL for xl (was loading the 80px thumb), and forces AsyncImage to reset when the URL goes nil -> real. Profile avatar should now show your Sleeper image.
- Landing gets a new UpcomingDraftCountdownCard — surfaces the 2026 draft start time + live countdown right under the AI weekly card. Hides when no upcoming draft. Tap pushes the Draft tray destination.