### PR TITLE
#137 feat: My Team rework — tabs, Quick Hitters, embedded analyzer

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		3403B87830513963A9D86F8F /* MockDraftMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7877A392F88F41B8D4979F23 /* MockDraftMetadataTests.swift */; };
 		366C0075FA9F4ABA1C88C1A9 /* Championship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18383A0375F5728A9E3FE065 /* Championship.swift */; };
 		368D96609CAF02430F340657 /* MatchupHistoryBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A3969B9E9E60F0C59D83C9 /* MatchupHistoryBrowserView.swift */; };
+		37556D3EE4134E6419CE5354 /* QuickHittersStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273FF9D973C37FE35D0DB988 /* QuickHittersStrip.swift */; };
 		37E600A31B5AA5DA5A766692 /* AdminStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ED7387DCA3E1DC5CDD7AFF /* AdminStoreTests.swift */; };
 		38443B41FCC1E80A22E818B5 /* AnnouncementsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A884A785F461C755979D421 /* AnnouncementsStoreTests.swift */; };
 		3B1DDBCA7B19B8703FAF717E /* DrawerScrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D921732971689E8096F9549 /* DrawerScrim.swift */; };
@@ -248,6 +249,7 @@
 		231B20212409143CB0FA0108 /* UpcomingDraftCountdownCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingDraftCountdownCard.swift; sourceTree = "<group>"; };
 		2549566AC9312F44BA381BB6 /* WeeklyRecapMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapMetadata.swift; sourceTree = "<group>"; };
 		26975318DD0DFF73C9469AC5 /* TradeAnalyzerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeAnalyzerController.swift; sourceTree = "<group>"; };
+		273FF9D973C37FE35D0DB988 /* QuickHittersStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickHittersStrip.swift; sourceTree = "<group>"; };
 		2B670A3A0762D22FB3202E1E /* DivisionBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DivisionBadge.swift; sourceTree = "<group>"; };
 		2B6C68E1131F2BBBE625DEAF /* RuleProposalFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleProposalFormView.swift; sourceTree = "<group>"; };
 		2DB0B979B62A1CF6EB80417F /* DraftRecapResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftRecapResolverTests.swift; sourceTree = "<group>"; };
@@ -623,6 +625,7 @@
 			isa = PBXGroup;
 			children = (
 				BC44D14381C74E97D8AF868F /* PlayerDetailView.swift */,
+				273FF9D973C37FE35D0DB988 /* QuickHittersStrip.swift */,
 				F51CC9357B13AB7ADD9C8586 /* TeamView.swift */,
 			);
 			path = Team;
@@ -1191,6 +1194,7 @@
 				77A0EFCEE4340D3A7853BF08 /* ProfileView.swift in Sources */,
 				42E7DDAD3454512247E1AFA6 /* ProposedTrade.swift in Sources */,
 				7D94ADAC136455C3056D5867 /* PushNotificationManager.swift in Sources */,
+				37556D3EE4134E6419CE5354 /* QuickHittersStrip.swift in Sources */,
 				90E2B85AB940A7DF47EED4B1 /* RecommendedTradeCard.swift in Sources */,
 				76260F26A40213A62E5F22FB /* RecordBadge.swift in Sources */,
 				1D67D0B027D9C2AA6E033E38 /* ReportFlag.swift in Sources */,

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -351,7 +351,13 @@ struct MainShell: View {
                 team: team,
                 roster: roster,
                 league: league,
-                playerStore: playerStore
+                playerStore: playerStore,
+                leagueStore: leagueStore,
+                valuesStore: valuesStore,
+                authStore: authStore,
+                navStore: navStore,
+                router: router,
+                tradeController: tradeController
             )
         } else {
             EmptyStateView(
@@ -413,7 +419,13 @@ struct MainShell: View {
                         team: team,
                         roster: roster,
                         league: league,
-                        playerStore: playerStore
+                        playerStore: playerStore,
+                        leagueStore: leagueStore,
+                        valuesStore: valuesStore,
+                        authStore: authStore,
+                        navStore: navStore,
+                        router: router,
+                        tradeController: tradeController
                     )
                 } else {
                     EmptyStateView(icon: "person.3.fill", title: "Team Not Found", message: nil)

--- a/Xomper/Features/Team/QuickHittersStrip.swift
+++ b/Xomper/Features/Team/QuickHittersStrip.swift
@@ -1,0 +1,209 @@
+import SwiftUI
+
+/// Horizontal at-a-glance strip on the My Team page. Six tiles in
+/// canonical order: Record, League rank, Total dynasty value,
+/// Weakness, Total FPTS, Best position.
+///
+/// On phone-width the strip scrolls horizontally — six tiles don't
+/// fit at default Dynamic Type. On regular-width (iPad) the strip
+/// snaps to a non-scrolling `LazyHStack`.
+///
+/// Tiles that reference positional strength (Weakness, Best position)
+/// are tappable and bubble back to the parent so the page can flip
+/// the section picker to `.strengths`.
+struct QuickHittersStrip: View {
+    let data: QuickHittersData
+    /// Called when the user taps Weakness or Best position. Parent
+    /// uses this to switch the section picker to `.strengths`.
+    var onTapStrength: (() -> Void)?
+
+    @Environment(\.horizontalSizeClass) private var sizeClass
+
+    var body: some View {
+        Group {
+            if sizeClass == .regular {
+                LazyHStack(spacing: XomperTheme.Spacing.sm) { tiles }
+                    .padding(.horizontal, XomperTheme.Spacing.md)
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    LazyHStack(spacing: XomperTheme.Spacing.sm) { tiles }
+                        .padding(.horizontal, XomperTheme.Spacing.md)
+                }
+            }
+        }
+        .padding(.vertical, XomperTheme.Spacing.xs)
+    }
+
+    @ViewBuilder
+    private var tiles: some View {
+        recordTile
+        rankTile
+        valueTile
+        fptsTile
+        bestTile
+        weakTile
+    }
+
+    // MARK: - Tiles
+
+    private var recordTile: some View {
+        tile(
+            icon: "trophy.fill",
+            iconColor: XomperColors.championGold,
+            label: "Record",
+            value: data.record,
+            accent: data.streakAccent.map { ($0, data.streakLabel ?? "") }
+        )
+    }
+
+    private var rankTile: some View {
+        tile(
+            icon: "list.number",
+            iconColor: XomperColors.steelBlue,
+            label: "League",
+            value: data.rankDisplay,
+            accent: data.rankIsTop3 ? (XomperColors.championGold, "TOP 3") : nil
+        )
+    }
+
+    private var valueTile: some View {
+        tile(
+            icon: "chart.line.uptrend.xyaxis",
+            iconColor: XomperColors.championGold,
+            label: "Dynasty",
+            value: data.totalValueDisplay,
+            accent: data.totalValueDelta.map { delta in
+                let color: Color = delta >= 0 ? XomperColors.successGreen : XomperColors.errorRed
+                let prefix = delta >= 0 ? "+" : ""
+                return (color, "\(prefix)\(delta)")
+            }
+        )
+    }
+
+    private var fptsTile: some View {
+        tile(
+            icon: "flame.fill",
+            iconColor: Color.orange,
+            label: "FPTS",
+            value: data.fptsDisplay,
+            accent: nil
+        )
+    }
+
+    private var bestTile: some View {
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            onTapStrength?()
+        } label: {
+            tile(
+                icon: "arrow.up.right.square.fill",
+                iconColor: XomperColors.successGreen,
+                label: "Strongest",
+                value: data.bestPosition,
+                accent: nil,
+                interactive: true
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var weakTile: some View {
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            onTapStrength?()
+        } label: {
+            tile(
+                icon: "arrow.down.right.square.fill",
+                iconColor: XomperColors.errorRed,
+                label: "Weakest",
+                value: data.weakestPosition,
+                accent: nil,
+                interactive: true
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Tile shell
+
+    private func tile(
+        icon: String,
+        iconColor: Color,
+        label: String,
+        value: String,
+        accent: (Color, String)?,
+        interactive: Bool = false
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(iconColor)
+                Text(label.uppercased())
+                    .font(.caption2.weight(.bold))
+                    .tracking(0.5)
+                    .foregroundStyle(XomperColors.textMuted)
+                Spacer(minLength: 0)
+                if interactive {
+                    Image(systemName: "chevron.right")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(XomperColors.textMuted)
+                }
+            }
+
+            Text(value)
+                .font(.headline.weight(.bold))
+                .foregroundStyle(XomperColors.textPrimary)
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+
+            if let (color, text) = accent {
+                Text(text)
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(color)
+                    .monospacedDigit()
+            } else {
+                // Reserve the row so all tiles align vertically.
+                Text(" ")
+                    .font(.caption2.weight(.bold))
+            }
+        }
+        .padding(.horizontal, XomperTheme.Spacing.sm)
+        .padding(.vertical, XomperTheme.Spacing.sm)
+        .frame(width: 116, alignment: .leading)
+        .background(
+            LinearGradient(
+                colors: [
+                    XomperColors.bgCard,
+                    XomperColors.bgCard.opacity(0.7)
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md)
+                .strokeBorder(XomperColors.surfaceLight.opacity(0.4), lineWidth: 1)
+        )
+    }
+}
+
+// MARK: - Data
+
+/// Strongly-typed payload for `QuickHittersStrip`. Built by the
+/// parent (`TeamView`) once per body invocation from existing stores
+/// — keeps the strip pure-presentation and easy to preview.
+struct QuickHittersData: Equatable {
+    let record: String           // e.g. "8-6" or "9-4-1"
+    let streakLabel: String?     // "W3" / "L2" / nil
+    let streakAccent: Color?     // green / red / nil
+    let rankDisplay: String      // "8th"
+    let rankIsTop3: Bool         // true if leagueRank <= 3
+    let totalValueDisplay: String // "42,180"
+    let totalValueDelta: Int?    // delta vs league mean, nil if not computable
+    let fptsDisplay: String      // "1,742.4"
+    let bestPosition: String     // axis label e.g. "WR"
+    let weakestPosition: String  // axis label e.g. "TE"
+}

--- a/Xomper/Features/Team/TeamView.swift
+++ b/Xomper/Features/Team/TeamView.swift
@@ -5,9 +5,22 @@ struct TeamView: View {
     let roster: Roster
     let league: League
     let playerStore: PlayerStore
+    /// Shared stores added to power the Strengths + Trades tabs and
+    /// the Quick Hitters strip. Quick Hitters needs dynasty values
+    /// for the totalValue tile; Trades tab needs the controller to
+    /// preload a recommendation before deep-linking into the Analyzer.
+    let leagueStore: LeagueStore
+    let valuesStore: PlayerValuesStore
+    let authStore: AuthStore
+    let navStore: NavigationStore
+    let router: AppRouter
+    let tradeController: TradeAnalyzerController
 
     @State private var selectedPlayer: Player?
     @State private var isRefreshing = false
+    /// Active sub-section. Defaults to `.roster` — it's the
+    /// highest-traffic surface and matches today's behavior.
+    @State private var activeSection: TeamSection = .roster
 
     private var rosterPositions: [String] {
         league.rosterPositions ?? []
@@ -22,45 +35,44 @@ struct TeamView: View {
             VStack(spacing: XomperTheme.Spacing.lg) {
                 teamHeader
 
-                if !hasPlayers && (playerStore.isLoading || isRefreshing) {
-                    LoadingView(message: "Loading players...")
-                        .frame(height: 200)
-                } else if !hasPlayers {
-                    VStack(spacing: XomperTheme.Spacing.md) {
-                        EmptyStateView(
-                            icon: "arrow.clockwise",
-                            title: "Players Not Loaded",
-                            message: "Player data hasn't loaded yet."
-                        )
-                        Button {
-                            Task { await refreshRoster() }
-                        } label: {
-                            Label("Retry", systemImage: "arrow.clockwise")
-                                .font(.subheadline.weight(.semibold))
-                                .foregroundStyle(XomperColors.bgDark)
-                                .padding(.horizontal, XomperTheme.Spacing.lg)
-                                .padding(.vertical, XomperTheme.Spacing.sm)
-                                .background(XomperColors.championGold)
-                                .clipShape(Capsule())
+                // Quick Hitters surfaces six at-a-glance stats above
+                // the section picker. Hidden until both player data
+                // and dynasty values are loaded — otherwise tiles
+                // would show "0" placeholders.
+                if hasPlayers, valuesStore.hasValues {
+                    QuickHittersStrip(
+                        data: quickHittersData(),
+                        onTapStrength: {
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                activeSection = .strengths
+                            }
                         }
-                        .accessibilityLabel("Retry loading players")
-                    }
-                } else {
-                    startersSection
-                    benchSection
-                    taxiSection
-                    irSection
+                    )
+                }
+
+                sectionPicker
+
+                switch activeSection {
+                case .roster:
+                    rosterContent
+                case .strengths:
+                    strengthsContent
+                case .trades:
+                    tradesContent
                 }
             }
             .padding(.horizontal, XomperTheme.Spacing.md)
             .padding(.bottom, XomperTheme.Spacing.xl)
         }
         .refreshable {
-            await refreshRoster()
+            await refreshAll()
         }
         .task {
             if !hasPlayers {
                 await playerStore.loadPlayers()
+            }
+            if !valuesStore.hasValues {
+                await valuesStore.loadValues()
             }
         }
         .background(XomperColors.bgDark)
@@ -69,6 +81,146 @@ struct TeamView: View {
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
         }
+    }
+
+    // MARK: - Section picker
+
+    private var sectionPicker: some View {
+        Picker("Section", selection: $activeSection) {
+            ForEach(TeamSection.allCases) { section in
+                Text(section.label).tag(section)
+            }
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal, XomperTheme.Spacing.xs)
+    }
+
+    // MARK: - Roster section content
+
+    @ViewBuilder
+    private var rosterContent: some View {
+        if !hasPlayers && (playerStore.isLoading || isRefreshing) {
+            LoadingView(message: "Loading players...")
+                .frame(height: 200)
+        } else if !hasPlayers {
+            VStack(spacing: XomperTheme.Spacing.md) {
+                EmptyStateView(
+                    icon: "arrow.clockwise",
+                    title: "Players Not Loaded",
+                    message: "Player data hasn't loaded yet."
+                )
+                Button {
+                    Task { await refreshAll() }
+                } label: {
+                    Label("Retry", systemImage: "arrow.clockwise")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(XomperColors.bgDark)
+                        .padding(.horizontal, XomperTheme.Spacing.lg)
+                        .padding(.vertical, XomperTheme.Spacing.sm)
+                        .background(XomperColors.championGold)
+                        .clipShape(Capsule())
+                }
+                .accessibilityLabel("Retry loading players")
+            }
+        } else {
+            startersSection
+            benchSection
+            taxiSection
+            irSection
+        }
+    }
+
+    // MARK: - Strengths section content
+
+    @ViewBuilder
+    private var strengthsContent: some View {
+        if !valuesStore.hasValues && valuesStore.isLoading {
+            LoadingView(message: "Loading player values…")
+                .frame(height: 200)
+        } else if let my = myAnalysis() {
+            VStack(spacing: XomperTheme.Spacing.lg) {
+                HexagonChartView(
+                    primary: my.hexAxes,
+                    comparison: nil,
+                    leagueAverage: leagueAverages(),
+                    axisMaxes: axisMaxes()
+                )
+                .frame(maxWidth: .infinity)
+
+                PositionBreakdownCard(
+                    my: my,
+                    opp: nil,
+                    averages: leagueAverages(),
+                    maxes: axisMaxes()
+                )
+            }
+        } else {
+            EmptyStateView(
+                icon: "chart.pie",
+                title: "Strengths Unavailable",
+                message: "Couldn't compute your team's strength profile yet. Pull to refresh."
+            )
+        }
+    }
+
+    // MARK: - Trades section content
+
+    @ViewBuilder
+    private var tradesContent: some View {
+        if !valuesStore.hasValues && valuesStore.isLoading {
+            LoadingView(message: "Loading player values…")
+                .frame(height: 200)
+        } else if let my = myAnalysis() {
+            let recs = RecommendedTradeBuilder.recommend(
+                myAnalysis: my,
+                analyses: allAnalyses(),
+                rosters: leagueStore.myLeagueRosters,
+                playerStore: playerStore,
+                valuesStore: valuesStore
+            )
+            if recs.isEmpty {
+                EmptyStateView(
+                    icon: "arrow.left.arrow.right.circle",
+                    title: "No Recommendations",
+                    message: "We didn't find any fair-value swaps that improve your weak positions right now. Check back after your next move."
+                )
+            } else {
+                VStack(spacing: XomperTheme.Spacing.md) {
+                    Text("Tap a recommendation to open it in the Trade Analyzer.")
+                        .font(.caption)
+                        .foregroundStyle(XomperColors.textMuted)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, XomperTheme.Spacing.xs)
+
+                    ForEach(recs) { rec in
+                        Button {
+                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                            tradeController.preload(rec)
+                            navStore.select(.teamAnalyzer, router: router)
+                        } label: {
+                            RecommendedTradeCard(rec)
+                        }
+                        .buttonStyle(.pressableCard)
+                    }
+                }
+            }
+        } else {
+            EmptyStateView(
+                icon: "arrow.left.arrow.right.circle",
+                title: "Trades Unavailable",
+                message: "Couldn't compute trade recommendations yet. Pull to refresh."
+            )
+        }
+    }
+
+    // MARK: - Refresh
+
+    private func refreshAll() async {
+        isRefreshing = true
+        defer { isRefreshing = false }
+        async let players: () = playerStore.loadPlayers()
+        async let values:  () = valuesStore.loadValues(forceRefresh: true)
+        _ = await (players, values)
     }
 }
 
@@ -309,13 +461,172 @@ private extension TeamView {
     }
 }
 
-// MARK: - Refresh
+// MARK: - Analyses + Quick Hitters builders
 
 private extension TeamView {
-    func refreshRoster() async {
-        isRefreshing = true
-        await playerStore.loadPlayers()
-        isRefreshing = false
+
+    /// Build per-team analyses once. Cheap enough to re-run per body
+    /// invocation — matches `TeamAnalyzerView.content`'s pattern.
+    /// Returns an empty array when prerequisites haven't loaded.
+    func allAnalyses() -> [TeamAnalysis] {
+        guard !leagueStore.myLeagueRosters.isEmpty, valuesStore.hasValues else {
+            return []
+        }
+        return TeamAnalysisBuilder.build(
+            rosters: leagueStore.myLeagueRosters,
+            users: leagueStore.myLeagueUsers,
+            playerStore: playerStore,
+            valuesStore: valuesStore
+        )
+    }
+
+    /// My team's analysis. Falls back to the first analysis if the
+    /// signed-in user isn't owner of any roster (shouldn't happen in
+    /// the home league, but defensive).
+    func myAnalysis() -> TeamAnalysis? {
+        let analyses = allAnalyses()
+        guard let myUserId = authStore.sleeperUserId else { return analyses.first }
+        return analyses.first { $0.userId == myUserId } ?? analyses.first
+    }
+
+    func axisMaxes() -> [String: Int] {
+        TeamAnalysisBuilder.axisMaxes(allAnalyses())
+    }
+
+    func leagueAverages() -> [TeamAnalysis.HexAxis] {
+        TeamAnalysisBuilder.leagueAverageAxes(allAnalyses())
+    }
+
+    /// Builds the Quick Hitters payload from `team`, the cached
+    /// analyses, and `leagueStore.myLeagueRosters`. Safe to call when
+    /// analyses are empty — the strength tiles fall back to a "—"
+    /// placeholder.
+    func quickHittersData() -> QuickHittersData {
+        let analyses = allAnalyses()
+        let mine = analyses.first { $0.userId == authStore.sleeperUserId } ?? analyses.first
+        let averages = TeamAnalysisBuilder.leagueAverageAxes(analyses)
+
+        // Record + streak. The streak tile coloring matches the
+        // existing teamHeader's `streakBadge`.
+        let recordStr: String
+        if team.ties > 0 {
+            recordStr = "\(team.wins)-\(team.losses)-\(team.ties)"
+        } else {
+            recordStr = "\(team.wins)-\(team.losses)"
+        }
+        let streakLabel = team.streak.displayString
+        let streakAccent: Color? = {
+            switch team.streak.type {
+            case .win:  return XomperColors.successGreen
+            case .loss: return XomperColors.errorRed
+            case .none: return nil
+            }
+        }()
+
+        // League rank ordinal.
+        let rank = team.leagueRank
+        let rankStr = "\(rank)\(ordinalSuffix(rank))"
+        let isTop3 = rank > 0 && rank <= 3
+
+        // Dynasty total + delta vs league mean.
+        let total = mine?.totalValue ?? 0
+        let totalDisplay = formatThousands(total)
+        let totalDelta: Int? = {
+            guard !analyses.isEmpty else { return nil }
+            let mean = analyses.map(\.totalValue).reduce(0, +) / max(analyses.count, 1)
+            return total - mean
+        }()
+
+        // Season FPTS straight from standings.
+        let fptsDisplay = formatFpts(team.fpts)
+
+        // Best / worst axis by ratio to league average.
+        let (bestLabel, weakestLabel) = bestAndWeakest(
+            for: mine?.hexAxes ?? [],
+            averages: averages
+        )
+
+        return QuickHittersData(
+            record: recordStr,
+            streakLabel: streakLabel,
+            streakAccent: streakAccent,
+            rankDisplay: rankStr,
+            rankIsTop3: isTop3,
+            totalValueDisplay: totalDisplay,
+            totalValueDelta: totalDelta,
+            fptsDisplay: fptsDisplay,
+            bestPosition: bestLabel,
+            weakestPosition: weakestLabel
+        )
+    }
+
+    /// Compute the axis labels with the highest / lowest ratio of
+    /// `axis.value` to the league average. Falls back to "—" when
+    /// the data isn't ready.
+    func bestAndWeakest(
+        for axes: [TeamAnalysis.HexAxis],
+        averages: [TeamAnalysis.HexAxis]
+    ) -> (best: String, weakest: String) {
+        guard !axes.isEmpty, !averages.isEmpty else {
+            return ("—", "—")
+        }
+        let avgByLabel: [String: Int] = Dictionary(
+            uniqueKeysWithValues: averages.map { ($0.label, $0.value) }
+        )
+        var bestLabel = axes[0].label
+        var weakestLabel = axes[0].label
+        var bestRatio: Double = -.infinity
+        var weakestRatio: Double = .infinity
+        for axis in axes {
+            let avg = max(avgByLabel[axis.label] ?? 0, 1)
+            let ratio = Double(axis.value) / Double(avg)
+            if ratio > bestRatio {
+                bestRatio = ratio
+                bestLabel = axis.label
+            }
+            if ratio < weakestRatio {
+                weakestRatio = ratio
+                weakestLabel = axis.label
+            }
+        }
+        return (bestLabel, weakestLabel)
+    }
+
+    func formatThousands(_ value: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.groupingSeparator = ","
+        return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+
+    func formatFpts(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 1
+        formatter.maximumFractionDigits = 1
+        formatter.groupingSeparator = ","
+        return formatter.string(from: NSNumber(value: value)) ?? String(format: "%.1f", value)
+    }
+}
+
+// MARK: - Section enum
+
+/// Three top-level tabs inside My Team. Roster leads (highest-traffic
+/// surface); Strengths and Trades follow in dependency order
+/// (Strengths reads the data Trades acts on).
+enum TeamSection: String, CaseIterable, Identifiable, Hashable {
+    case roster
+    case strengths
+    case trades
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .roster:    "Roster"
+        case .strengths: "Strengths"
+        case .trades:    "Trades"
+        }
     }
 }
 
@@ -522,7 +833,13 @@ struct PlayerRow: View {
             rosterPositions: ["QB", "RB", "RB", "WR", "WR", "TE", "FLEX", "FLEX", "SUPER_FLEX", "BN", "BN", "BN", "BN", "BN", "IR"],
             metadata: nil
         ),
-        playerStore: store
+        playerStore: store,
+        leagueStore: LeagueStore(),
+        valuesStore: PlayerValuesStore(),
+        authStore: AuthStore(),
+        navStore: NavigationStore(),
+        router: AppRouter(),
+        tradeController: TradeAnalyzerController()
     )
     .preferredColorScheme(.dark)
 }

--- a/docs/features/my-team-rework/EXECUTION_LOG.md
+++ b/docs/features/my-team-rework/EXECUTION_LOG.md
@@ -49,6 +49,43 @@ Both Phase 0 PRs (#138 merged, #139 open) match the locked plan decisions. Once 
 
 ---
 
-## Next step (pending PR #139 review)
+## 2026-06-03 — Phase 0c PR #139 merged
 
-Step 1: `TeamSection` enum + segmented Picker scaffold in `TeamView.swift`. Wrap existing roster body in `case .roster:`. No visible behavior change yet — sets up the structure for Step 2's Quick Hitters and Steps 3–5's tab content.
+Squash-merged to `main`. Branch deleted. Clean field for the visible TeamView changes.
+
+---
+
+## 2026-06-03 12:30 — Steps 1–9: TeamView restructure (single PR)
+
+Steps 1 through 9 from the plan executed in one feature branch / one PR to minimize churn:
+
+- **Step 1 (TeamSection scaffold)** — Added `TeamSection` enum (`.roster / .strengths / .trades`) at file-end. `@State activeSection` defaults to `.roster`. Segmented `Picker` added between Quick Hitters and the section body.
+- **Step 2 (QuickHittersStrip)** — New file `Xomper/Features/Team/QuickHittersStrip.swift`. Six tiles in canonical order: Record (with W/L streak chip) → League rank (TOP 3 badge if ≤ 3rd) → Dynasty (with +/- delta vs league mean) → FPTS → Strongest position → Weakest position. Horizontal `ScrollView` on compact widths, non-scrolling `LazyHStack` on regular widths (iPad). Tiles use a subtle gradient + `surfaceLight` stroke; strength tiles are tappable and flip the section picker to `.strengths`.
+- **Step 3 (Strengths tab)** — Renders `HexagonChartView` + `PositionBreakdownCard`. Loading + empty states handled.
+- **Step 4 (Trades tab)** — Renders `RecommendedTradeBuilder.recommend(...)` as `RecommendedTradeCard` rows. Tap → `tradeController.preload(rec)` then `navStore.select(.teamAnalyzer, router: router)` — the Analyzer opens with the recommendation already populated. Single source of truth shared with the Analyzer's own recommended-trades section.
+- **Step 5 (Wire data deps)** — `TeamView` gains six new props: `leagueStore`, `valuesStore`, `authStore`, `navStore`, `router`, `tradeController`. Body precomputes analyses + axisMaxes + leagueAverages via a private extension; Quick Hitters payload built in a single helper.
+- **Step 6 (Update MainShell call sites)** — Both call sites updated (`.myTeam` destination and `.teamDetail` push). Preview block updated with default-init stores.
+- **Step 7 (Sticky behavior, D-5)** — Decided **not sticky** on first pass. Reasoning: the existing team header is tall (avatar + name + manager + record badge + streak + rank badges) and stacking sticky Quick Hitters above the section picker eats 35-40% of viewport on iPhone 17 Pro before content shows. Quick Hitters scrolls with the page; section picker scrolls too. Cleaner first impression; can revisit if user feedback says otherwise.
+- **Step 8 (Build)** — `xcodegen generate` + `BUILD SUCCEEDED` on iPhone 17 Pro sim. No new warnings.
+- **Step 9 (Commit + PR)** — Branch `feat/137-my-team-rework`. PR pending.
+
+### Files touched
+
+- NEW `Xomper/Features/Team/QuickHittersStrip.swift`
+- EDIT `Xomper/Features/Team/TeamView.swift` (+~250 lines)
+- EDIT `Xomper/Features/Shell/MainShell.swift` (2 call sites + new `@State tradeController` — already done in Phase 0c, both TeamView call sites now pass the controller through)
+- REGENERATED `Xomper.xcodeproj/project.pbxproj`
+- EDIT `docs/features/my-team-rework/EXECUTION_LOG.md`
+
+### Polish notes per "make it look nice"
+
+- Quick Hitters tiles use a subtle vertical gradient (`bgCard` → `bgCard.opacity(0.7)`) so they pop off the dark background without competing with the existing team header.
+- Color coding is consistent with the rest of the app: gold for accolades (record trophy, dynasty chart-up, top-3 badge), green for positive deltas + strongest position, red for negative deltas + weakest position, orange for FPTS flame, steel-blue for rank.
+- Each tile reserves the accent-text row even when empty so all six tiles align vertically.
+- Tappable tiles get a chevron-right glyph in the upper-right corner — affordance signal for the user.
+
+### Open follow-ups (out of scope for this PR)
+
+- Sticky Quick Hitters revisit (D-5) — current decision is non-sticky; flag for review if user wants pinned behavior.
+- Trade-recommendation chips on the strongest/weakest tiles (e.g., "Trade for an RB?") — could land later as a polish PR.
+- Optional Section-specific pull-to-refresh (e.g., refreshing Strengths re-fetches values; refreshing Trades re-runs the recommender) — currently `refreshAll()` runs on any section.


### PR DESCRIPTION
## Summary
Closes #137. Visible TeamView changes for the My Team rework.

- **3-tab structure** — Roster (existing roster body verbatim) / Strengths (hex chart + position breakdown) / Trades (recommendation list).
- **Quick Hitters strip** — six tiles above the picker: Record (+ streak chip), League rank (+ TOP 3 badge), Dynasty total (+ delta vs league mean), Season FPTS, Strongest position, Weakest position. Horizontal scroll on phone; non-scrolling LazyHStack on iPad. Strongest/weakest tiles tap to flip section to \`.strengths\`.
- **Trades deep-link** — Tapping a recommendation calls \`tradeController.preload(rec)\` then \`navStore.select(.teamAnalyzer, router: router)\`. The Analyzer opens with the builder already seeded. Same path the Analyzer's internal recommendations use — single source of truth.
- **Polish** — Tiles use subtle vertical gradient (\`bgCard\` → \`bgCard.opacity(0.7)\`) with \`surfaceLight\` stroke. Consistent color palette: gold for accolades, green for positive deltas + strongest, red for negative + weakest, orange for FPTS, steel-blue for rank.

Stacked on top of merged PR #139 (\`TradeAnalyzerController\` hoist) and PR #138 (\`PositionBreakdownCard\` + \`RecommendedTradeCard\` extraction). Both are on \`main\` now.

## Decisions in this PR
- **D-5 (sticky strip)**: non-sticky on first pass — existing team header + Quick Hitters + picker already eats ~35% of iPhone 17 Pro viewport before content. Revisit if user wants pinned.
- **Roster tab is the default** (per D-4 plan lock) — highest-traffic surface, zero regression on existing UX.

## Test plan
- [ ] Open My Team — defaults to Roster, identical to today's UI
- [ ] Quick Hitters strip renders six tiles, scrolls horizontally on phone
- [ ] TOP 3 badge appears when leagueRank ≤ 3
- [ ] Dynasty tile shows + or − delta vs league mean
- [ ] Tap "Strongest" or "Weakest" tile → section picker animates to Strengths
- [ ] Strengths tab: hex chart + per-position breakdown matches Analyzer's Compare tab (sans opponent column)
- [ ] Trades tab: list of recommendations or empty-state copy
- [ ] Tap a Trade row → drawer destination switches to Team Analyzer with builder pre-populated (partner + give/receive players)
- [ ] Pull-to-refresh reloads players + values without thrash
- [ ] Selected-team push (via Search / standings) still works with new prop signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)