### PR TITLE
#137 refactor: extract PositionBreakdownCard + RecommendedTradeCard

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		8E8B3EC17A43676ACA176FC3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6F2D6E80C100927C4C20FAD7 /* Assets.xcassets */; };
 		901F54CB41785D269CC63160 /* WorldCupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E1C6D5A18697DE79586C1B /* WorldCupStore.swift */; };
 		90B62C24495752B9C03F5CE8 /* HighestPossibleCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6D698BC8816DA02019846C /* HighestPossibleCalculatorTests.swift */; };
+		90E2B85AB940A7DF47EED4B1 /* RecommendedTradeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1B49526B709B7DE2C352A5 /* RecommendedTradeCard.swift */; };
 		9134D2C8A8737083C9FB8F7F /* ClinchCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3728C5F6BEF61FE509A3EA32 /* ClinchCalculator.swift */; };
 		93D8C8E352B60752D37FD0FF /* PlayerSeasonStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C24A12080AD428D5A40A7E /* PlayerSeasonStats.swift */; };
 		93E069814B933A306E4EA2E3 /* TestEmailKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = C964C2174FEA2E5B4DE790BB /* TestEmailKind.swift */; };
@@ -177,6 +178,7 @@
 		D107A9FEAF17BE9FCEA44958 /* LiveDraftView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04B5251715A37E924DF7CEF /* LiveDraftView.swift */; };
 		D1F778B07CC0F05640F72142 /* ArchiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AA9304E883FF9B1D42EB60 /* ArchiveView.swift */; };
 		D2CB1CF4D61C27A0AEA9E1C3 /* AdminTablesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C206B0A18917D2B43B17ADCF /* AdminTablesStore.swift */; };
+		D649D51624A360754E27A007 /* PositionBreakdownCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673F6F49F0E79A44A4A03714 /* PositionBreakdownCard.swift */; };
 		D78D5302B3D17DE9BE7D557C /* AuthGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5E661424C55F695BF96281 /* AuthGateView.swift */; };
 		D7A95C32621E03E2AAB37327 /* TaxiStealConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66A2C896FE4C62CF9719D7A /* TaxiStealConfirmView.swift */; };
 		D9737CEB4C36AEFB5EC727D0 /* PastStandingsArchiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC1E989411B5FACF30C4B3A /* PastStandingsArchiveTests.swift */; };
@@ -300,6 +302,7 @@
 		6504EE31A645398C41BC2ED1 /* EnvironmentValues+Season.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+Season.swift"; sourceTree = "<group>"; };
 		65C814C64F50004B297F6808 /* AnnouncementsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsStore.swift; sourceTree = "<group>"; };
 		669A80C2A9F46A0C4612388C /* Double+Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Formatting.swift"; sourceTree = "<group>"; };
+		673F6F49F0E79A44A4A03714 /* PositionBreakdownCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionBreakdownCard.swift; sourceTree = "<group>"; };
 		67C24A12080AD428D5A40A7E /* PlayerSeasonStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerSeasonStats.swift; sourceTree = "<group>"; };
 		69B7E5CBAFC3B1281D1134F0 /* LeagueAnnouncement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeagueAnnouncement.swift; sourceTree = "<group>"; };
 		6B160A8ED14F5BE08B79C7FA /* PlayoffBracket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayoffBracket.swift; sourceTree = "<group>"; };
@@ -353,6 +356,7 @@
 		A84518A312FF0F96719AF1E8 /* LeagueOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeagueOverviewView.swift; sourceTree = "<group>"; };
 		A8BD31456E25771C8D7D39C9 /* XomperApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperApp.swift; sourceTree = "<group>"; };
 		A951936FD34F712A8D8E66C0 /* MockDraftEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftEngineTests.swift; sourceTree = "<group>"; };
+		AC1B49526B709B7DE2C352A5 /* RecommendedTradeCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendedTradeCard.swift; sourceTree = "<group>"; };
 		ACCFF9888476668EBE7AA0CC /* XomperTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = XomperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD43D54AB620DABD559F8A40 /* CareerStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareerStats.swift; sourceTree = "<group>"; };
 		AE543CB2E49335ADD02E8000 /* Roster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Roster.swift; sourceTree = "<group>"; };
@@ -777,6 +781,8 @@
 				A83A8FEFFD8FA91F498D03A0 /* EmptyStateView.swift */,
 				DC24A8748C940FC57B142AFF /* ErrorView.swift */,
 				DBD0F6820960B354EAB3E89D /* LoadingView.swift */,
+				673F6F49F0E79A44A4A03714 /* PositionBreakdownCard.swift */,
+				AC1B49526B709B7DE2C352A5 /* RecommendedTradeCard.swift */,
 				1AD376EFB7AD4A192FAB3E8F /* RecordBadge.swift */,
 				DE3B178733D5AF9EB7DA7189 /* XomperLoader.swift */,
 			);
@@ -1176,11 +1182,13 @@
 				B309CAE3F00F954918C09554 /* PlayerValuesStore.swift in Sources */,
 				F201A3A40D624F6AAA0C0CC1 /* PlayoffBracket.swift in Sources */,
 				CB47F51AA46AEBC59183C449 /* PlayoffBracketView.swift in Sources */,
+				D649D51624A360754E27A007 /* PositionBreakdownCard.swift in Sources */,
 				F9A37723FE37F4C30D46D6E1 /* PressableCardButtonStyle.swift in Sources */,
 				6C89029D05AEE66FB2315616 /* Profile.swift in Sources */,
 				77A0EFCEE4340D3A7853BF08 /* ProfileView.swift in Sources */,
 				42E7DDAD3454512247E1AFA6 /* ProposedTrade.swift in Sources */,
 				7D94ADAC136455C3056D5867 /* PushNotificationManager.swift in Sources */,
+				90E2B85AB940A7DF47EED4B1 /* RecommendedTradeCard.swift in Sources */,
 				76260F26A40213A62E5F22FB /* RecordBadge.swift in Sources */,
 				1D67D0B027D9C2AA6E033E38 /* ReportFlag.swift in Sources */,
 				54863F3F6ECDD3BE00083582 /* Roster.swift in Sources */,

--- a/Xomper/Features/Shared/PositionBreakdownCard.swift
+++ b/Xomper/Features/Shared/PositionBreakdownCard.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+/// Per-position breakdown grid used on the Analyzer Compare tab and
+/// (without an opponent column) on the My Team Strengths tab.
+///
+/// Shows each hex axis as a labeled progress bar. My value is color-
+/// coded gold (above league avg) or red (significantly below). When
+/// an opponent analysis is supplied their values appear in cyan as a
+/// second column; otherwise the league-average value fills that slot.
+struct PositionBreakdownCard: View {
+
+    let my: TeamAnalysis
+    let opp: TeamAnalysis?
+    let averages: [TeamAnalysis.HexAxis]
+    let maxes: [String: Int]
+
+    var body: some View {
+        VStack(spacing: XomperTheme.Spacing.xs) {
+            ForEach(Array(my.hexAxes.enumerated()), id: \.offset) { idx, axis in
+                let oppValue = opp?.hexAxes[idx].value
+                let avgValue = idx < averages.count ? averages[idx].value : 0
+                breakdownRow(
+                    label: axis.label,
+                    myValue: axis.value,
+                    oppValue: oppValue,
+                    avgValue: avgValue,
+                    leagueMax: maxes[axis.label] ?? axis.value
+                )
+            }
+            Divider().background(XomperColors.surfaceLight.opacity(0.4))
+            HStack {
+                Text("Total roster value")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(XomperColors.textSecondary)
+                Spacer()
+                Text("\(my.totalValue)")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+                    .monospacedDigit()
+                if let opp {
+                    Text("vs \(opp.totalValue)")
+                        .font(.subheadline)
+                        .foregroundStyle(.cyan)
+                        .monospacedDigit()
+                }
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(Color.clear, lineWidth: 0)
+        )
+        .padding(.horizontal, XomperTheme.Spacing.md)
+    }
+
+    // MARK: - Private
+
+    private func breakdownRow(
+        label: String,
+        myValue: Int,
+        oppValue: Int?,
+        avgValue: Int,
+        leagueMax: Int
+    ) -> some View {
+        HStack(spacing: XomperTheme.Spacing.sm) {
+            Text(label)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(XomperColors.textPrimary)
+                .frame(width: 60, alignment: .leading)
+
+            ProgressView(
+                value: leagueMax > 0 ? Double(myValue) / Double(leagueMax) : 0
+            )
+            .tint(XomperColors.championGold)
+            .frame(maxWidth: .infinity)
+
+            Text("\(myValue)")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(deltaColor(myValue: myValue, avgValue: avgValue))
+                .monospacedDigit()
+                .frame(width: 50, alignment: .trailing)
+
+            if let oppValue {
+                Text("\(oppValue)")
+                    .font(.caption)
+                    .foregroundStyle(.cyan)
+                    .monospacedDigit()
+                    .frame(width: 50, alignment: .trailing)
+            } else {
+                Text("\(avgValue)")
+                    .font(.caption)
+                    .foregroundStyle(.gray)
+                    .monospacedDigit()
+                    .frame(width: 50, alignment: .trailing)
+            }
+        }
+    }
+}
+
+/// Color the my-team value gold when above league average and red
+/// when significantly below — a glance-readable health check on
+/// position depth without needing to do the math.
+private func deltaColor(myValue: Int, avgValue: Int) -> Color {
+    guard avgValue > 0 else { return XomperColors.textPrimary }
+    let ratio = Double(myValue) / Double(avgValue)
+    if ratio >= 1.05 { return XomperColors.championGold }
+    if ratio <= 0.85 { return XomperColors.errorRed }
+    return XomperColors.textPrimary
+}

--- a/Xomper/Features/Shared/RecommendedTradeCard.swift
+++ b/Xomper/Features/Shared/RecommendedTradeCard.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+/// Card rendering a single `RecommendedTrade` suggestion. Used in the
+/// Team Analyzer Trade tab's recommended-trades section and on the My
+/// Team Trades tab.
+///
+/// Pure presentation — the button action (load into builder, or
+/// pre-load via controller + navigate) is the caller's responsibility.
+struct RecommendedTradeCard: View {
+
+    let rec: RecommendedTrade
+
+    init(_ rec: RecommendedTrade) {
+        self.rec = rec
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            HStack(spacing: XomperTheme.Spacing.sm) {
+                Text(rec.partnerTeamName)
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .lineLimit(1)
+                Spacer()
+                Text(String(format: "%.0f%% gap", rec.percentGap * 100))
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(XomperColors.bgDark)
+                    .padding(.horizontal, XomperTheme.Spacing.xs)
+                    .background(XomperColors.successGreen)
+                    .clipShape(Capsule())
+            }
+
+            HStack(alignment: .top, spacing: XomperTheme.Spacing.sm) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Give")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(XomperColors.textMuted)
+                        .textCase(.uppercase)
+                    Text(rec.give.name)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(XomperColors.textPrimary)
+                        .lineLimit(1)
+                    Text("\(rec.give.position) · \(rec.give.value)")
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Image(systemName: "arrow.left.arrow.right")
+                    .foregroundStyle(XomperColors.textMuted)
+                    .padding(.top, 12)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Receive")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(XomperColors.championGold)
+                        .textCase(.uppercase)
+                    Text(rec.receive.name)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(XomperColors.textPrimary)
+                        .lineLimit(1)
+                    Text("\(rec.receive.position) · \(rec.receive.value)")
+                        .font(.caption2)
+                        .foregroundStyle(XomperColors.textMuted)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            Text("Tap to load into the builder above.")
+                .font(.caption2)
+                .foregroundStyle(XomperColors.textMuted)
+        }
+        .padding(XomperTheme.Spacing.md)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+    }
+}

--- a/Xomper/Features/TeamAnalyzer/TeamAnalyzerView.swift
+++ b/Xomper/Features/TeamAnalyzer/TeamAnalyzerView.swift
@@ -173,7 +173,7 @@ struct TeamAnalyzerView: View {
                         excludingRosterId: my.rosterId
                     )
 
-                    breakdownGrid(
+                    PositionBreakdownCard(
                         my: my,
                         opp: comparison,
                         averages: leagueAverages,
@@ -292,94 +292,10 @@ struct TeamAnalyzerView: View {
         .padding(.horizontal, XomperTheme.Spacing.md)
     }
 
-    // MARK: - Breakdown grid
+    // MARK: - League tab
 
-    private func breakdownGrid(
-        my: TeamAnalysis,
-        opp: TeamAnalysis?,
-        averages: [TeamAnalysis.HexAxis],
-        maxes: [String: Int]
-    ) -> some View {
-        VStack(spacing: XomperTheme.Spacing.xs) {
-            ForEach(Array(my.hexAxes.enumerated()), id: \.offset) { idx, axis in
-                let oppValue = opp?.hexAxes[idx].value
-                let avgValue = idx < averages.count ? averages[idx].value : 0
-                breakdownRow(
-                    label: axis.label,
-                    myValue: axis.value,
-                    oppValue: oppValue,
-                    avgValue: avgValue,
-                    leagueMax: maxes[axis.label] ?? axis.value
-                )
-            }
-            Divider().background(XomperColors.surfaceLight.opacity(0.4))
-            HStack {
-                Text("Total roster value")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(XomperColors.textSecondary)
-                Spacer()
-                Text("\(my.totalValue)")
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(XomperColors.championGold)
-                    .monospacedDigit()
-                if let opp {
-                    Text("vs \(opp.totalValue)")
-                        .font(.subheadline)
-                        .foregroundStyle(.cyan)
-                        .monospacedDigit()
-                }
-            }
-        }
-        .padding(XomperTheme.Spacing.md)
-        .background(XomperColors.bgCard)
-        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
-        .padding(.horizontal, XomperTheme.Spacing.md)
-    }
-
-    private func breakdownRow(
-        label: String,
-        myValue: Int,
-        oppValue: Int?,
-        avgValue: Int,
-        leagueMax: Int
-    ) -> some View {
-        HStack(spacing: XomperTheme.Spacing.sm) {
-            Text(label)
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(XomperColors.textPrimary)
-                .frame(width: 60, alignment: .leading)
-
-            ProgressView(
-                value: leagueMax > 0 ? Double(myValue) / Double(leagueMax) : 0
-            )
-            .tint(XomperColors.championGold)
-            .frame(maxWidth: .infinity)
-
-            Text("\(myValue)")
-                .font(.caption.weight(.bold))
-                .foregroundStyle(deltaColor(myValue: myValue, avgValue: avgValue))
-                .monospacedDigit()
-                .frame(width: 50, alignment: .trailing)
-
-            if let oppValue {
-                Text("\(oppValue)")
-                    .font(.caption)
-                    .foregroundStyle(.cyan)
-                    .monospacedDigit()
-                    .frame(width: 50, alignment: .trailing)
-            } else {
-                Text("\(avgValue)")
-                    .font(.caption)
-                    .foregroundStyle(.gray)
-                    .monospacedDigit()
-                    .frame(width: 50, alignment: .trailing)
-            }
-        }
-    }
-
-    /// Color my-team's value gold when above league average and red
-    /// when significantly below — a glance-readable health check on
-    /// position depth without needing to do the math.
+    /// Color a value gold when above league average and red when
+    /// significantly below — used by the League tab axis cells.
     private func deltaColor(myValue: Int, avgValue: Int) -> Color {
         guard avgValue > 0 else { return XomperColors.textPrimary }
         let ratio = Double(myValue) / Double(avgValue)
@@ -387,8 +303,6 @@ struct TeamAnalyzerView: View {
         if ratio <= 0.85 { return XomperColors.errorRed }
         return XomperColors.textPrimary
     }
-
-    // MARK: - League tab
 
     private func leagueTab(
         analyses: [TeamAnalysis],
@@ -1263,7 +1177,7 @@ extension TeamAnalyzerView {
                         tradeSideAPickNames = []
                         tradeSideBPickNames = []
                     } label: {
-                        recommendedTradeRow(rec)
+                        RecommendedTradeCard(rec)
                     }
                     .buttonStyle(.pressableCard)
                     .padding(.horizontal, XomperTheme.Spacing.md)
@@ -1272,71 +1186,8 @@ extension TeamAnalyzerView {
         }
     }
 
-    private func recommendedTradeRow(_ rec: RecommendedTrade) -> some View {
-        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
-            HStack(spacing: XomperTheme.Spacing.sm) {
-                Text(rec.partnerTeamName)
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(XomperColors.textPrimary)
-                    .lineLimit(1)
-                Spacer()
-                Text(String(format: "%.0f%% gap", rec.percentGap * 100))
-                    .font(.caption2.weight(.bold))
-                    .foregroundStyle(XomperColors.bgDark)
-                    .padding(.horizontal, XomperTheme.Spacing.xs)
-                    .background(XomperColors.successGreen)
-                    .clipShape(Capsule())
-            }
-
-            HStack(alignment: .top, spacing: XomperTheme.Spacing.sm) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Give")
-                        .font(.caption2.weight(.bold))
-                        .foregroundStyle(XomperColors.textMuted)
-                        .textCase(.uppercase)
-                    Text(rec.give.name)
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(XomperColors.textPrimary)
-                        .lineLimit(1)
-                    Text("\(rec.give.position) · \(rec.give.value)")
-                        .font(.caption2)
-                        .foregroundStyle(XomperColors.textMuted)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                Image(systemName: "arrow.left.arrow.right")
-                    .foregroundStyle(XomperColors.textMuted)
-                    .padding(.top, 12)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Receive")
-                        .font(.caption2.weight(.bold))
-                        .foregroundStyle(XomperColors.championGold)
-                        .textCase(.uppercase)
-                    Text(rec.receive.name)
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(XomperColors.textPrimary)
-                        .lineLimit(1)
-                    Text("\(rec.receive.position) · \(rec.receive.value)")
-                        .font(.caption2)
-                        .foregroundStyle(XomperColors.textMuted)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-
-            Text("Tap to load into the builder above.")
-                .font(.caption2)
-                .foregroundStyle(XomperColors.textMuted)
-        }
-        .padding(XomperTheme.Spacing.md)
-        .background(XomperColors.bgCard)
-        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
-                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
-        )
-    }
 }
+
 
 // MARK: - Trade picker context
 


### PR DESCRIPTION
## Summary

- New `Xomper/Features/Shared/PositionBreakdownCard.swift` — lifts `breakdownGrid` + `breakdownRow` from `TeamAnalyzerView` verbatim. `deltaColor` helper privatized into the file (free function, file-private scope). `TeamAnalyzerView` retains its own `deltaColor` for the League-tab axis cells.
- New `Xomper/Features/Shared/RecommendedTradeCard.swift` — lifts `recommendedTradeRow` from `TeamAnalyzerView` verbatim.
- `TeamAnalyzerView` updated: uses both new components; inline `breakdownGrid`, `breakdownRow`, `recommendedTradeRow` methods removed.
- Build: `BUILD SUCCEEDED` on iPhone 17 Pro sim.

## Test plan

- [ ] Open Analyzer → Compare tab — hex chart + breakdown grid renders identically (progress bars, gold/red coloring, opp cyan column)
- [ ] Open Analyzer → Trade tab → Recommended trades section — cards render identically
- [ ] No new warnings in build output

Part of #137. `Closes #137` deferred to the final Phase 0c / feature PR.