### PR TITLE
#137 refactor: hoist trade-builder state into TradeAnalyzerController

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		B309CAE3F00F954918C09554 /* PlayerValuesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE99E9B095120FB6636FC8A /* PlayerValuesStore.swift */; };
 		B3826B5CCBF64A347CCF75D0 /* DraftPersonality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E909175D4E989F36E6A4B9B /* DraftPersonality.swift */; };
 		B48B9F6061A67CFC74A096CC /* StandingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957EE31D25CFE325633622D4 /* StandingsStore.swift */; };
+		B7BD3E81860C8271FA1C068F /* TradeAnalyzerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26975318DD0DFF73C9469AC5 /* TradeAnalyzerController.swift */; };
 		B7EB06298BFBF6AC76ABF53E /* TeamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51CC9357B13AB7ADD9C8586 /* TeamView.swift */; };
 		BAD102C79A8A7F98CFB6DA68 /* AnnouncementsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C249C7D8A57EDD62886B0D /* AnnouncementsListView.swift */; };
 		BB91E92DC29E6ECA5E1F0DEC /* SeasonStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F3F1A18F4EEC5A3F81FD28 /* SeasonStore.swift */; };
@@ -246,6 +247,7 @@
 		22D61F12E32D7C81FCA8F8CE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		231B20212409143CB0FA0108 /* UpcomingDraftCountdownCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingDraftCountdownCard.swift; sourceTree = "<group>"; };
 		2549566AC9312F44BA381BB6 /* WeeklyRecapMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapMetadata.swift; sourceTree = "<group>"; };
+		26975318DD0DFF73C9469AC5 /* TradeAnalyzerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeAnalyzerController.swift; sourceTree = "<group>"; };
 		2B670A3A0762D22FB3202E1E /* DivisionBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DivisionBadge.swift; sourceTree = "<group>"; };
 		2B6C68E1131F2BBBE625DEAF /* RuleProposalFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleProposalFormView.swift; sourceTree = "<group>"; };
 		2DB0B979B62A1CF6EB80417F /* DraftRecapResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftRecapResolverTests.swift; sourceTree = "<group>"; };
@@ -879,6 +881,7 @@
 				6387E34B6FA70159F3F9D80A /* TaxiSquadStore.swift */,
 				36A01820FD0F6643BBF8511D /* TeamStore.swift */,
 				5E98CD5B3ECB6292B6D7637B /* TestEmailStore.swift */,
+				26975318DD0DFF73C9469AC5 /* TradeAnalyzerController.swift */,
 				62948D0A455E7CE99B15CB75 /* UserStore.swift */,
 				43E1C6D5A18697DE79586C1B /* WorldCupStore.swift */,
 			);
@@ -1227,6 +1230,7 @@
 				EE987501F73209179D5CEEB4 /* TestEmailStore.swift in Sources */,
 				825E9A2C109291322461741A /* TestEmailView.swift in Sources */,
 				98D5EE595D14742780A47B81 /* ThisWeekMatchupsCard.swift in Sources */,
+				B7BD3E81860C8271FA1C068F /* TradeAnalyzerController.swift in Sources */,
 				57C17293587E8DBED9A14970 /* TradedPick.swift in Sources */,
 				78094B6DF90F54E0FA59898A /* TrayDestination.swift in Sources */,
 				95DE1C46E20BF6910D4E5447 /* TrayItem.swift in Sources */,

--- a/Xomper/Core/Stores/TradeAnalyzerController.swift
+++ b/Xomper/Core/Stores/TradeAnalyzerController.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Observation
+
+/// Shared owner of the Trade Analyzer's builder state. Hoisted out of
+/// `TeamAnalyzerView` so a second consumer (My Team's Trades tab) can
+/// seed a `RecommendedTrade` into the builder before the user lands
+/// on the screen.
+///
+/// Owns five fields (the previously-private `@State` on the view):
+/// - Selected partner roster
+/// - Side A players + picks (the user's side — what they're giving up)
+/// - Side B players + picks (the partner's side — what the user receives)
+///
+/// `showSidePicker` stays on the view itself — it's transient sheet
+/// presentation state, not anything a deep link would seed.
+///
+/// Lifecycle: instantiated once at `MainShell` alongside the other
+/// shared stores and injected into every consumer. The same instance
+/// is shared across drawer destination switches so a preload from
+/// the My Team Trades tab survives the tray flip to Team Analyzer.
+@Observable
+@MainActor
+final class TradeAnalyzerController {
+
+    /// Selected partner roster id. `nil` until the user picks a partner.
+    var tradePartnerRosterId: Int?
+
+    /// Player ids on the user's side (what they would give up).
+    var tradeSideAPlayerIds: [String] = []
+
+    /// Pick names on the user's side, e.g. "2026 Mid 1st".
+    var tradeSideAPickNames: [String] = []
+
+    /// Player ids on the partner's side (what the user would receive).
+    var tradeSideBPlayerIds: [String] = []
+
+    /// Pick names on the partner's side.
+    var tradeSideBPickNames: [String] = []
+
+    // MARK: - Preload
+
+    /// Seed all five fields from a `RecommendedTrade` so the Trade
+    /// Analyzer opens with the recommendation already populated.
+    /// Picks are cleared — recommendations only surface single-
+    /// player-for-single-player swaps today; the user can layer picks
+    /// in afterward.
+    func preload(_ rec: RecommendedTrade) {
+        tradePartnerRosterId = rec.partnerRosterId
+        tradeSideAPlayerIds  = [rec.give.playerId]
+        tradeSideBPlayerIds  = [rec.receive.playerId]
+        tradeSideAPickNames  = []
+        tradeSideBPickNames  = []
+    }
+
+    // MARK: - Reset
+
+    /// Clear every field. Called when the user exits the Trade tab
+    /// without saving or when they explicitly start a fresh trade.
+    func reset() {
+        tradePartnerRosterId = nil
+        tradeSideAPlayerIds  = []
+        tradeSideAPickNames  = []
+        tradeSideBPlayerIds  = []
+        tradeSideBPickNames  = []
+    }
+}

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -55,6 +55,11 @@ struct MainShell: View {
     /// public-read array the Landing card observes — saves a refetch
     /// after a successful save.
     @State private var announcementsStore = AnnouncementsStore()
+    /// Owns the Trade Analyzer's builder state so the My Team Trades
+    /// tab can preload a `RecommendedTrade` before the user lands on
+    /// the Analyzer screen. Lives at the shell so the preload survives
+    /// tray destination switches.
+    @State private var tradeController = TradeAnalyzerController()
 
     // MARK: - Body
 
@@ -229,7 +234,8 @@ struct MainShell: View {
                     leagueStore: leagueStore,
                     playerStore: playerStore,
                     authStore: authStore,
-                    valuesStore: valuesStore
+                    valuesStore: valuesStore,
+                    tradeController: tradeController
                 )
 
             case .payouts:

--- a/Xomper/Features/TeamAnalyzer/TeamAnalyzerView.swift
+++ b/Xomper/Features/TeamAnalyzer/TeamAnalyzerView.swift
@@ -26,14 +26,13 @@ struct TeamAnalyzerView: View {
     @State private var activeTab: AnalyzerTab = .compare
     @State private var comparisonRosterId: Int?
 
-    // Trade-builder state. Lives at the parent so the proposal
-    // survives tab switches; the user can hop to Compare / League
-    // mid-build and come back to the same trade.
-    @State private var tradePartnerRosterId: Int?
-    @State private var tradeSideAPlayerIds: [String] = []
-    @State private var tradeSideBPlayerIds: [String] = []
-    @State private var tradeSideAPickNames: [String] = []
-    @State private var tradeSideBPickNames: [String] = []
+    /// Trade-builder state lives on a shared `TradeAnalyzerController`
+    /// so the My Team Trades tab can preload a recommendation before
+    /// the user lands on this screen. The proposal also survives tab
+    /// switches inside this view because the controller outlives any
+    /// single body invocation.
+    let tradeController: TradeAnalyzerController
+
     @State private var showSidePicker: TradeSidePickerContext?
 
     var body: some View {
@@ -509,7 +508,7 @@ extension TeamAnalyzerView {
         my: TeamAnalysis,
         analyses: [TeamAnalysis]
     ) -> some View {
-        let partner = analyses.first { $0.rosterId == tradePartnerRosterId }
+        let partner = analyses.first { $0.rosterId == tradeController.tradePartnerRosterId }
         let trade = currentTrade(my: my, partner: partner)
         let evaluation = TradeEvaluator.evaluate(trade, valuesStore: valuesStore)
         let suggestions = TradeEvaluator.suggestBalance(
@@ -532,8 +531,8 @@ extension TeamAnalyzerView {
                     tradeSideCard(
                         sideLabel: "You give",
                         teamName: my.teamName,
-                        playerIds: tradeSideAPlayerIds,
-                        pickNames: tradeSideAPickNames,
+                        playerIds: tradeController.tradeSideAPlayerIds,
+                        pickNames: tradeController.tradeSideAPickNames,
                         sideValue: evaluation.sideAValue,
                         addPlayerAction: {
                             showSidePicker = TradeSidePickerContext(
@@ -552,10 +551,10 @@ extension TeamAnalyzerView {
                             )
                         },
                         removePlayerAction: { pid in
-                            tradeSideAPlayerIds.removeAll { $0 == pid }
+                            tradeController.tradeSideAPlayerIds.removeAll { $0 == pid }
                         },
                         removePickAction: { name in
-                            tradeSideAPickNames.removeAll { $0 == name }
+                            tradeController.tradeSideAPickNames.removeAll { $0 == name }
                         }
                     )
 
@@ -563,8 +562,8 @@ extension TeamAnalyzerView {
                         tradeSideCard(
                             sideLabel: "You receive",
                             teamName: partner.teamName,
-                            playerIds: tradeSideBPlayerIds,
-                            pickNames: tradeSideBPickNames,
+                            playerIds: tradeController.tradeSideBPlayerIds,
+                            pickNames: tradeController.tradeSideBPickNames,
                             sideValue: evaluation.sideBValue,
                             addPlayerAction: {
                                 showSidePicker = TradeSidePickerContext(
@@ -583,10 +582,10 @@ extension TeamAnalyzerView {
                                 )
                             },
                             removePlayerAction: { pid in
-                                tradeSideBPlayerIds.removeAll { $0 == pid }
+                                tradeController.tradeSideBPlayerIds.removeAll { $0 == pid }
                             },
                             removePickAction: { name in
-                                tradeSideBPickNames.removeAll { $0 == name }
+                                tradeController.tradeSideBPickNames.removeAll { $0 == name }
                             }
                         )
                     }
@@ -600,10 +599,10 @@ extension TeamAnalyzerView {
 
                     if !trade.isEmpty {
                         Button(role: .destructive) {
-                            tradeSideAPlayerIds = []
-                            tradeSideBPlayerIds = []
-                            tradeSideAPickNames = []
-                            tradeSideBPickNames = []
+                            tradeController.tradeSideAPlayerIds = []
+                            tradeController.tradeSideBPlayerIds = []
+                            tradeController.tradeSideAPickNames = []
+                            tradeController.tradeSideBPickNames = []
                         } label: {
                             Text("Clear trade")
                                 .font(.caption.weight(.semibold))
@@ -630,14 +629,14 @@ extension TeamAnalyzerView {
             sideA: TradeSide(
                 rosterId: my.rosterId,
                 teamName: my.teamName,
-                playerIds: tradeSideAPlayerIds,
-                pickNames: tradeSideAPickNames
+                playerIds: tradeController.tradeSideAPlayerIds,
+                pickNames: tradeController.tradeSideAPickNames
             ),
             sideB: TradeSide(
                 rosterId: partner?.rosterId ?? 0,
                 teamName: partner?.teamName ?? "",
-                playerIds: tradeSideBPlayerIds,
-                pickNames: tradeSideBPickNames
+                playerIds: tradeController.tradeSideBPlayerIds,
+                pickNames: tradeController.tradeSideBPickNames
             )
         )
     }
@@ -670,7 +669,7 @@ extension TeamAnalyzerView {
         let candidates = analyses
             .filter { $0.rosterId != my.rosterId }
             .sorted { $0.totalValue > $1.totalValue }
-        let selectedName = candidates.first { $0.rosterId == tradePartnerRosterId }?.teamName
+        let selectedName = candidates.first { $0.rosterId == tradeController.tradePartnerRosterId }?.teamName
 
         return HStack(spacing: XomperTheme.Spacing.sm) {
             Text("Trade partner")
@@ -679,16 +678,16 @@ extension TeamAnalyzerView {
 
             Menu {
                 Button("None") {
-                    tradePartnerRosterId = nil
-                    tradeSideBPlayerIds = []
+                    tradeController.tradePartnerRosterId = nil
+                    tradeController.tradeSideBPlayerIds = []
                 }
                 Divider()
                 ForEach(candidates, id: \.rosterId) { team in
                     Button {
-                        if tradePartnerRosterId != team.rosterId {
-                            tradeSideBPlayerIds = []
+                        if tradeController.tradePartnerRosterId != team.rosterId {
+                            tradeController.tradeSideBPlayerIds = []
                         }
-                        tradePartnerRosterId = team.rosterId
+                        tradeController.tradePartnerRosterId = team.rosterId
                     } label: {
                         HStack {
                             Text(team.teamName)
@@ -940,12 +939,12 @@ extension TeamAnalyzerView {
                 Button {
                     switch evaluation.verdict {
                     case .sideAWins:
-                        if !tradeSideBPlayerIds.contains(suggestion.playerId) {
-                            tradeSideBPlayerIds.append(suggestion.playerId)
+                        if !tradeController.tradeSideBPlayerIds.contains(suggestion.playerId) {
+                            tradeController.tradeSideBPlayerIds.append(suggestion.playerId)
                         }
                     case .sideBWins:
-                        if !tradeSideAPlayerIds.contains(suggestion.playerId) {
-                            tradeSideAPlayerIds.append(suggestion.playerId)
+                        if !tradeController.tradeSideAPlayerIds.contains(suggestion.playerId) {
+                            tradeController.tradeSideAPlayerIds.append(suggestion.playerId)
                         }
                     default:
                         break
@@ -1004,8 +1003,8 @@ extension TeamAnalyzerView {
     private func tradePlayerSelectionList(context: TradeSidePickerContext) -> some View {
         let alreadyPicked: Set<String> = {
             switch context.side {
-            case .a: return Set(tradeSideAPlayerIds)
-            case .b: return Set(tradeSideBPlayerIds)
+            case .a: return Set(tradeController.tradeSideAPlayerIds)
+            case .b: return Set(tradeController.tradeSideBPlayerIds)
             }
         }()
         let roster = leagueStore.myLeagueRosters.first { $0.rosterId == context.rosterId }
@@ -1029,8 +1028,8 @@ extension TeamAnalyzerView {
                 ForEach(players) { entry in
                     Button {
                         switch context.side {
-                        case .a: tradeSideAPlayerIds.append(entry.playerId)
-                        case .b: tradeSideBPlayerIds.append(entry.playerId)
+                        case .a: tradeController.tradeSideAPlayerIds.append(entry.playerId)
+                        case .b: tradeController.tradeSideBPlayerIds.append(entry.playerId)
                         }
                         showSidePicker = nil
                     } label: {
@@ -1057,8 +1056,8 @@ extension TeamAnalyzerView {
     private func tradePickSelectionList(context: TradeSidePickerContext) -> some View {
         let alreadyPicked: Set<String> = {
             switch context.side {
-            case .a: return Set(tradeSideAPickNames)
-            case .b: return Set(tradeSideBPickNames)
+            case .a: return Set(tradeController.tradeSideAPickNames)
+            case .b: return Set(tradeController.tradeSideBPickNames)
             }
         }()
         // Default to current + next 2 NFL years from the device clock —
@@ -1086,8 +1085,8 @@ extension TeamAnalyzerView {
                     ForEach(names, id: \.self) { name in
                         Button {
                             switch context.side {
-                            case .a: tradeSideAPickNames.append(name)
-                            case .b: tradeSideBPickNames.append(name)
+                            case .a: tradeController.tradeSideAPickNames.append(name)
+                            case .b: tradeController.tradeSideBPickNames.append(name)
                             }
                             showSidePicker = nil
                         } label: {
@@ -1170,12 +1169,10 @@ extension TeamAnalyzerView {
             } else {
                 ForEach(recs) { rec in
                     Button {
-                        // Load the recommendation into the builder.
-                        tradePartnerRosterId = rec.partnerRosterId
-                        tradeSideAPlayerIds = [rec.give.playerId]
-                        tradeSideBPlayerIds = [rec.receive.playerId]
-                        tradeSideAPickNames = []
-                        tradeSideBPickNames = []
+                        // Seed the builder with this recommendation.
+                        // Identical to the deep-link path the My Team
+                        // Trades tab uses — single source of truth.
+                        tradeController.preload(rec)
                     } label: {
                         RecommendedTradeCard(rec)
                     }

--- a/docs/features/my-team-rework/EXECUTION_LOG.md
+++ b/docs/features/my-team-rework/EXECUTION_LOG.md
@@ -1,0 +1,54 @@
+# Execution Log: My Team Rework
+
+## 2026-06-03 12:09 — Phase 0a: Open GitHub issue
+
+- **Action**: Created GitHub issue via `gh issue create`
+- **Issue**: #137 — "feat: My Team rework — tabs, quick hitters, embedded analyzer"
+- **Files changed**: none
+- **Result**: Success
+
+---
+
+## 2026-06-03 12:09 — Phase 0b: Lossless extraction PR
+
+- **Action**: Created branch `refactor/137-extract-team-analyzer-cards`, created two new shared components, updated `TeamAnalyzerView` to consume them
+- **Files changed**:
+  - `Xomper/Features/Shared/PositionBreakdownCard.swift` — NEW. Lifts `breakdownGrid` + `breakdownRow` verbatim. File-private `deltaColor` free function.
+  - `Xomper/Features/Shared/RecommendedTradeCard.swift` — NEW. Lifts `recommendedTradeRow` verbatim.
+  - `Xomper/Features/TeamAnalyzer/TeamAnalyzerView.swift` — EDIT. Replaced `breakdownGrid(...)` call with `PositionBreakdownCard(...)`, replaced `recommendedTradeRow(rec)` label with `RecommendedTradeCard(rec)`. Removed inline `breakdownGrid`, `breakdownRow`, `recommendedTradeRow` methods. Retained `deltaColor` on struct (still used by `leagueTeamAxisCell` in League tab).
+  - `Xomper.xcodeproj/project.pbxproj` — regenerated via `xcodegen generate`
+- **Decisions**: `deltaColor` kept on `TeamAnalyzerView` (League tab still references it). File-private free function in `PositionBreakdownCard.swift` handles the same logic for that component independently. No name collision risk — different scopes.
+- **Build**: `BUILD SUCCEEDED` on iPhone 17 Pro sim
+- **PR**: #138 — open, not merged
+- **Result**: Success — paused for review
+
+---
+
+## 2026-06-03 — Phase 0b PR #138 merged
+
+Squash-merged to `main` at `859fd8e`. Source branch deleted.
+
+---
+
+## 2026-06-03 12:19 — Phase 0c: TradeAnalyzerController hoist
+
+- **Action**: Created branch `refactor/137-trade-analyzer-controller` off updated main. Hoisted all five trade-builder state fields out of `TeamAnalyzerView` into a new shared controller.
+- **Files changed**:
+  - `Xomper/Core/Stores/TradeAnalyzerController.swift` — NEW. `@Observable @MainActor final class`. Owns the five fields: `tradePartnerRosterId: Int?`, `tradeSideAPlayerIds: [String]`, `tradeSideAPickNames: [String]`, `tradeSideBPlayerIds: [String]`, `tradeSideBPickNames: [String]`. Methods `preload(_ rec: RecommendedTrade)` + `reset()`.
+  - `Xomper/Features/TeamAnalyzer/TeamAnalyzerView.swift` — EDIT. Dropped the five `@State` declarations, accepted `tradeController` as constructor prop, redirected every read/write via `replace_all` to `tradeController.<field>`. Inline 5-line preload block inside the recommended-trade `Button` collapsed to `tradeController.preload(rec)` — single source of truth, matches the deep-link path My Team will use.
+  - `Xomper/Features/Shell/MainShell.swift` — EDIT. Instantiated `@State private var tradeController = TradeAnalyzerController()` alongside the other shared stores; passed into the `.teamAnalyzer` case's `TeamAnalyzerView(...)` constructor.
+  - `Xomper.xcodeproj/project.pbxproj` — regenerated via `xcodegen generate`
+- **Deviations from plan**: Plan called out **three** fields; actual code has **five** (pick-name arrays too). Hoisted all five so future Trades-tab recommendations that include picks are also seedable via `preload`. No scope expansion — still exactly three files touched. `showSidePicker` stays as `@State` on the view (transient sheet state, not preload-relevant).
+- **Build**: `BUILD SUCCEEDED` on iPhone 17 Pro sim, no new warnings
+- **PR**: #139 — open, not merged
+- **Result**: Success — paused for review
+
+### Phase 0 wrap-up
+
+Both Phase 0 PRs (#138 merged, #139 open) match the locked plan decisions. Once #139 merges, Step 1 (`TeamView` restructure scaffold) can begin.
+
+---
+
+## Next step (pending PR #139 review)
+
+Step 1: `TeamSection` enum + segmented Picker scaffold in `TeamView.swift`. Wrap existing roster body in `case .roster:`. No visible behavior change yet — sets up the structure for Step 2's Quick Hitters and Steps 3–5's tab content.


### PR DESCRIPTION
## Summary
Phase 0c of the My Team rework (Closes #137 is on the visible-changes PR, not this one).

- New \`TradeAnalyzerController\` — \`@Observable @MainActor final class\` owning the five trade-builder fields that previously lived as private \`@State\` on \`TeamAnalyzerView\`.
- \`TeamAnalyzerView\` switched to consume the controller. The recommended-trade Button now calls \`tradeController.preload(rec)\` — same path the My Team Trades tab will use.
- \`MainShell\` instantiates the controller alongside the other shared stores and injects it.
- \`showSidePicker\` stays on the view as \`@State\` (transient sheet state).

## Deviation from plan
Plan called out three fields; actual code has five (pick-name arrays too). Hoisted all five so future Trades-tab recommendations that include picks are also seedable.

## Test plan
- [ ] Team Analyzer → Trade sub-tab → select a partner → add players to both sides → trade card renders + verdict pill unchanged
- [ ] Pick selection sheet adds picks to both sides
- [ ] "Recommended trades" cards tap → builder populated with give/receive players, picks cleared
- [ ] Tab-switch (Compare ↔ Trade ↔ League) preserves builder state
- [ ] Pull-to-refresh on Compare doesn't reset the trade builder