### PR TITLE
ios: client-side draft grades + structured grade card

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		42BF3DEE63074148F1DF0BD1 /* AIReviewDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967DCE922FE090CE4F067587 /* AIReviewDetailView.swift */; };
 		42E7DDAD3454512247E1AFA6 /* ProposedTrade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4690614F644FE74115D0DAB6 /* ProposedTrade.swift */; };
 		42F9C81AF6338A720FE0BC12 /* ArchiveNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E65C159F2C84E48B61A9A8 /* ArchiveNavigationTests.swift */; };
+		4358973CB450667407A22310 /* DraftGrade.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30266A2CB62F694EB45ACEA /* DraftGrade.swift */; };
 		440A44095AD70A8D3D273EEE /* StandingsScrollBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1A7B1219575171DA3ABAB7 /* StandingsScrollBar.swift */; };
 		4A321187068EEBA8C4E75EFE /* PayoutProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E3BE36BCEA1A7722157C37 /* PayoutProjection.swift */; };
 		4AFF52CDFE011C65E819946A /* EmailArchiveListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52633D7C9BB49C28288B36A6 /* EmailArchiveListView.swift */; };
@@ -202,6 +203,7 @@
 		F5AD059EF52A068C469AFB6E /* URL+Sleeper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2452A5AEC270BE14CC085E1 /* URL+Sleeper.swift */; };
 		F5FB358418D7528D863DEA8E /* HistoricalStandingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46DB1025586B733C289B45A3 /* HistoricalStandingsView.swift */; };
 		F66FCFE7466291137B314370 /* HighestPossibleLineup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 765C03E7E4268373F28754DC /* HighestPossibleLineup.swift */; };
+		F727EF19FD6DB0E9909D1B40 /* DraftGradesCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D46350B1C3D4C29A70D1C9F /* DraftGradesCard.swift */; };
 		F783C9073E40497F1D4BA48D /* TablesSubScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7AC7756D5F973D69491BC5 /* TablesSubScreenView.swift */; };
 		F7AC235256A88B1877A69345 /* UserEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9874F6016A90DC85B195F58 /* UserEditView.swift */; };
 		F7E0A8B9AECD0291527E0D0E /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F46A0AAE61A4E963BB15B0 /* SearchView.swift */; };
@@ -302,6 +304,7 @@
 		69B7E5CBAFC3B1281D1134F0 /* LeagueAnnouncement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeagueAnnouncement.swift; sourceTree = "<group>"; };
 		6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayoffBracket.swift; sourceTree = "<group>"; };
 		6CFEC46AB65E6E7A90E0A695 /* AdminStoreWeeklyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStoreWeeklyTests.swift; sourceTree = "<group>"; };
+		6D46350B1C3D4C29A70D1C9F /* DraftGradesCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftGradesCard.swift; sourceTree = "<group>"; };
 		6D6CCEB0FAEF9674F7498C65 /* TestEmailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestEmailView.swift; sourceTree = "<group>"; };
 		6E6A6BADE3F51FA922A078F4 /* AIReviewStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewStore.swift; sourceTree = "<group>"; };
 		6F2C7D74B3584D53CE601054 /* MatchupDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupDetailView.swift; sourceTree = "<group>"; };
@@ -372,6 +375,7 @@
 		BE87151F7F5AAB8F12F98B91 /* PlayerValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerValue.swift; sourceTree = "<group>"; };
 		C1CD5644F6F8376CA86092AF /* Xomper.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Xomper.entitlements; sourceTree = "<group>"; };
 		C206B0A18917D2B43B17ADCF /* AdminTablesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminTablesStore.swift; sourceTree = "<group>"; };
+		C30266A2CB62F694EB45ACEA /* DraftGrade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftGrade.swift; sourceTree = "<group>"; };
 		C3AFC2ADE424F95E3121BF22 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		C7474B2C8F1F2B14821F4539 /* CronSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronSettingsView.swift; sourceTree = "<group>"; };
 		C82B0FEAAB9BC80BA0801E98 /* XomperColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperColors.swift; sourceTree = "<group>"; };
@@ -683,6 +687,7 @@
 		7D491FDD816B6270D6975B2A /* Draft */ = {
 			isa = PBXGroup;
 			children = (
+				6D46350B1C3D4C29A70D1C9F /* DraftGradesCard.swift */,
 				A5DA384F46CEDA38C9898C14 /* DraftRecapView.swift */,
 				831DFA7D391F8415451D6479 /* DraftSubTabBar.swift */,
 				B04B5251715A37E924DF7CEF /* LiveDraftView.swift */,
@@ -729,6 +734,7 @@
 				18383A0375F5728A9E3FE065 /* Championship.swift */,
 				2E172A0188BB654B8E010842 /* CronSetting.swift */,
 				7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */,
+				C30266A2CB62F694EB45ACEA /* DraftGrade.swift */,
 				A789B8D49FA4430886626289 /* DraftHistory.swift */,
 				44F22FF3CF671CAA9E80918C /* EmailPreview.swift */,
 				765C03E7E4268373F28754DC /* HighestPossibleLineup.swift */,
@@ -1096,6 +1102,8 @@
 				0C2B77E0A46ECE55AE8CE46F /* DivisionBadge.swift in Sources */,
 				A28A24923C27CF0929ED97E1 /* Double+Formatting.swift in Sources */,
 				1C4049A62CC4A443AC38E464 /* Draft.swift in Sources */,
+				4358973CB450667407A22310 /* DraftGrade.swift in Sources */,
+				F727EF19FD6DB0E9909D1B40 /* DraftGradesCard.swift in Sources */,
 				4E0CAC9964BF3F2B59EDD844 /* DraftHistory.swift in Sources */,
 				3B67875F822BE9AA9BD052EF /* DraftHistoryView.swift in Sources */,
 				6BC002C5DD7EF547F82CA860 /* DraftOrderView.swift in Sources */,

--- a/Xomper/Core/Models/DraftGrade.swift
+++ b/Xomper/Core/Models/DraftGrade.swift
@@ -1,0 +1,191 @@
+import Foundation
+
+/// Client-side draft grade for one team in a single year's rookie
+/// draft. Pure value type; produced by `DraftGradeCalculator` from
+/// `DraftHistoryRecord` + `PlayerValuesStore`. No backend / AI work
+/// involved — every input is data we already have on device.
+///
+/// Used by `DraftGradesCard` in `DraftRecapView` to render a
+/// structured grade panel above the AI-generated recap markdown.
+struct DraftGrade: Sendable, Hashable, Identifiable {
+    let rosterId: Int
+    let userId: String
+    let teamName: String
+    let managerName: String
+    let avatarId: String?
+    let picks: [GradedPick]
+    /// Sum of FantasyCalc value across this team's picks.
+    let totalValue: Int
+    /// Sum of (actualValue - expectedAtPickNo) across this team's picks.
+    /// Positive = stole value, negative = reached.
+    let valueOverExpected: Int
+    /// Letter assigned after bucketing all teams in the room by
+    /// `valueOverExpected`.
+    let letter: String
+
+    var id: Int { rosterId }
+}
+
+/// Per-pick grade attached to a `DraftGrade`. Carries the player
+/// info pre-resolved so the view layer doesn't need to re-join
+/// against PlayerValuesStore at render time.
+struct GradedPick: Sendable, Hashable, Identifiable {
+    let round: Int
+    let slot: Int
+    let pickNo: Int
+    let playerId: String
+    let playerName: String
+    let position: String
+    let nflTeam: String
+    let value: Int
+    /// Expected value at this overall pick number, derived from the
+    /// actual draft (nth-highest value across all drafted players).
+    let expectedValue: Int
+    /// `value - expectedValue`. Positive = steal, negative = reach.
+    var delta: Int { value - expectedValue }
+
+    var id: Int { pickNo }
+}
+
+// MARK: - Calculator
+
+enum DraftGradeCalculator {
+
+    /// Build per-team grades from a year's draft picks + FantasyCalc
+    /// values. Returns a roster-keyed dictionary so `DraftRecapView`
+    /// can iterate teams in any order it wants.
+    ///
+    /// Algorithm:
+    /// 1. For each pick, resolve `value = playerValues.value(playerId)`.
+    /// 2. Build the expected-value curve by sorting **actual** pick
+    ///    values descending. At overall pick N, expected[N] = the
+    ///    Nth-highest value drafted. If a team took the best available
+    ///    when their pick came up, `delta == 0`. Reaches go negative,
+    ///    steals positive.
+    /// 3. Group picks by `pickedByRosterId`, sum value + delta.
+    /// 4. Rank teams by `valueOverExpected` desc, bucket into A+/A/A-/
+    ///    B+/B/B-/C+/C/C-/D using even thirds of the spread.
+    ///
+    /// Need-fit bonus (penalty for doubling on a strong position,
+    /// bonus for filling a thin one) is intentionally not modeled in
+    /// v1 — pre-draft roster composition isn't reliably available at
+    /// recap time. The value-over-expected number alone is the
+    /// dominant signal for dynasty rookie drafts where positional
+    /// scarcity is league-wide.
+    @MainActor
+    static func grade(
+        picks: [DraftHistoryRecord],
+        playerValues: PlayerValuesStore
+    ) -> [Int: DraftGrade] {
+        guard !picks.isEmpty else { return [:] }
+
+        // 1. Resolve every pick's value once.
+        let sortedPicks = picks.sorted { $0.pickNo < $1.pickNo }
+        let resolved: [(record: DraftHistoryRecord, value: Int)] = sortedPicks.map { record in
+            (record, playerValues.value(for: record.playerId))
+        }
+
+        // 2. Expected curve = actual values sorted desc.
+        let expectedCurve = resolved.map(\.value).sorted(by: >)
+
+        // Build GradedPick per record; pickNo is 1-based so index by
+        // (pickNo - 1) into the expected curve.
+        var picksByRoster: [Int: [GradedPick]] = [:]
+        for (idx, entry) in resolved.enumerated() {
+            let expected = idx < expectedCurve.count ? expectedCurve[idx] : 0
+            let graded = GradedPick(
+                round: entry.record.round,
+                slot: entry.record.draftSlot,
+                pickNo: entry.record.pickNo,
+                playerId: entry.record.playerId,
+                playerName: entry.record.playerName,
+                position: entry.record.playerPosition,
+                nflTeam: entry.record.playerTeam,
+                value: entry.value,
+                expectedValue: expected
+            )
+            picksByRoster[entry.record.pickedByRosterId, default: []].append(graded)
+        }
+
+        // 3. Aggregate per team.
+        struct TeamAgg {
+            let rosterId: Int
+            let userId: String
+            let teamName: String
+            let managerName: String
+            let avatarId: String?
+            let picks: [GradedPick]
+            let totalValue: Int
+            let valueOverExpected: Int
+        }
+
+        let aggregates: [TeamAgg] = picksByRoster.compactMap { (rosterId, picks) in
+            guard let firstRecord = sortedPicks.first(where: { $0.pickedByRosterId == rosterId }) else {
+                return nil
+            }
+            let total = picks.reduce(0) { $0 + $1.value }
+            let voe   = picks.reduce(0) { $0 + $1.delta }
+            return TeamAgg(
+                rosterId: rosterId,
+                userId: firstRecord.pickedByUserId,
+                teamName: firstRecord.pickedByTeamName,
+                managerName: firstRecord.pickedByUsername,
+                avatarId: nil,
+                picks: picks.sorted { $0.pickNo < $1.pickNo },
+                totalValue: total,
+                valueOverExpected: voe
+            )
+        }
+
+        // 4. Bucket into letters by ranking on valueOverExpected.
+        let letters = bucketLetters(byValueOverExpected: aggregates.map(\.valueOverExpected))
+        let ranked = aggregates.enumerated().sorted {
+            $0.element.valueOverExpected > $1.element.valueOverExpected
+        }
+        var out: [Int: DraftGrade] = [:]
+        for (rankIdx, item) in ranked.enumerated() {
+            let agg = item.element
+            let letter = rankIdx < letters.count ? letters[rankIdx] : "C"
+            out[agg.rosterId] = DraftGrade(
+                rosterId: agg.rosterId,
+                userId: agg.userId,
+                teamName: agg.teamName,
+                managerName: agg.managerName,
+                avatarId: agg.avatarId,
+                picks: agg.picks,
+                totalValue: agg.totalValue,
+                valueOverExpected: agg.valueOverExpected,
+                letter: letter
+            )
+        }
+        return out
+    }
+
+    /// Assign letters across N teams ranked from best to worst on
+    /// `valueOverExpected`. We spread A+/A/A-/B+/B/B-/C+/C/C-/D-like
+    /// labels using thirds of the rank distribution — top third gets
+    /// A-range, middle gets B-range, bottom gets C/D-range. Plus/
+    /// minus suffixes within each band by sub-rank.
+    private static func bucketLetters(byValueOverExpected values: [Int]) -> [String] {
+        guard !values.isEmpty else { return [] }
+        let n = values.count
+        // The order here matches the rank order (best -> worst), so
+        // index i corresponds to the i-th best team. We don't depend
+        // on the underlying values being sorted — only on count.
+        return (0..<n).map { idx in
+            let band = idx * 3 / n  // 0=A, 1=B, 2=C/D
+            let subIdx = (idx % (max(n / 3, 1))) * 3 / max(n / 3, 1) // 0=+, 1=blank, 2=-
+            switch (band, subIdx) {
+            case (0, 0): return "A+"
+            case (0, 1): return "A"
+            case (0, _): return "A-"
+            case (1, 0): return "B+"
+            case (1, 1): return "B"
+            case (1, _): return "B-"
+            case (2, 0): return "C+"
+            case (2, 1): return "C"
+            default:     return "C-"
+            }
+        }
+    }
+}

--- a/Xomper/Features/DraftHistory/Draft/DraftGradesCard.swift
+++ b/Xomper/Features/DraftHistory/Draft/DraftGradesCard.swift
@@ -1,0 +1,178 @@
+import SwiftUI
+
+/// Structured "team grades" panel rendered above the AI markdown on
+/// `DraftRecapView`. One row per team — letter grade chip on the left,
+/// manager + value-over-expected in the middle, expandable per-pick
+/// breakdown with position-colored pills below.
+///
+/// All data is computed client-side via `DraftGradeCalculator` from
+/// FantasyCalc values + the `DraftHistoryRecord` list. No backend
+/// calls.
+struct DraftGradesCard: View {
+    let grades: [DraftGrade]
+    @State private var expandedRosterId: Int?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            header
+            ForEach(orderedGrades) { grade in
+                row(grade)
+            }
+            footnote
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+    }
+
+    private var orderedGrades: [DraftGrade] {
+        grades.sorted { $0.valueOverExpected > $1.valueOverExpected }
+    }
+
+    private var header: some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            Text("TEAM GRADES")
+                .font(.caption2.weight(.bold))
+                .tracking(2)
+                .foregroundStyle(XomperColors.championGold)
+            Spacer()
+            Text("Tap a row for picks")
+                .font(.caption2)
+                .foregroundStyle(XomperColors.textMuted)
+        }
+        .padding(.bottom, 4)
+    }
+
+    private func row(_ grade: DraftGrade) -> some View {
+        VStack(spacing: 0) {
+            Button(action: {
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                withAnimation(.easeInOut(duration: 0.18)) {
+                    expandedRosterId = expandedRosterId == grade.rosterId ? nil : grade.rosterId
+                }
+            }) {
+                HStack(spacing: XomperTheme.Spacing.sm) {
+                    letterChip(grade.letter)
+
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(grade.teamName)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(XomperColors.textPrimary)
+                            .lineLimit(1)
+                        Text(grade.managerName)
+                            .font(.caption2)
+                            .foregroundStyle(XomperColors.textMuted)
+                            .lineLimit(1)
+                    }
+
+                    Spacer()
+
+                    voeBadge(grade.valueOverExpected)
+
+                    Image(systemName: expandedRosterId == grade.rosterId ? "chevron.up" : "chevron.down")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(XomperColors.textMuted)
+                }
+                .padding(.vertical, 6)
+            }
+            .buttonStyle(.plain)
+
+            if expandedRosterId == grade.rosterId {
+                picksList(grade)
+                    .padding(.top, 4)
+                    .padding(.bottom, 8)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+
+            Divider().background(XomperColors.surfaceLight.opacity(0.3))
+        }
+    }
+
+    private func letterChip(_ letter: String) -> some View {
+        Text(letter)
+            .font(.caption.weight(.heavy))
+            .foregroundStyle(XomperColors.bgDark)
+            .monospacedDigit()
+            .frame(width: 36, height: 28)
+            .background(letterColor(letter))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    /// A-range → gold, B-range → green, C-range → orange, D → red.
+    private func letterColor(_ letter: String) -> Color {
+        if letter.hasPrefix("A") { return XomperColors.championGold }
+        if letter.hasPrefix("B") { return XomperColors.successGreen }
+        if letter.hasPrefix("C") { return Color.orange }
+        return XomperColors.errorRed
+    }
+
+    private func voeBadge(_ voe: Int) -> some View {
+        let sign = voe > 0 ? "+" : ""
+        let color: Color = voe > 0 ? XomperColors.successGreen : (voe < 0 ? XomperColors.errorRed : XomperColors.textSecondary)
+        return Text("\(sign)\(voe)")
+            .font(.caption2.weight(.semibold))
+            .monospacedDigit()
+            .foregroundStyle(color)
+    }
+
+    private func picksList(_ grade: DraftGrade) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(grade.picks) { pick in
+                HStack(spacing: XomperTheme.Spacing.xs) {
+                    Text(String(format: "%d.%02d", pick.round, pick.slot))
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(XomperColors.textMuted)
+                        .frame(width: 38, alignment: .leading)
+                        .monospacedDigit()
+
+                    positionPill(pick.position)
+
+                    Text(pick.playerName)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(XomperColors.textPrimary)
+                        .lineLimit(1)
+
+                    if !pick.nflTeam.isEmpty {
+                        Text(pick.nflTeam)
+                            .font(.caption2)
+                            .foregroundStyle(XomperColors.textMuted)
+                    }
+
+                    Spacer()
+
+                    voeBadge(pick.delta)
+                }
+            }
+        }
+    }
+
+    private func positionPill(_ position: String) -> some View {
+        Text(position)
+            .font(.caption2.weight(.bold))
+            .foregroundStyle(XomperColors.bgDark)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(positionColor(position))
+            .clipShape(Capsule())
+    }
+
+    /// Same palette used by `DraftHistoryView.positionColor` so a
+    /// pick chip looks the same here as in the round-by-round list.
+    private func positionColor(_ position: String) -> Color {
+        switch position.uppercased() {
+        case "QB":  return XomperColors.errorRed
+        case "RB":  return XomperColors.successGreen
+        case "WR":  return Color.blue
+        case "TE":  return Color.orange
+        default:    return XomperColors.textMuted
+        }
+    }
+
+    private var footnote: some View {
+        Text("Grade = value of each pick (FantasyCalc dynasty) vs the best-available curve from this draft. + = steal, − = reach.")
+            .font(.caption2)
+            .foregroundStyle(XomperColors.textMuted)
+            .padding(.top, 4)
+    }
+}

--- a/Xomper/Features/DraftHistory/Draft/DraftRecapView.swift
+++ b/Xomper/Features/DraftHistory/Draft/DraftRecapView.swift
@@ -23,7 +23,23 @@ import SwiftUI
 /// `force: true`.
 struct DraftRecapView: View {
     var aiReviewStore: AIReviewStore
+    var historyStore: HistoryStore
+    var playerValuesStore: PlayerValuesStore
     let year: String
+
+    /// Lazily computed grades for `year`. Filters
+    /// `historyStore.draftHistory` to the year's picks then delegates
+    /// to `DraftGradeCalculator`. Empty when picks haven't loaded yet
+    /// or no FantasyCalc values are available — the card is silently
+    /// absent in that case.
+    private var grades: [DraftGrade] {
+        let picks = historyStore.draftHistory.filter { $0.season == year }
+        guard !picks.isEmpty else { return [] }
+        return Array(DraftGradeCalculator.grade(
+            picks: picks,
+            playerValues: playerValuesStore
+        ).values)
+    }
 
     var body: some View {
         Group {
@@ -87,6 +103,9 @@ struct DraftRecapView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: XomperTheme.Spacing.md) {
                 headerCard(report)
+                if !grades.isEmpty {
+                    DraftGradesCard(grades: grades)
+                }
                 bodyCard(report)
             }
             .padding(.horizontal, XomperTheme.Spacing.md)

--- a/Xomper/Features/DraftHistory/DraftHistoryView.swift
+++ b/Xomper/Features/DraftHistory/DraftHistoryView.swift
@@ -89,6 +89,8 @@ struct DraftHistoryView: View {
                 case .recap:
                     DraftRecapView(
                         aiReviewStore: aiReviewStore,
+                        historyStore: historyStore,
+                        playerValuesStore: playerValuesStore,
                         year: currentSeason
                     )
                 case .picks:


### PR DESCRIPTION
## Summary
- New \`DraftGradeCalculator\` scores every pick by value-over-expected (FantasyCalc value vs the nth-highest value drafted at that overall pick number). Sums per team, buckets into A+ → C- letters by rank thirds.
- New \`DraftGradesCard\` renders the structured grades above the AI markdown in \`DraftRecapView\`: letter chip + team/manager + VOE badge per row, tap to expand into per-pick rows with position-colored pills (QB red / RB green / WR blue / TE orange) — same palette as the past-picks round list.
- Zero backend work. No prompt change. \`PlayerValuesStore\` + \`historyStore.draftHistory\` already had everything needed.

## Test plan
- [ ] Open a past-season Recap tab → grades card shows above AI markdown
- [ ] Tap a row → expands to show picks with player name + position pill + VOE per pick
- [ ] Letter colors: A-range gold, B-range green, C-range orange, D red
- [ ] Years without picks loaded yet → card is silently absent (no broken state)
- [ ] AI markdown still renders below unchanged