### PR TITLE
fix(draft): blank manager names, recap bullets, dynasty chain resilience

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		11EFE5DD5C1D6DE5056597BB /* PlayerPointsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36829F2AD0FD089788B9CE1 /* PlayerPointsStore.swift */; };
 		133F58C70F4FA02676079E9A /* RulesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FDC8A9B02A2BFD83398D04F /* RulesStore.swift */; };
 		143F0C4F56D88430BDC07B2A /* SeasonPickerBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD5AF5657020E1DBB5CB8886 /* SeasonPickerBar.swift */; };
+		14C05C401FBE86429AB1CD7E /* XomperAPIClientProtocol+TestStubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C12289B5D74747C89E09283 /* XomperAPIClientProtocol+TestStubs.swift */; };
 		16F47DD114B2470F88D007A5 /* MatchupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8521885A7FF4C6910DFBF549 /* MatchupsView.swift */; };
 		1720E856ACCE0189331605F2 /* AdminStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7839DD9CF0968986F91A58DB /* AdminStore.swift */; };
 		189F79187B5D4D5686909B2F /* AIReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A95FE8DD123C85CA39DAE13 /* AIReport.swift */; };
@@ -64,6 +65,7 @@
 		42F9C81AF6338A720FE0BC12 /* ArchiveNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E65C159F2C84E48B61A9A8 /* ArchiveNavigationTests.swift */; };
 		4358973CB450667407A22310 /* DraftGrade.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30266A2CB62F694EB45ACEA /* DraftGrade.swift */; };
 		440A44095AD70A8D3D273EEE /* StandingsScrollBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1A7B1219575171DA3ABAB7 /* StandingsScrollBar.swift */; };
+		45B77984A7DC400395826FE6 /* MarkdownBulletRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B08409B47A56CAD2EAB776C /* MarkdownBulletRenderingTests.swift */; };
 		4A321187068EEBA8C4E75EFE /* PayoutProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E3BE36BCEA1A7722157C37 /* PayoutProjection.swift */; };
 		4AFF52CDFE011C65E819946A /* EmailArchiveListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52633D7C9BB49C28288B36A6 /* EmailArchiveListView.swift */; };
 		4B629DB100C96EB68A6A9A41 /* SearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323F422F2D0E1C2BA5D46C0A /* SearchResults.swift */; };
@@ -241,6 +243,7 @@
 		19CAA19890E461D00B644AA0 /* EmailArchiveDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailArchiveDetailView.swift; sourceTree = "<group>"; };
 		1A884A785F461C755979D421 /* AnnouncementsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsStoreTests.swift; sourceTree = "<group>"; };
 		1AD376EFB7AD4A192FAB3E8F /* RecordBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordBadge.swift; sourceTree = "<group>"; };
+		1B08409B47A56CAD2EAB776C /* MarkdownBulletRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownBulletRenderingTests.swift; sourceTree = "<group>"; };
 		1D61FC118C0250CA87BDF647 /* ReportFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportFlagTests.swift; sourceTree = "<group>"; };
 		1D6C6489A04EC9CA00FFBD0F /* StandingsOffseasonCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsOffseasonCard.swift; sourceTree = "<group>"; };
 		1FBB5433786555EDDBC896C7 /* XomperTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperTheme.swift; sourceTree = "<group>"; };
@@ -252,6 +255,7 @@
 		273FF9D973C37FE35D0DB988 /* QuickHittersStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickHittersStrip.swift; sourceTree = "<group>"; };
 		2B670A3A0762D22FB3202E1E /* DivisionBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DivisionBadge.swift; sourceTree = "<group>"; };
 		2B6C68E1131F2BBBE625DEAF /* RuleProposalFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleProposalFormView.swift; sourceTree = "<group>"; };
+		2C12289B5D74747C89E09283 /* XomperAPIClientProtocol+TestStubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XomperAPIClientProtocol+TestStubs.swift"; sourceTree = "<group>"; };
 		2DB0B979B62A1CF6EB80417F /* DraftRecapResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftRecapResolverTests.swift; sourceTree = "<group>"; };
 		2DBAC7CE2DC64237D218FAB8 /* AdminTablesStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminTablesStoreTests.swift; sourceTree = "<group>"; };
 		2DCF4387BA57375E04A8940B /* AnnouncementsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsCard.swift; sourceTree = "<group>"; };
@@ -599,6 +603,7 @@
 				36E84A86BA7FCA57856BD476 /* LeagueAnnouncementDecoderTests.swift */,
 				82A98546D2F68452085EEC9C /* LogEventTests.swift */,
 				ED8C8F9BD9880370D65EDF0B /* LogsStoreTests.swift */,
+				1B08409B47A56CAD2EAB776C /* MarkdownBulletRenderingTests.swift */,
 				A951936FD34F712A8D8E66C0 /* MockDraftEngineTests.swift */,
 				7877A392F88F41B8D4979F23 /* MockDraftMetadataTests.swift */,
 				7589768F3AF9DB478D8E0419 /* MockDraftStoreFallbackTests.swift */,
@@ -606,6 +611,7 @@
 				1D61FC118C0250CA87BDF647 /* ReportFlagTests.swift */,
 				48F82C66C92981F7F8AB58CE /* SeededRNGTests.swift */,
 				BB79AE4EA78D33BDCD8565A8 /* TestEmailStoreTests.swift */,
+				B56844DA85C58D7C0203E412 /* Support */,
 			);
 			path = XomperTests;
 			sourceTree = "<group>";
@@ -776,6 +782,14 @@
 				E969C4A894017F9D0072CCFA /* WorldCup.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		B56844DA85C58D7C0203E412 /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				2C12289B5D74747C89E09283 /* XomperAPIClientProtocol+TestStubs.swift */,
+			);
+			path = Support;
 			sourceTree = "<group>";
 		};
 		CF0EB2B68A2AB44A16E88FB9 /* Shared */ = {
@@ -1065,6 +1079,7 @@
 				EC07E5ADB7CEF9AFDC9B152A /* LeagueAnnouncementDecoderTests.swift in Sources */,
 				31527A4E320270A464DBADDB /* LogEventTests.swift in Sources */,
 				7794B2E1BA5055ACFF150166 /* LogsStoreTests.swift in Sources */,
+				45B77984A7DC400395826FE6 /* MarkdownBulletRenderingTests.swift in Sources */,
 				2ECED2F6ACF5F762D1E1462F /* MockDraftEngineTests.swift in Sources */,
 				3403B87830513963A9D86F8F /* MockDraftMetadataTests.swift in Sources */,
 				4DA6A8F315E4AFF217B5C7F5 /* MockDraftStoreFallbackTests.swift in Sources */,
@@ -1072,6 +1087,7 @@
 				9FA30DE0724E90F9914ED3BA /* ReportFlagTests.swift in Sources */,
 				CC44774FC6B17057810140CF /* SeededRNGTests.swift in Sources */,
 				57E9FA9D90F0BF708A014023 /* TestEmailStoreTests.swift in Sources */,
+				14C05C401FBE86429AB1CD7E /* XomperAPIClientProtocol+TestStubs.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Xomper/Core/Extensions/MarkdownReflow.swift
+++ b/Xomper/Core/Extensions/MarkdownReflow.swift
@@ -86,6 +86,20 @@ enum MarkdownReflow {
             options: .regularExpression
         )
 
+        // 7b. Promote list items to their own blocks. Claude emits
+        //     "- 1.02 name — Player..." pick lines separated by single
+        //     newlines; the block parser would otherwise collapse them
+        //     into one run-on paragraph ("...in Madden. - 1.02 name...").
+        //     Detaching each marker onto a blank-line boundary lets the
+        //     parser render real, spaced bullets. Matches `-`, `*`, `•`
+        //     at a line start (optionally after the leading text of the
+        //     first bullet in a run).
+        out = out.replacingOccurrences(
+            of: #"[ \t]*\n[ \t]*([-*•])[ \t]+"#,
+            with: "\n\n- ",
+            options: .regularExpression
+        )
+
         // 8. Normalize whitespace — collapse 3+ newlines and strip
         //    leading whitespace on the result so SwiftUI's
         //    AttributedString(markdown:) sees clean input.
@@ -118,8 +132,9 @@ enum MarkdownReflow {
     /// prose, and shouldn't be sliced.
     private static func splitLongParagraph(_ paragraph: String, maxLen: Int, maxSplits: Int) -> String {
         let trimmed = paragraph.trimmingCharacters(in: .whitespacesAndNewlines)
-        // Don't touch heading-like blocks.
+        // Don't touch heading-like or list-item blocks.
         if trimmed.hasPrefix("#") || trimmed.hasPrefix(">") { return paragraph }
+        if trimmed.hasPrefix("- ") || trimmed.hasPrefix("* ") || trimmed.hasPrefix("• ") { return paragraph }
         if trimmed.count <= maxLen || maxSplits == 0 { return paragraph }
 
         // Find every sentence boundary: period/exclamation/question

--- a/Xomper/Core/Extensions/StyledMarkdownView.swift
+++ b/Xomper/Core/Extensions/StyledMarkdownView.swift
@@ -75,6 +75,21 @@ struct StyledMarkdownView: View {
             }
             .padding(.vertical, 8)
 
+        case .bullet(let text):
+            HStack(alignment: .top, spacing: 8) {
+                Text("•")
+                    .font(.body.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+                inlineText(text)
+                    .font(.body)
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .lineSpacing(5)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+            }
+            .padding(.bottom, 8)
+
         case .paragraph(let text):
             inlineText(text)
                 .font(.body)
@@ -125,6 +140,7 @@ enum MarkdownBlock: Hashable {
     case h2(String)
     case h3(String)
     case quote(String)
+    case bullet(String)
     case paragraph(String)
 }
 
@@ -149,6 +165,13 @@ enum MarkdownBlockParser {
             }
             if trimmed.hasPrefix("> ") {
                 return .quote(String(trimmed.dropFirst(2)).trimmingCharacters(in: .whitespaces))
+            }
+            if trimmed.hasPrefix("- ") || trimmed.hasPrefix("* ") || trimmed.hasPrefix("• ") {
+                // Collapse any wrapped continuation lines within the
+                // bullet into a single spaced run, mirroring paragraph
+                // handling below.
+                let body = String(trimmed.dropFirst(2)).trimmingCharacters(in: .whitespaces)
+                return .bullet(body.replacingOccurrences(of: "\n", with: " "))
             }
             // Paragraph — collapse internal newlines into spaces so a
             // wrapped paragraph from the AI doesn't render with hard

--- a/Xomper/Core/Stores/HistoryStore.swift
+++ b/Xomper/Core/Stores/HistoryStore.swift
@@ -579,9 +579,13 @@ final class HistoryStore {
             }
 
             for pick in picks {
-                // Resolve user from roster data
+                // Resolve user from roster data. Try the pick's own
+                // drafter first, then fall back to the roster's current
+                // owner (covers picks whose `picked_by` manager has since
+                // left the dynasty).
                 let roster = rosters.first { $0.rosterId == pick.rosterId }
-                let user = users.first { $0.userId == (pick.pickedBy ?? roster?.ownerId) }
+                let user = users.first { $0.userId == pick.pickedBy }
+                    ?? users.first { $0.userId == roster?.ownerId }
 
                 let playerName = [
                     pick.metadata?.firstName ?? "",
@@ -603,7 +607,10 @@ final class HistoryStore {
                     playerTeam: pick.metadata?.team ?? "",
                     pickedByUserId: pick.pickedBy ?? roster?.ownerId ?? "",
                     pickedByRosterId: pick.rosterId ?? 0,
-                    pickedByUsername: user?.username ?? "",
+                    // Sleeper's league-users endpoint returns `username`
+                    // as null — `display_name` is the real handle, so use
+                    // the model's resolved accessor.
+                    pickedByUsername: user?.resolvedDisplayName ?? "",
                     pickedByTeamName: user?.teamName ?? "",
                     isKeeper: pick.isKeeper ?? false
                 )

--- a/Xomper/Core/Stores/LeagueStore.swift
+++ b/Xomper/Core/Stores/LeagueStore.swift
@@ -185,19 +185,41 @@ final class LeagueStore {
 
         var chain: [League] = []
         var currentId: String? = leagueId
+        var truncated = false
 
         while let id = currentId {
             do {
-                let league = try await apiClient.fetchLeague(id)
+                // A single transient Sleeper failure on one hop would
+                // otherwise `break` and drop that season *and every older
+                // season* from the dynasty history — and the truncated
+                // chain gets cached below, so the gap persists until app
+                // relaunch. Retry once before giving up on the hop.
+                let league = try await fetchLeagueWithRetry(id)
                 chain.append(league)
                 currentId = league.previousLeagueId
             } catch {
+                truncated = true
                 break
             }
         }
 
-        leagueChainCache = chain
         leagueChain = chain
+        // Only cache a fully-walked chain. Caching a truncated result
+        // would freeze a transient gap (e.g. a missing prior season) in
+        // place until relaunch; leaving the cache empty lets the next
+        // load re-attempt the full walk.
+        leagueChainCache = truncated ? nil : chain
+    }
+
+    /// Fetch a single league, retrying once after a short backoff so a
+    /// transient network blip doesn't truncate the dynasty chain.
+    private func fetchLeagueWithRetry(_ id: String) async throws -> League {
+        do {
+            return try await apiClient.fetchLeague(id)
+        } catch {
+            try? await Task.sleep(nanoseconds: 400_000_000)
+            return try await apiClient.fetchLeague(id)
+        }
     }
 
     // MARK: - Set Current League

--- a/Xomper/Features/DraftHistory/Draft/DraftGradesCard.swift
+++ b/Xomper/Features/DraftHistory/Draft/DraftGradesCard.swift
@@ -56,14 +56,20 @@ struct DraftGradesCard: View {
                     letterChip(grade.letter)
 
                     VStack(alignment: .leading, spacing: 1) {
-                        Text(grade.teamName)
+                        // Most managers never set a custom team name, so
+                        // fall back to the manager handle for the primary
+                        // line and only show the secondary line when a
+                        // distinct team name exists.
+                        Text(grade.teamName.isEmpty ? grade.managerName : grade.teamName)
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(XomperColors.textPrimary)
                             .lineLimit(1)
-                        Text(grade.managerName)
-                            .font(.caption2)
-                            .foregroundStyle(XomperColors.textMuted)
-                            .lineLimit(1)
+                        if !grade.teamName.isEmpty {
+                            Text(grade.managerName)
+                                .font(.caption2)
+                                .foregroundStyle(XomperColors.textMuted)
+                                .lineLimit(1)
+                        }
                     }
 
                     Spacer()

--- a/XomperTests/AdminStorePreviewTests.swift
+++ b/XomperTests/AdminStorePreviewTests.swift
@@ -36,10 +36,11 @@ final class AdminStorePreviewTests: XCTestCase {
 
         let typeId: String
         switch reportType {
-        case .postDraft: typeId = "postDraft#2026"
-        case .preseason: typeId = "preseason#2026-PRESEASON"
-        case .weekly:    typeId = "weekly#2026W04"
-        case .mock:      typeId = "mock#test"
+        case .postDraft:   typeId = "postDraft#2026"
+        case .preseason:   typeId = "preseason#2026-PRESEASON"
+        case .weekly:      typeId = "weekly#2026W04"
+        case .weekPreview: typeId = "weekPreview#2026W04"
+        case .mock:        typeId = "mock#test"
         }
 
         let json = """

--- a/XomperTests/LandingViewTests.swift
+++ b/XomperTests/LandingViewTests.swift
@@ -71,6 +71,8 @@ final class LandingViewTests: XCTestCase {
             nflStateStore: NflStateStore(),
             aiReviewStore: AIReviewStore(),
             announcementsStore: AnnouncementsStore(),
+            historyStore: HistoryStore(),
+            userStore: UserStore(),
             navStore: NavigationStore(),
             router: AppRouter()
         )

--- a/XomperTests/MarkdownBulletRenderingTests.swift
+++ b/XomperTests/MarkdownBulletRenderingTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import Xomper
+
+/// Tests for the list-item handling added to the recap markdown
+/// pipeline. Claude emits pick lines as single-newline "- " bullets;
+/// before the fix `MarkdownBlockParser` collapsed a run of them into one
+/// run-on paragraph ("...in Madden. - 1.02 name — ..."). These tests
+/// pin the reflow → parse contract that turns them into discrete,
+/// spaced `.bullet` blocks.
+final class MarkdownBulletRenderingTests: XCTestCase {
+
+    /// End-to-end: raw AI body with newline-led bullets reflows and
+    /// parses into one bullet block per pick line.
+    func testNewlineBullets_parseAsDiscreteBulletBlocks() {
+        let raw = """
+        Connor took the safe pick.
+        - 1.02 reesegriffin — Caleb Williams (QB, CHI). Reese drafted his real team.
+        - 1.03 mwynne16 — Josh Allen (QB, BUF). Solid.
+        """
+
+        let blocks = MarkdownBlockParser.parse(MarkdownReflow.paragraphs(raw))
+        let bullets = blocks.filter { if case .bullet = $0 { return true } else { return false } }
+
+        XCTAssertEqual(bullets.count, 2, "each '- ' line should become its own bullet")
+        if case let .bullet(text) = bullets[0] {
+            XCTAssertTrue(text.hasPrefix("1.02 reesegriffin"))
+            XCTAssertFalse(text.contains(" - "), "bullet body must not swallow the next marker")
+        } else {
+            XCTFail("expected first bullet")
+        }
+    }
+
+    /// A leading non-bullet sentence stays a paragraph; the bullets that
+    /// follow do not get merged into it.
+    func testLeadParagraphNotMergedIntoBullets() {
+        let raw = "The room knew the math.\n- 1.01 cfolk — Patrick Mahomes (QB, KC). Safe."
+        let blocks = MarkdownBlockParser.parse(MarkdownReflow.paragraphs(raw))
+
+        guard case let .paragraph(p) = blocks.first else {
+            return XCTFail("expected a lead paragraph block")
+        }
+        XCTAssertEqual(p, "The room knew the math.")
+        XCTAssertFalse(p.contains("cfolk"), "the bullet must not fold into the lead paragraph")
+    }
+
+    /// `*` and `•` markers normalize to the same bullet treatment.
+    func testAlternateBulletMarkers() {
+        let raw = "Intro.\n* first item\n• second item"
+        let blocks = MarkdownBlockParser.parse(MarkdownReflow.paragraphs(raw))
+        let bullets = blocks.filter { if case .bullet = $0 { return true } else { return false } }
+        XCTAssertEqual(bullets.count, 2)
+    }
+}

--- a/XomperTests/Support/XomperAPIClientProtocol+TestStubs.swift
+++ b/XomperTests/Support/XomperAPIClientProtocol+TestStubs.swift
@@ -1,0 +1,50 @@
+import Foundation
+@testable import Xomper
+
+/// Default implementations for the admin/email-archive corner of
+/// `XomperAPIClientProtocol` so per-suite mocks don't each have to stub
+/// methods they never exercise. Any mock that *does* care about one of
+/// these overrides it with a concrete implementation, which wins over the
+/// default below. Calling an un-overridden method throws so a test that
+/// unexpectedly hits it fails loudly instead of silently returning junk.
+///
+/// Added when several protocol methods (`sendTestEmailTemplate`,
+/// `triggerWeekPreviewAIReview`, `fetchEmailArchive*`,
+/// `resendArchivedEmail`) landed on the protocol without the older mocks
+/// being updated, which broke the whole test target's compilation.
+enum TestStubError: Error { case notStubbed(String) }
+
+extension XomperAPIClientProtocol {
+    func sendTestEmailTemplate(
+        kind: String,
+        recipientSleeperUserId: String
+    ) async throws -> TestEmailTemplateResponse {
+        throw TestStubError.notStubbed("sendTestEmailTemplate")
+    }
+
+    func triggerWeekPreviewAIReview(
+        week: Int?,
+        dryRun: Bool,
+        force: Bool,
+        seasonsBack: Int?
+    ) async throws -> AIReviewTriggerResponse {
+        throw TestStubError.notStubbed("triggerWeekPreviewAIReview")
+    }
+
+    func fetchEmailArchive(
+        limit: Int,
+        cursor: String?,
+        recipient: String?,
+        template: String?
+    ) async throws -> EmailArchiveListResponse {
+        throw TestStubError.notStubbed("fetchEmailArchive")
+    }
+
+    func fetchEmailArchiveDetail(id: String) async throws -> EmailArchiveEntry {
+        throw TestStubError.notStubbed("fetchEmailArchiveDetail")
+    }
+
+    func resendArchivedEmail(id: String, toEmail: String) async throws -> ResendEmailResponse {
+        throw TestStubError.notStubbed("resendArchivedEmail")
+    }
+}

--- a/docs/features/recap-rework/SPEC.md
+++ b/docs/features/recap-rework/SPEC.md
@@ -1,0 +1,102 @@
+# Draft Recap Structure Rework
+
+**Status:** Draft
+**Date:** 2026-07-02
+**Owner:** Dom
+**Scope:** Backend recap generation (separate API repo) — NOT the iOS client.
+
+## Problem
+
+The post-draft recap renders as a wall of text with no reliable structure.
+User feedback: *"no structure, no grades per pick, seems so random."* Two
+root causes:
+
+1. **Generation** produces free-form prose. Section breaks, per-team
+   groupings, and per-pick grades are inconsistent or absent, so the iOS
+   `MarkdownReflow` heuristics have to guess where paragraphs go.
+2. **Disconnect from real grades.** The client already computes objective
+   per-pick grades (`DraftGradeCalculator` → value-over-expected vs the
+   best-available curve, surfaced in `DraftGradesCard`). The AI prose never
+   references these numbers, so the narrative and the grades can disagree.
+
+The iOS side has been patched to render `## / ###` headers, `> ` callouts,
+and `- ` bullets cleanly (see `StyledMarkdownView` + `MarkdownReflow`). This
+spec covers making the **generated content** actually use that structure.
+
+## Target format (what the generator must emit)
+
+Markdown, in this order, using the tokens the client renders:
+
+```
+# {Season} Draft Recap
+
+## Round-by-Round
+### Round 1 — {one-line theme}
+- **{pick} {manager}** — {Player} ({POS}, {NFL}). {1-2 sentence take.} **Grade: {A+..F}**
+- ...
+
+## Steals & Reaches
+> {The single biggest steal, one sentence.}
+- **Steal — {manager}**: {Player} at {pick}. {why}
+- **Reach — {manager}**: {Player} at {pick}. {why}
+
+## Team Grades
+### {manager} — {overall letter}
+- {2-3 bullet summary of their draft: best pick, biggest risk, positional fit}
+
+## Season Awards
+- **{Award}** — {manager} ({reason})
+```
+
+Rules for the generator:
+- **One `- ` bullet per pick / per point.** Never chain picks inside one
+  paragraph with inline em-dashes.
+- **Every pick line ends with `**Grade: X**`.** Grades must come from the
+  structured input (below), not invented.
+- Blank line (`\n\n`) between every block. Do not rely on the client to
+  re-flow.
+- Keep each bullet to ~1–2 sentences ("bite-sized").
+
+## Feed the model the real grades
+
+Pass the `DraftGradeCalculator` output (or its server equivalent) into the
+prompt as structured JSON so the narrative is anchored to objective values:
+
+```json
+{
+  "picks": [
+    {"pick": "1.01", "manager": "cfolk", "player": "Patrick Mahomes",
+     "pos": "QB", "nfl": "KC", "value": 4200, "expected": 5100,
+     "delta": -900, "grade": "C+"}
+  ],
+  "teams": [
+    {"manager": "lukenovak", "team_name": "Gangsters of Love",
+     "voe": 8056, "letter": "A+"}
+  ]
+}
+```
+
+The model narrates; it does not compute grades. This kills the
+"grades disagree with the story" problem.
+
+## Naming: use display names, not `username`
+
+Sleeper's `/league/{id}/users` returns `username: null` for everyone — only
+`display_name` is populated, and `team_name` is set for a minority. The
+recap should reference `team_name` when present, else `display_name`
+(mirror the client's `SleeperUser.resolvedDisplayName`). This is the same
+bug that produced blank rows in the client grades card (fixed there in
+`HistoryStore.fetchDraftRecords`).
+
+## Out of scope
+
+- iOS rendering (already handled).
+- Re-generating historical reports already in DynamoDB — decide separately
+  whether to backfill or only apply to new reports.
+
+## Acceptance
+
+- 2026 post-draft recap renders as: title → round-by-round bullets w/ grades
+  → steals/reaches → per-team grades → awards, with visible spacing.
+- Every pick bullet shows a grade that matches the Team Grades card.
+- No blank manager names anywhere in the recap.


### PR DESCRIPTION
Ships three user-reported fixes on the Draft History surface, plus a repair of the pre-existing broken test target.

## Fixes

**1. Blank team names in the grades card** — Sleeper's `/league/{id}/users` returns `username: null` for everyone, and only 3 of 12 managers set a custom `team_name`. The record builder read `user.username` with no fallback, so 9 of 12 rows rendered blank (grade + points but no name). Now uses `resolvedDisplayName` and falls back drafter → roster owner; the card shows the manager handle as the primary line when no team name exists. Verified against live 2024 Sleeper data: 0/360 picks now blank (was 9 teams). Also fixes the "Picked by:" line on the draft board — and the 2026 live-draft grades.

**2. Recap wall-of-text** — Claude emits `- pick` lines on single newlines; the block parser collapsed them into one run-on paragraph. Added a reflow rule that promotes list items to their own blocks + a `.bullet` block type that renders spaced bullets, guarded from the long-paragraph splitter.

**3. Missing 2025 season** — 2025's league and completed draft both exist on Sleeper and chain-link correctly, so the data is clean. But `loadLeagueChain` broke on any single failed hop *and cached the truncated result*, so one transient blip could drop a season permanently. Now retries each hop once and never caches a truncated chain. (If 2025 is still missing after this, it was stale cache — pull-to-refresh self-heals.)

## Test target repair

The suite didn't compile before this branch (unrelated to the fixes): stale protocol mocks missing 5 methods, `LandingView` init drift, a non-exhaustive `AIReportType` switch. Fixed via a shared default-impl extension (`XomperTests/Support/`) so mocks don't each need stubs. **All 238 tests pass**, including the new `MarkdownBulletRenderingTests`.

## Follow-up (not in this PR)

- `docs/features/recap-rework/SPEC.md` — backend recap-structure rework (per-team sections, per-pick grades wired to `DraftGradeCalculator`). Separate API repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)