### PR TITLE
#144 Fix player values returning 0

### DIFF
--- a/Xomper/Core/Stores/PlayerValuesStore.swift
+++ b/Xomper/Core/Stores/PlayerValuesStore.swift
@@ -29,7 +29,7 @@ final class PlayerValuesStore {
     /// Closest publicly-available proxy for our league's TE-premium
     /// scoring; FantasyCalc doesn't expose a TE+ toggle in the URL but
     /// the values track close enough for relative team comparison.
-    private let endpoint = URL(string: "https://api.fantasycalc.com/values/current?isDynasty=true&numQbs=2&numTeams=12&ppr=1")!
+    private let endpoint = URL(string: "https://api.fantasycalc.com/values/current?isDynasty=true&numQbs=2&numTeams=12&ppr=1&limit=2000")!
 
     /// Fetch values from FantasyCalc unless they were loaded within
     /// the last 12 hours (values move slowly in dynasty — daily refresh

--- a/Xomper/Features/DraftHistory/Draft/DraftRecapView.swift
+++ b/Xomper/Features/DraftHistory/Draft/DraftRecapView.swift
@@ -57,6 +57,7 @@ struct DraftRecapView: View {
         }
         .background(XomperColors.bgDark.ignoresSafeArea())
         .task(id: year) {
+            await playerValuesStore.loadValues()
             await ensureArchiveLoaded()
         }
         .refreshable {


### PR DESCRIPTION
## Summary
Fixes player values showing as 0 across the app (draft grades, trade analyzer).

Two root causes:
1. **FantasyCalc endpoint was truncating results.** The `values/current` endpoint returns a limited default result set, so many players (and picks) were absent from the response and resolved to `value(for:) == 0`. Added `&limit=2000` to return the full player universe.
2. **DraftRecapView never loaded values.** The draft-grades card depends on `PlayerValuesStore`, but the view never called `loadValues()`, so `grades` was always empty. Added `await playerValuesStore.loadValues()` to the `.task(id: year)`.

## Testing
- `xcodebuild ... build` → **BUILD SUCCEEDED**

Closes #144