### PR TITLE
ios: weekly title fix + recap card collapsed by default

### DIFF
--- a/Xomper/Core/Models/AIReport.swift
+++ b/Xomper/Core/Models/AIReport.swift
@@ -152,7 +152,16 @@ struct AIReport: Decodable, Identifiable, Sendable, Hashable {
     /// Human-friendly title for cards and detail headers.
     /// e.g. "Post-Draft Recap — 2026" / "Week 4 Recap — 2026W04".
     var displayTitle: String {
-        "\(reportType.displayName) — \(period)"
+        let formatted = AIReportType.formattedPeriod(period)
+        switch reportType {
+        case .weekly, .weekPreview:
+            // Type already conveyed by the chip on every surface that
+            // renders this title; "Week 17 — 2025" stands on its own
+            // and avoids the redundant "Weekly — Week 17 — 2025".
+            return formatted
+        default:
+            return "\(reportType.displayName) — \(formatted)"
+        }
     }
 
     // MARK: - F3 Metadata flags

--- a/Xomper/Features/League/WeeklyRecapHeaderCard.swift
+++ b/Xomper/Features/League/WeeklyRecapHeaderCard.swift
@@ -6,9 +6,10 @@ import SwiftUI
 /// AI-generated weekly content — the per-matchup blurbs that sit under
 /// each matchup card stay in place as a secondary detail surface.
 ///
-/// Collapsible via `DisclosureGroup` (default expanded) so users can
-/// hide a long recap after reading without scrolling past it on every
-/// expand.
+/// Collapsible via `DisclosureGroup` (default collapsed) so the
+/// expanded-week view doesn't drop a wall of recap markdown above
+/// the actual matchup cards — the cards are what most users came
+/// for. Tap to reveal the full recap.
 ///
 /// Visual treatment mirrors `DraftRecapView.headerCard` +
 /// `bodyCard` rolled into a single card: gold "WEEKLY RECAP" pill +
@@ -18,7 +19,7 @@ import SwiftUI
 struct WeeklyRecapHeaderCard: View {
     let report: AIReport
 
-    @State private var isExpanded: Bool = true
+    @State private var isExpanded: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {


### PR DESCRIPTION
## Summary
- \`AIReport.displayTitle\` drops the redundant type label for \`weekly\` / \`weekPreview\` since the formatted period already says "Week 17 — 2025". Other report types keep the "Post-Draft — 2025" pattern.
- \`WeeklyRecapHeaderCard\` defaults \`isExpanded\` to false so the expanded-week view in Matchups doesn't dump a wall of recap markdown above the actual matchup cards.

## Test plan
- [ ] Landing hero card shows "Week 17 — 2025" instead of "Weekly — 2025W17"
- [ ] AI Review hub list rows show the same
- [ ] Post-Draft and Preseason reports still render with their type prefix
- [ ] Matchups → expand a past week → recap card is collapsed; tap to expand