### PR TITLE
ios: AI review — hide mock drafts from non-admins + back-nav fix

### DIFF
--- a/Xomper/Features/AIReview/AIReviewView.swift
+++ b/Xomper/Features/AIReview/AIReviewView.swift
@@ -32,12 +32,16 @@ struct AIReviewView: View {
         authStore.whitelistedUser?.isAdmin == true
     }
 
-    /// Client-side defense-in-depth filter — the server already strips
-    /// `is_redacted == true` rows for non-admin callers. Admins see
-    /// the full list when `showRedacted` is on, otherwise they get
-    /// the same view as everyone else.
+    /// Client-side defense-in-depth filter:
+    /// - Mock-draft reports are admin-only — they're internal scratch
+    ///   reports that aren't meant for the league at large.
+    /// - Redacted reports are stripped server-side for non-admins;
+    ///   admins see them when `showRedacted` is on.
     private var visibleArchive: [AIReport] {
-        store.archive.filter { !$0.isRedacted || store.showRedacted }
+        store.archive.filter { report in
+            if report.reportType == .mock && !isAdmin { return false }
+            return !report.isRedacted || store.showRedacted
+        }
     }
 
     var body: some View {

--- a/Xomper/Features/Landing/HeadlineAIReportCard.swift
+++ b/Xomper/Features/Landing/HeadlineAIReportCard.swift
@@ -26,9 +26,12 @@ struct HeadlineAIReportCard: View {
     private func reportCard(report: AIReport) -> some View {
         Button {
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            // Switch tray to AI Review, then push detail. The two
-            // happen inside the same navStore animation envelope.
-            navStore.select(.aiReview, router: router)
+            // Push the detail on the current router without switching
+            // the tray destination. Back from the detail lands on
+            // wherever the user tapped from (Landing in the hero
+            // case) — previously we'd swap to .aiReview first, which
+            // dropped the user on the AI Review hub on back, surprising
+            // people who tapped a card on Home.
             router.navigate(to: .aiReportDetail(reportId: report.id))
         } label: {
             VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {


### PR DESCRIPTION
## Summary
- \`AIReviewView.visibleArchive\` strips \`.mock\` entries for non-admins. Server already strips \`is_redacted\` for non-admins; this is the matching defense-in-depth for the mock kind.
- \`HeadlineAIReportCard\` tap drops the \`navStore.select(.aiReview, ...)\` call before pushing detail. The destination switch made back-nav from a report tapped on Home drop users on the AI Review hub instead of returning to Home.

## Test plan
- [ ] Non-admin sees only weekly / postDraft / preseason / weekPreview entries in AI Review
- [ ] Admin still sees mock drafts in the list
- [ ] Tap Headline card on Home → report detail → back → land on Home (not on AI Review hub)
- [ ] Tap a row in AI Review hub → detail → back → land on hub (unchanged)