### PR TITLE
fix(admin): drop confusing test_mode toggle from cron settings

### DIFF
--- a/Xomper/Features/Admin/CronSettingsView.swift
+++ b/Xomper/Features/Admin/CronSettingsView.swift
@@ -2,18 +2,15 @@ import SwiftUI
 
 /// Admin → Cron Settings.
 ///
-/// List of every scheduled-notification lambda with two toggles per row:
-/// `Enabled` (kill switch — no-op the lambda) and `Test mode` (restrict
-/// delivery to the admin's Sleeper user only — useful for previewing
-/// AI Review newsletters or recap emails before they fan out to the
-/// league).
+/// List of every scheduled-notification lambda with a single per-row
+/// `Enabled` toggle (kill switch — no-op the lambda).
+///
+/// On-demand email previews live on the dedicated Admin → Test Email
+/// screen, so there is no per-row test-mode toggle here — that passive
+/// "next fire restricts recipients to admin" flag was redundant and
+/// confusing. An inline hint points admins to the Test Email screen.
 ///
 /// UX rules:
-/// - The "Test mode" toggle is disabled (greyed) when `enabled == false`
-///   so the admin doesn't toggle test-mode on a disabled cron by mistake.
-/// - A prominent "Test mode active" banner pins to the top when any
-///   cron has `test_mode == true` — mitigation for the "set test mode,
-///   forgot to flip back" risk called out in the plan.
 /// - Each row gets its own spinner during the per-row save POST.
 /// - `tableMissing` from the backend renders a dedicated empty state
 ///   explaining the manual Supabase migration needs to be applied.
@@ -67,9 +64,7 @@ struct CronSettingsView: View {
     private var list: some View {
         ScrollView {
             VStack(spacing: XomperTheme.Spacing.md) {
-                if store.anyTestModeActive {
-                    testModeBanner
-                }
+                previewHint
 
                 if let lastError = store.lastError, !lastError.isEmpty {
                     saveErrorBanner(lastError)
@@ -84,11 +79,6 @@ struct CronSettingsView: View {
                                 let generator = UIImpactFeedbackGenerator(style: .light)
                                 generator.impactOccurred()
                                 Task { await store.toggleEnabled(cronKey: setting.cronKey, enabled: newValue) }
-                            },
-                            onToggleTestMode: { newValue in
-                                let generator = UIImpactFeedbackGenerator(style: .light)
-                                generator.impactOccurred()
-                                Task { await store.toggleTestMode(cronKey: setting.cronKey, testMode: newValue) }
                             }
                         )
                     }
@@ -99,35 +89,26 @@ struct CronSettingsView: View {
         }
     }
 
-    // MARK: - Banners
+    // MARK: - Hint
 
-    private var testModeBanner: some View {
+    private var previewHint: some View {
         HStack(spacing: XomperTheme.Spacing.sm) {
-            Image(systemName: "flask.fill")
-                .font(.headline)
-                .foregroundStyle(XomperColors.championGold)
+            Image(systemName: "envelope.badge")
+                .font(.caption)
+                .foregroundStyle(XomperColors.textSecondary)
                 .accessibilityHidden(true)
-
-            VStack(alignment: .leading, spacing: XomperTheme.Spacing.xxs) {
-                Text("Test mode active")
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(XomperColors.textPrimary)
-                Text("At least one cron is delivering only to the admin. Flip back before the next live send.")
-                    .font(.caption)
-                    .foregroundStyle(XomperColors.textSecondary)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            Text("To preview an email, use Admin → Test Email.")
+                .font(.caption)
+                .foregroundStyle(XomperColors.textSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(XomperTheme.Spacing.md)
-        .background(XomperColors.championGold.opacity(0.12))
-        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
-                .strokeBorder(XomperColors.championGold.opacity(0.4), lineWidth: 1)
-        )
+        .padding(XomperTheme.Spacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Test mode active. At least one cron is delivering only to the admin.")
+        .accessibilityLabel("To preview an email, use Admin, Test Email.")
     }
+
+    // MARK: - Banners
 
     private func saveErrorBanner(_ message: String) -> some View {
         HStack(spacing: XomperTheme.Spacing.sm) {
@@ -152,14 +133,12 @@ struct CronSettingsView: View {
 
 // MARK: - Row
 
-/// One cron row. Two toggles + a small spinner gutter so the layout
-/// doesn't reflow when a save is in flight. The Test-mode toggle is
-/// disabled when `setting.enabled == false`.
+/// One cron row. A single `Enabled` kill-switch toggle + a small
+/// spinner gutter so the layout doesn't reflow when a save is in flight.
 private struct CronSettingRow: View {
     let setting: CronSetting
     let isPending: Bool
     let onToggleEnabled: (Bool) -> Void
-    let onToggleTestMode: (Bool) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
@@ -183,30 +162,18 @@ private struct CronSettingRow: View {
                 .lineLimit(1)
 
             Toggle(isOn: enabledBinding) {
-                Text("Enabled")
-                    .font(.subheadline)
-                    .foregroundStyle(XomperColors.textPrimary)
-            }
-            .tint(XomperColors.successGreen)
-
-            Toggle(isOn: testModeBinding) {
                 VStack(alignment: .leading, spacing: XomperTheme.Spacing.xxs) {
-                    Text("Test mode")
+                    Text("Enabled")
                         .font(.subheadline)
-                        .foregroundStyle(setting.enabled ? XomperColors.textPrimary : XomperColors.textMuted)
-                    if !setting.enabled {
-                        Text("Enable the cron to toggle test mode")
+                        .foregroundStyle(XomperColors.textPrimary)
+                    if let description = setting.description, !description.isEmpty {
+                        Text(description)
                             .font(.caption2)
                             .foregroundStyle(XomperColors.textMuted)
-                    } else if setting.testMode {
-                        Text("Delivers only to the admin user")
-                            .font(.caption2)
-                            .foregroundStyle(XomperColors.championGold)
                     }
                 }
             }
-            .tint(XomperColors.championGold)
-            .disabled(!setting.enabled)
+            .tint(XomperColors.successGreen)
         }
         .padding(XomperTheme.Spacing.md)
         .frame(minHeight: XomperTheme.minTouchTarget)
@@ -214,15 +181,10 @@ private struct CronSettingRow: View {
         .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
         .overlay(
             RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
-                .strokeBorder(
-                    setting.testMode
-                        ? XomperColors.championGold.opacity(0.4)
-                        : XomperColors.championGold.opacity(0.15),
-                    lineWidth: 1
-                )
+                .strokeBorder(XomperColors.championGold.opacity(0.15), lineWidth: 1)
         )
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("\(setting.displayTitle). \(setting.enabled ? "Enabled" : "Disabled"). \(setting.testMode ? "Test mode on" : "Test mode off").")
+        .accessibilityLabel("\(setting.displayTitle). \(setting.enabled ? "Enabled" : "Disabled").")
     }
 
     // MARK: - Bindings
@@ -231,13 +193,6 @@ private struct CronSettingRow: View {
         Binding(
             get: { setting.enabled },
             set: { onToggleEnabled($0) }
-        )
-    }
-
-    private var testModeBinding: Binding<Bool> {
-        Binding(
-            get: { setting.testMode },
-            set: { onToggleTestMode($0) }
         )
     }
 }


### PR DESCRIPTION
## Summary
Removes the passive per-row `test_mode` toggle from Admin → Cron Settings. That flag only meant "the next scheduled fire restricts recipients to admin" — redundant and confusing now that the dedicated **Admin → Test Email** screen is the proper on-demand email-preview path.

## Changes
- `CronSettingsView.swift`: removed the per-row Test mode toggle, its binding, the `onToggleTestMode` callback wiring, and the "Test mode active" banner. Kept the per-row **Enabled** kill-switch (now showing the cron description). Added a lightweight inline hint: "To preview an email, use Admin → Test Email."

## Kept intentionally
- `CronSetting.testMode` model field, the store's `toggleTestMode`/`anyTestModeActive`, and the update endpoint contract are untouched — backend still returns the field and the API payload is unchanged. Only the UI surface was removed (minimal change, no ripple).

## Verification
- `xcodegen generate` + `xcodebuild` → **BUILD SUCCEEDED**