### PR TITLE
#145 feat: Trade Grades + News section

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		02AC6FBAE68011749AA17644 /* ClinchCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3893B13276074EF6033CEA2 /* ClinchCalculatorTests.swift */; };
 		02B230B210B4BFC6DEE151C4 /* EmailArchiveStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F01A41F93A3CE34A49D23D /* EmailArchiveStore.swift */; };
 		04C5B75AA224E7ED8314FBA5 /* AIReviewHomeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12507ED13C57EFA8B240301 /* AIReviewHomeCard.swift */; };
+		052BCC0B640F20AAC500CEBD /* MoveNewsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDD900B9F7D81E8D0B18AB1 /* MoveNewsCard.swift */; };
 		063FCD6AA342CA5D64ED79ED /* HistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F013CD37874EFB0FA1CB4261 /* HistoryStore.swift */; };
 		08251EFB3181B634553CDCE1 /* TaxiSquadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57940AEB84889A20016648F2 /* TaxiSquadView.swift */; };
 		087C52AE54EBC054E36E696B /* CronSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B9527EA5CA26FE5197FCF5 /* CronSettingsStore.swift */; };
@@ -19,6 +20,7 @@
 		095CA7262F4A1EE9C03CEBF1 /* StyledMarkdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41FCF228AB87F9E3417ECB6 /* StyledMarkdownView.swift */; };
 		0A87A5226863819FF3884F6C /* AnnouncementsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCF4387BA57375E04A8940B /* AnnouncementsCard.swift */; };
 		0C2B77E0A46ECE55AE8CE46F /* DivisionBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B670A3A0762D22FB3202E1E /* DivisionBadge.swift */; };
+		0FB2DD60345B32846B635B0D /* NewsComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63990A163C8407A2E9CB8A1F /* NewsComponents.swift */; };
 		10F252D05E75C513A5780FD8 /* EngineMockedPick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CD7928EAED8A9ADA1C683B /* EngineMockedPick.swift */; };
 		114998283E6705D075ED2CA7 /* League.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD88B55D96BD7C519B6B65B6 /* League.swift */; };
 		11EFE5DD5C1D6DE5056597BB /* PlayerPointsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36829F2AD0FD089788B9CE1 /* PlayerPointsStore.swift */; };
@@ -39,6 +41,7 @@
 		2378DF41F2BB3933117897A7 /* MatchupHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B52D5FD69B62417928B713 /* MatchupHistory.swift */; };
 		284F17C4CD26363D19756E03 /* TrayProfileCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3FE7B1A468AA2569D95B20 /* TrayProfileCard.swift */; };
 		2A6A3B695891A9925C663FB4 /* AuditEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E231D553037403D68EB216 /* AuditEntry.swift */; };
+		2AB458D3EDC94989EF6820A6 /* NewsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FFB24F383C6C33724F54CF /* NewsView.swift */; };
 		2BE0B9AB9BAEFD6AA714D2EF /* DraftRecapResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB0B979B62A1CF6EB80417F /* DraftRecapResolverTests.swift */; };
 		2ECED2F6ACF5F762D1E1462F /* MockDraftEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A951936FD34F712A8D8E66C0 /* MockDraftEngineTests.swift */; };
 		2F09FBAE23D8109C931D63A9 /* XomperTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBB5433786555EDDBC896C7 /* XomperTheme.swift */; };
@@ -101,6 +104,7 @@
 		6D833D6D3E53E0913363925C /* DraftSubTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831DFA7D391F8415451D6479 /* DraftSubTabBar.swift */; };
 		6D9C0E43C329D80ED8933AD2 /* AdminStoreWeeklyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFEC46AB65E6E7A90E0A695 /* AdminStoreWeeklyTests.swift */; };
 		6DC7870A5CEFAA4FF6FB6ADE /* LeaguesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0B516C6EF1C2084E204E8E /* LeaguesListView.swift */; };
+		6EA0DD58F974EF8324C2B113 /* NewsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 283A7AACCAE887497850AA8D /* NewsStore.swift */; };
 		724482308D102AFA35AB4017 /* LeagueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56BB91320E3D5EBE1F777838 /* LeagueStore.swift */; };
 		72FF7B4516B2DCDAE4683B9D /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83A8FEFFD8FA91F498D03A0 /* EmptyStateView.swift */; };
 		73E3AB3D048A23D710376D09 /* AIReviewStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E6A6BADE3F51FA922A078F4 /* AIReviewStore.swift */; };
@@ -110,6 +114,7 @@
 		76260F26A40213A62E5F22FB /* RecordBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AD376EFB7AD4A192FAB3E8F /* RecordBadge.swift */; };
 		76B8EBD352AAA56BD6A5F446 /* CronSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E172A0188BB654B8E010842 /* CronSetting.swift */; };
 		775985FFAD33E6481C34174A /* TrophyCaseCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2908776CDAC0CACB28B4B1 /* TrophyCaseCard.swift */; };
+		778ED20629581AAD73320327 /* NewsPreviewCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90B7C97E7E853689CA02304 /* NewsPreviewCard.swift */; };
 		7794B2E1BA5055ACFF150166 /* LogsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8C8F9BD9880370D65EDF0B /* LogsStoreTests.swift */; };
 		77A0EFCEE4340D3A7853BF08 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43685B0C212A644C0EF202E5 /* ProfileView.swift */; };
 		77CFB7F9C5E4975E6350662B /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AFC2ADE424F95E3121BF22 /* SettingsView.swift */; };
@@ -143,6 +148,7 @@
 		98F895FBCECB23325658339C /* StandingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A47FD1CF3BE7AE0B940DEC /* StandingsView.swift */; };
 		9B5472B757330119136683F1 /* PastDraftPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806CFC3CC188242F06D8639C /* PastDraftPickerView.swift */; };
 		9D9E8D2C4A8A0C623AC1EF0D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E767CD5492176E84C2092B0F /* AppDelegate.swift */; };
+		9DE6BF11B45BECAD95788B04 /* NewsFilterBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B721BC741854F856169316 /* NewsFilterBar.swift */; };
 		9E5C71DAB504EDCDF2084DF3 /* MyProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558164667DF7D89C4DF2F32E /* MyProfileView.swift */; };
 		9FA30DE0724E90F9914ED3BA /* ReportFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D61FC118C0250CA87BDF647 /* ReportFlagTests.swift */; };
 		A0F4E9BCA7E5D757DE8BE5B3 /* AIReviewStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08BD215787E2BFC1C57E7E7E /* AIReviewStoreTests.swift */; };
@@ -157,6 +163,7 @@
 		B309CAE3F00F954918C09554 /* PlayerValuesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE99E9B095120FB6636FC8A /* PlayerValuesStore.swift */; };
 		B3826B5CCBF64A347CCF75D0 /* DraftPersonality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E909175D4E989F36E6A4B9B /* DraftPersonality.swift */; };
 		B48B9F6061A67CFC74A096CC /* StandingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957EE31D25CFE325633622D4 /* StandingsStore.swift */; };
+		B645CF88B5881CBE29EE6705 /* TradeNewsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C46DBFDF0160DA0CC8751E /* TradeNewsCard.swift */; };
 		B7BD3E81860C8271FA1C068F /* TradeAnalyzerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26975318DD0DFF73C9469AC5 /* TradeAnalyzerController.swift */; };
 		B7EB06298BFBF6AC76ABF53E /* TeamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51CC9357B13AB7ADD9C8586 /* TeamView.swift */; };
 		BAD102C79A8A7F98CFB6DA68 /* AnnouncementsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C249C7D8A57EDD62886B0D /* AnnouncementsListView.swift */; };
@@ -214,6 +221,7 @@
 		F783C9073E40497F1D4BA48D /* TablesSubScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7AC7756D5F973D69491BC5 /* TablesSubScreenView.swift */; };
 		F7AC235256A88B1877A69345 /* UserEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9874F6016A90DC85B195F58 /* UserEditView.swift */; };
 		F7E0A8B9AECD0291527E0D0E /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F46A0AAE61A4E963BB15B0 /* SearchView.swift */; };
+		F967D570DA8932AA69D4E5C6 /* NewsItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21727B870012185F06C89E0D /* NewsItem.swift */; };
 		F9A37723FE37F4C30D46D6E1 /* PressableCardButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FB63BCA4BDD437FFE6D3A8 /* PressableCardButtonStyle.swift */; };
 		FAE7847413A293EF8CE9090C /* NFLTeamColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DF8F2FE857C55AFB1C1205 /* NFLTeamColors.swift */; };
 		FC8AD0A6A8B4648E71C63553 /* AnnouncementsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C814C64F50004B297F6808 /* AnnouncementsStore.swift */; };
@@ -248,12 +256,14 @@
 		1D61FC118C0250CA87BDF647 /* ReportFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportFlagTests.swift; sourceTree = "<group>"; };
 		1D6C6489A04EC9CA00FFBD0F /* StandingsOffseasonCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsOffseasonCard.swift; sourceTree = "<group>"; };
 		1FBB5433786555EDDBC896C7 /* XomperTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomperTheme.swift; sourceTree = "<group>"; };
+		21727B870012185F06C89E0D /* NewsItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsItem.swift; sourceTree = "<group>"; };
 		22A99CAA9B57C1A0144DCA22 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 		22D61F12E32D7C81FCA8F8CE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		231B20212409143CB0FA0108 /* UpcomingDraftCountdownCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingDraftCountdownCard.swift; sourceTree = "<group>"; };
 		2549566AC9312F44BA381BB6 /* WeeklyRecapMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapMetadata.swift; sourceTree = "<group>"; };
 		26975318DD0DFF73C9469AC5 /* TradeAnalyzerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeAnalyzerController.swift; sourceTree = "<group>"; };
 		273FF9D973C37FE35D0DB988 /* QuickHittersStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickHittersStrip.swift; sourceTree = "<group>"; };
+		283A7AACCAE887497850AA8D /* NewsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsStore.swift; sourceTree = "<group>"; };
 		2B670A3A0762D22FB3202E1E /* DivisionBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DivisionBadge.swift; sourceTree = "<group>"; };
 		2B6C68E1131F2BBBE625DEAF /* RuleProposalFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleProposalFormView.swift; sourceTree = "<group>"; };
 		2C12289B5D74747C89E09283 /* XomperAPIClientProtocol+TestStubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XomperAPIClientProtocol+TestStubs.swift"; sourceTree = "<group>"; };
@@ -307,6 +317,7 @@
 		5FDC8A9B02A2BFD83398D04F /* RulesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesStore.swift; sourceTree = "<group>"; };
 		62948D0A455E7CE99B15CB75 /* UserStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStore.swift; sourceTree = "<group>"; };
 		6387E34B6FA70159F3F9D80A /* TaxiSquadStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxiSquadStore.swift; sourceTree = "<group>"; };
+		63990A163C8407A2E9CB8A1F /* NewsComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsComponents.swift; sourceTree = "<group>"; };
 		63E231D553037403D68EB216 /* AuditEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditEntry.swift; sourceTree = "<group>"; };
 		6504EE31A645398C41BC2ED1 /* EnvironmentValues+Season.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+Season.swift"; sourceTree = "<group>"; };
 		65C814C64F50004B297F6808 /* AnnouncementsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsStore.swift; sourceTree = "<group>"; };
@@ -322,6 +333,7 @@
 		6F2C7D74B3584D53CE601054 /* MatchupDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchupDetailView.swift; sourceTree = "<group>"; };
 		6F2D6E80C100927C4C20FAD7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		71FB63BCA4BDD437FFE6D3A8 /* PressableCardButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PressableCardButtonStyle.swift; sourceTree = "<group>"; };
+		72B721BC741854F856169316 /* NewsFilterBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsFilterBar.swift; sourceTree = "<group>"; };
 		72CFD764A2BA7FF93B318A7F /* CareerStatsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareerStatsSection.swift; sourceTree = "<group>"; };
 		747BA75CF4BABB8C5748469D /* TeamContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamContext.swift; sourceTree = "<group>"; };
 		7589768F3AF9DB478D8E0419 /* MockDraftStoreFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftStoreFallbackTests.swift; sourceTree = "<group>"; };
@@ -329,6 +341,7 @@
 		7839DD9CF0968986F91A58DB /* AdminStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStore.swift; sourceTree = "<group>"; };
 		7877A392F88F41B8D4979F23 /* MockDraftMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftMetadataTests.swift; sourceTree = "<group>"; };
 		7C33587E13342D4234DD55FA /* MockDraftStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftStore.swift; sourceTree = "<group>"; };
+		7CDD900B9F7D81E8D0B18AB1 /* MoveNewsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveNewsCard.swift; sourceTree = "<group>"; };
 		7E909175D4E989F36E6A4B9B /* DraftPersonality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftPersonality.swift; sourceTree = "<group>"; };
 		7EECC0AA469B6BEE9D1AEFFE /* Draft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Draft.swift; sourceTree = "<group>"; };
 		806CFC3CC188242F06D8639C /* PastDraftPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastDraftPickerView.swift; sourceTree = "<group>"; };
@@ -387,6 +400,7 @@
 		BC44D14381C74E97D8AF868F /* PlayerDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerDetailView.swift; sourceTree = "<group>"; };
 		BD2908776CDAC0CACB28B4B1 /* TrophyCaseCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrophyCaseCard.swift; sourceTree = "<group>"; };
 		BE87151F7F5AAB8F12F98B91 /* PlayerValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerValue.swift; sourceTree = "<group>"; };
+		C1C46DBFDF0160DA0CC8751E /* TradeNewsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeNewsCard.swift; sourceTree = "<group>"; };
 		C1CD5644F6F8376CA86092AF /* Xomper.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Xomper.entitlements; sourceTree = "<group>"; };
 		C206B0A18917D2B43B17ADCF /* AdminTablesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminTablesStore.swift; sourceTree = "<group>"; };
 		C30266A2CB62F694EB45ACEA /* DraftGrade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftGrade.swift; sourceTree = "<group>"; };
@@ -420,6 +434,7 @@
 		E257076F7FE641947D1DC978 /* AdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminView.swift; sourceTree = "<group>"; };
 		E41FCF228AB87F9E3417ECB6 /* StyledMarkdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyledMarkdownView.swift; sourceTree = "<group>"; };
 		E6A47FD1CF3BE7AE0B940DEC /* StandingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandingsView.swift; sourceTree = "<group>"; };
+		E6FFB24F383C6C33724F54CF /* NewsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsView.swift; sourceTree = "<group>"; };
 		E70E04168BDBA7D3372BB605 /* TrayDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayDestination.swift; sourceTree = "<group>"; };
 		E767CD5492176E84C2092B0F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E7E3BE36BCEA1A7722157C37 /* PayoutProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayoutProjection.swift; sourceTree = "<group>"; };
@@ -441,6 +456,7 @@
 		F5EA1D700C954EFB08B185F2 /* MockDraftEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDraftEngine.swift; sourceTree = "<group>"; };
 		F6F606D0624D23D47A171D26 /* SearchResultGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultGroup.swift; sourceTree = "<group>"; };
 		F7048EDD875E2582C792BE47 /* LandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingView.swift; sourceTree = "<group>"; };
+		F90B7C97E7E853689CA02304 /* NewsPreviewCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsPreviewCard.swift; sourceTree = "<group>"; };
 		FA617F940D736CBA78987B46 /* AnnouncementEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementEditView.swift; sourceTree = "<group>"; };
 		FB3748F7A26B406C00F1C546 /* AIReviewSubScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReviewSubScreen.swift; sourceTree = "<group>"; };
 		FC09DFF48D9AAFEF0A286BAD /* TeamAnalysis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamAnalysis.swift; sourceTree = "<group>"; };
@@ -504,6 +520,7 @@
 				92075E680F858F8EB156001A /* HeadlineAIReportCard.swift */,
 				F7048EDD875E2582C792BE47 /* LandingView.swift */,
 				69B7E5CBAFC3B1281D1134F0 /* LeagueAnnouncement.swift */,
+				F90B7C97E7E853689CA02304 /* NewsPreviewCard.swift */,
 				DF1A7B1219575171DA3ABAB7 /* StandingsScrollBar.swift */,
 				C921F3EC29B03A85D9F2A42C /* ThisWeekMatchupsCard.swift */,
 				231B20212409143CB0FA0108 /* UpcomingDraftCountdownCard.swift */,
@@ -544,6 +561,7 @@
 				1EA5925C2F4298FD2DAD1E2E /* Landing */,
 				47014533E72495E9E9DC8F74 /* League */,
 				2D1CA584D084FE022DC6401D /* MatchupHistory */,
+				7488E5F0415B9E66A0E5D8AB /* News */,
 				374AF06666E690518BB92FAE /* Payouts */,
 				18DB797ECD581E0649842AFC /* Profile */,
 				CF0EB2B68A2AB44A16E88FB9 /* Shared */,
@@ -702,6 +720,18 @@
 			path = Config;
 			sourceTree = "<group>";
 		};
+		7488E5F0415B9E66A0E5D8AB /* News */ = {
+			isa = PBXGroup;
+			children = (
+				7CDD900B9F7D81E8D0B18AB1 /* MoveNewsCard.swift */,
+				63990A163C8407A2E9CB8A1F /* NewsComponents.swift */,
+				72B721BC741854F856169316 /* NewsFilterBar.swift */,
+				E6FFB24F383C6C33724F54CF /* NewsView.swift */,
+				C1C46DBFDF0160DA0CC8751E /* TradeNewsCard.swift */,
+			);
+			path = News;
+			sourceTree = "<group>";
+		};
 		7D491FDD816B6270D6975B2A /* Draft */ = {
 			isa = PBXGroup;
 			children = (
@@ -764,6 +794,7 @@
 				C83EF3C6C93199CF3FCBAE42 /* Matchup.swift */,
 				45B52D5FD69B62417928B713 /* MatchupHistory.swift */,
 				F26DB16948AD7EE81EF91B47 /* MockDraftModels.swift */,
+				21727B870012185F06C89E0D /* NewsItem.swift */,
 				E1E5A60EE78F668F02CF63C0 /* NflState.swift */,
 				E7E3BE36BCEA1A7722157C37 /* PayoutProjection.swift */,
 				22A99CAA9B57C1A0144DCA22 /* Player.swift */,
@@ -890,6 +921,7 @@
 				56BB91320E3D5EBE1F777838 /* LeagueStore.swift */,
 				A3AF6560D898E487AD13DA35 /* LogsStore.swift */,
 				7C33587E13342D4234DD55FA /* MockDraftStore.swift */,
+				283A7AACCAE887497850AA8D /* NewsStore.swift */,
 				94E125AD2AA5212D0EB4C13A /* NflStateStore.swift */,
 				D36829F2AD0FD089788B9CE1 /* PlayerPointsStore.swift */,
 				CC3F6B5022E8151683A45F4F /* PlayerStore.swift */,
@@ -1189,9 +1221,16 @@
 				3E78C9E4D65745EF23FACBBA /* MockDraftResult.swift in Sources */,
 				3B72E4DFCC9CB503A8EB4BD0 /* MockDraftStore.swift in Sources */,
 				8C58AAB4103D2F8A473DAA4E /* MocksView.swift in Sources */,
+				052BCC0B640F20AAC500CEBD /* MoveNewsCard.swift in Sources */,
 				9E5C71DAB504EDCDF2084DF3 /* MyProfileView.swift in Sources */,
 				FAE7847413A293EF8CE9090C /* NFLTeamColors.swift in Sources */,
 				021A039E220940CD2E12304A /* NavigationStore.swift in Sources */,
+				0FB2DD60345B32846B635B0D /* NewsComponents.swift in Sources */,
+				9DE6BF11B45BECAD95788B04 /* NewsFilterBar.swift in Sources */,
+				F967D570DA8932AA69D4E5C6 /* NewsItem.swift in Sources */,
+				778ED20629581AAD73320327 /* NewsPreviewCard.swift in Sources */,
+				6EA0DD58F974EF8324C2B113 /* NewsStore.swift in Sources */,
+				2AB458D3EDC94989EF6820A6 /* NewsView.swift in Sources */,
 				7E34464209AAF9EC6801191A /* NflState.swift in Sources */,
 				CF4CEF4E2FE7A891950A2E17 /* NflStateStore.swift in Sources */,
 				9B5472B757330119136683F1 /* PastDraftPickerView.swift in Sources */,
@@ -1255,6 +1294,7 @@
 				98D5EE595D14742780A47B81 /* ThisWeekMatchupsCard.swift in Sources */,
 				E38EEC7B1F19582B9975C236 /* TradeAnalysisView.swift in Sources */,
 				B7BD3E81860C8271FA1C068F /* TradeAnalyzerController.swift in Sources */,
+				B645CF88B5881CBE29EE6705 /* TradeNewsCard.swift in Sources */,
 				57C17293587E8DBED9A14970 /* TradedPick.swift in Sources */,
 				78094B6DF90F54E0FA59898A /* TrayDestination.swift in Sources */,
 				95DE1C46E20BF6910D4E5447 /* TrayItem.swift in Sources */,

--- a/Xomper/Core/Models/NewsItem.swift
+++ b/Xomper/Core/Models/NewsItem.swift
@@ -1,0 +1,244 @@
+import Foundation
+
+/// One item in the league News feed — a completed Sleeper transaction
+/// (trade / waiver / free-agent move) enriched with dynasty values, a
+/// deterministic local write-up, and (for trades) a letter grade per side.
+///
+/// Pure value type. Built by `NewsBuilder.build(...)` from a raw
+/// `Transaction` + the league's rosters/users + the player & value
+/// stores. No LLM — every headline/summary/grade is derived locally so
+/// the feed renders identically offline and in previews.
+struct NewsItem: Identifiable, Sendable, Hashable {
+    /// Sleeper `transaction_id`.
+    let id: String
+    let type: NewsType
+    /// Scoring week the move was logged under (1...18).
+    let week: Int
+    let createdAt: Date
+    /// Roster ids involved (2 for a trade, 1 for a move).
+    let rosterIds: [Int]
+    /// Per-roster acquired/relinquished breakdown. Two sides for a
+    /// trade, one for a waiver/free-agent move.
+    let sides: [NewsSide]
+    /// Trade grade — nil for waiver/free-agent moves.
+    let grade: TradeGrade?
+    /// Short deterministic headline, e.g. "Dynasty Warriors ↔ Gridiron Kings".
+    let headline: String
+    /// Longer deterministic write-up describing the move + verdict.
+    let summary: String
+
+    /// True when `rosterId` is one of the teams in this item — drives the
+    /// team filter.
+    func involves(rosterId: Int) -> Bool {
+        rosterIds.contains(rosterId)
+    }
+}
+
+// MARK: - NewsType
+
+enum NewsType: String, CaseIterable, Sendable, Hashable, Identifiable {
+    case trade
+    case waiver
+    case freeAgent
+
+    var id: String { rawValue }
+
+    /// Map a raw Sleeper `transaction.type`. Returns nil for types we
+    /// don't surface (e.g. "commissioner").
+    init?(sleeperType: String?) {
+        switch sleeperType {
+        case "trade":       self = .trade
+        case "waiver":      self = .waiver
+        case "free_agent":  self = .freeAgent
+        default:            return nil
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .trade:      "Trade"
+        case .waiver:     "Waiver"
+        case .freeAgent:  "Free Agent"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .trade:      "arrow.left.arrow.right"
+        case .waiver:     "cart.fill"
+        case .freeAgent:  "person.badge.plus"
+        }
+    }
+}
+
+// MARK: - NewsSide
+
+/// One roster's involvement in a news item — what it acquired and what
+/// it gave up, plus the summed dynasty value of each bucket.
+struct NewsSide: Identifiable, Sendable, Hashable {
+    let rosterId: Int
+    let teamName: String
+    let acquired: [NewsAsset]
+    let relinquished: [NewsAsset]
+    /// FAAB spent (waiver claim) or received/sent in a trade. nil when
+    /// no budget changed hands.
+    let faab: Int?
+
+    var id: Int { rosterId }
+
+    var acquiredValue: Int { acquired.reduce(0) { $0 + $1.value } }
+    var relinquishedValue: Int { relinquished.reduce(0) { $0 + $1.value } }
+    /// Net dynasty value swing for this roster (acquired − relinquished).
+    var netValue: Int { acquiredValue - relinquishedValue }
+}
+
+// MARK: - NewsAsset
+
+/// A single player or draft pick that changed hands.
+struct NewsAsset: Identifiable, Sendable, Hashable {
+    /// Sleeper player id, or a synthetic id for a pick.
+    let id: String
+    /// Display name — "Josh Allen" or "2026 1st".
+    let name: String
+    /// "QB"/"RB"/… for players, "PICK" for draft picks.
+    let position: String
+    /// Dynasty value. Picks are valued at the Mid tier per issue #145.
+    let value: Int
+    let isPick: Bool
+}
+
+// MARK: - TradeGrade
+
+/// Deterministic grade for a two-team trade. Each side earns a letter
+/// from its share of the total dynasty value received; the differential
+/// is the raw value gap between the two hauls.
+struct TradeGrade: Sendable, Hashable {
+    /// rosterId → letter grade for what that side received.
+    let lettersByRoster: [Int: LetterGrade]
+    /// Absolute dynasty-value gap between the two sides' hauls.
+    let differential: Int
+    /// |gap| / larger-side value (0...1).
+    let percentGap: Double
+    /// True when the deal is within `fairThreshold`.
+    let isFair: Bool
+    /// Winning roster id, or nil when the deal is fair.
+    let winnerRosterId: Int?
+
+    /// Deals within this share of the larger haul are graded as even.
+    /// Mirrors `TradeEvaluation.fairThreshold`.
+    static let fairThreshold: Double = 0.05
+
+    func letter(for rosterId: Int) -> LetterGrade {
+        lettersByRoster[rosterId] ?? .b
+    }
+
+    /// Grade a two-team trade from each side's acquired value.
+    static func grade(
+        sideA: (rosterId: Int, value: Int),
+        sideB: (rosterId: Int, value: Int)
+    ) -> TradeGrade {
+        let total = sideA.value + sideB.value
+        let diff = abs(sideA.value - sideB.value)
+        let larger = max(sideA.value, sideB.value)
+        let pct = larger > 0 ? Double(diff) / Double(larger) : 0
+        let fair = pct <= fairThreshold
+
+        let shareA = total > 0 ? Double(sideA.value) / Double(total) : 0.5
+        let shareB = total > 0 ? Double(sideB.value) / Double(total) : 0.5
+
+        let letters: [Int: LetterGrade] = [
+            sideA.rosterId: LetterGrade(share: shareA),
+            sideB.rosterId: LetterGrade(share: shareB),
+        ]
+
+        let winner: Int?
+        if fair {
+            winner = nil
+        } else {
+            winner = sideA.value >= sideB.value ? sideA.rosterId : sideB.rosterId
+        }
+
+        return TradeGrade(
+            lettersByRoster: letters,
+            differential: diff,
+            percentGap: pct,
+            isFair: fair,
+            winnerRosterId: winner
+        )
+    }
+}
+
+// MARK: - LetterGrade
+
+/// Letter grade for one side of a trade, derived from that side's share
+/// of the total value exchanged. 50% ≈ B (fair); a lopsided winner
+/// climbs toward A+, the loser slides toward F.
+enum LetterGrade: String, Sendable, Hashable, CaseIterable {
+    case aPlus  = "A+"
+    case a      = "A"
+    case aMinus = "A-"
+    case bPlus  = "B+"
+    case b      = "B"
+    case bMinus = "B-"
+    case cPlus  = "C+"
+    case c      = "C"
+    case d      = "D"
+    case f      = "F"
+
+    /// Map a 0...1 value share to a letter. Bands are symmetric around
+    /// 0.50 so a fair trade grades both sides at B.
+    init(share: Double) {
+        switch share {
+        case 0.620...:        self = .aPlus
+        case 0.575..<0.620:   self = .a
+        case 0.535..<0.575:   self = .aMinus
+        case 0.515..<0.535:   self = .bPlus
+        case 0.485..<0.515:   self = .b
+        case 0.465..<0.485:   self = .bMinus
+        case 0.425..<0.465:   self = .cPlus
+        case 0.380..<0.425:   self = .c
+        case 0.300..<0.380:   self = .d
+        default:              self = .f
+        }
+    }
+
+    /// Rough tier for tinting: win / fair / loss.
+    var tier: Tier {
+        switch self {
+        case .aPlus, .a, .aMinus, .bPlus:   .win
+        case .b:                            .fair
+        case .bMinus, .cPlus, .c, .d, .f:   .loss
+        }
+    }
+
+    enum Tier { case win, fair, loss }
+}
+
+// MARK: - Draft pick valuation
+
+/// Pick-name helpers so historical trades value draft picks off the same
+/// FantasyCalc catalog the trade analyzer uses. Per issue #145 all picks
+/// are valued at the **Mid** tier (FantasyCalc splits each round into
+/// Early/Mid/Late; we deliberately collapse to Mid since Sleeper trade
+/// payloads only carry season + round, not the eventual slot).
+enum PickValuation {
+    /// FantasyCalc catalog name for a season + round at the Mid tier,
+    /// e.g. `(2026, 1)` → "2026 Mid 1st".
+    static func fantasyCalcName(season: String, round: Int) -> String {
+        "\(season) Mid \(ordinal(round))"
+    }
+
+    /// Human display name for a traded pick, e.g. `(2026, 1)` → "2026 1st".
+    static func displayName(season: String, round: Int) -> String {
+        "\(season) \(ordinal(round))"
+    }
+
+    static func ordinal(_ n: Int) -> String {
+        switch n {
+        case 1:  "1st"
+        case 2:  "2nd"
+        case 3:  "3rd"
+        default: "\(n)th"
+        }
+    }
+}

--- a/Xomper/Core/Models/TradedPick.swift
+++ b/Xomper/Core/Models/TradedPick.swift
@@ -27,6 +27,16 @@ struct Transaction: Codable, Identifiable, Sendable {
     let rosterIds: [Int]?
     let adds: [String: Int]?
     let drops: [String: Int]?
+    /// Draft picks that changed hands in a trade. Same shape as
+    /// `TradedPick` (`owner_id` = new owner, `previous_owner_id` = old).
+    /// Empty/absent for waiver + free-agent moves.
+    let draftPicks: [TradedPick]?
+    /// FAAB transfers included in a trade (`sender`/`receiver` roster ids
+    /// + `amount`). Absent for non-FAAB deals.
+    let waiverBudget: [WaiverBudgetTransfer]?
+    /// Per-transaction settings — carries the FAAB `waiver_bid` on a
+    /// successful waiver claim.
+    let settings: TransactionSettings?
     let created: Int?
 
     var id: String { transactionId }
@@ -38,6 +48,28 @@ struct Transaction: Codable, Identifiable, Sendable {
         case rosterIds = "roster_ids"
         case adds
         case drops
+        case draftPicks = "draft_picks"
+        case waiverBudget = "waiver_budget"
+        case settings
         case created
+    }
+}
+
+/// A FAAB transfer inside a trade transaction (Sleeper `waiver_budget`).
+struct WaiverBudgetTransfer: Codable, Sendable {
+    let sender: Int
+    let receiver: Int
+    let amount: Int
+}
+
+/// Transaction-level settings. Only `waiver_bid` (the FAAB amount spent
+/// on a winning waiver claim) is consumed on iOS today.
+struct TransactionSettings: Codable, Sendable {
+    let waiverBid: Int?
+    let seq: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case waiverBid = "waiver_bid"
+        case seq
     }
 }

--- a/Xomper/Core/Stores/NewsStore.swift
+++ b/Xomper/Core/Stores/NewsStore.swift
@@ -1,0 +1,404 @@
+import Foundation
+
+/// Fetches league transactions across the season and turns them into a
+/// graded, filterable News feed. Reads dynasty values from the shared
+/// `PlayerValuesStore` (draft picks valued at the Mid tier per #145) and
+/// player names from `PlayerStore`.
+///
+/// No backend round-trip — Sleeper's per-week transactions endpoint is
+/// hit directly (there's no "all transactions" call), then each move is
+/// enriched with a deterministic local write-up + trade grade. Email
+/// delivery of this content is a backend follow-up, out of scope here.
+@Observable
+@MainActor
+final class NewsStore {
+
+    // MARK: - State
+
+    private(set) var items: [NewsItem] = []
+    private(set) var isLoading = false
+    private(set) var error: Error?
+    private(set) var lastLoadedLeagueId: String?
+    private(set) var lastLoadedAt: Date?
+
+    /// rosterId → team name for every team that appears in the feed.
+    /// Drives the team filter chips.
+    private(set) var teamNames: [Int: String] = [:]
+
+    // MARK: - Filters
+
+    var typeFilter: NewsType?
+    var teamFilter: Int?
+    var dateFilter: NewsDateWindow = .all
+
+    // MARK: - Dependencies
+
+    private let apiClient: SleeperAPIClientProtocol
+
+    init(apiClient: SleeperAPIClientProtocol = SleeperAPIClient()) {
+        self.apiClient = apiClient
+    }
+
+    /// Weeks scanned. A full NFL season is 18 weeks; scanning the whole
+    /// range captures in-season moves plus offseason dynasty trades,
+    /// which Sleeper logs under the current league's early weeks.
+    private let weekRange = 1...18
+
+    // MARK: - Derived
+
+    var hasItems: Bool { !items.isEmpty }
+
+    /// Items after the active type/team/date filters, newest first.
+    var filteredItems: [NewsItem] {
+        items.filter { item in
+            (typeFilter == nil || item.type == typeFilter)
+                && (teamFilter == nil || item.involves(rosterId: teamFilter!))
+                && dateFilter.contains(item.createdAt)
+        }
+    }
+
+    /// Teams that appear in the feed, sorted by name — for the team chips.
+    var availableTeams: [(rosterId: Int, name: String)] {
+        teamNames
+            .map { (rosterId: $0.key, name: $0.value) }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    var activeFilterCount: Int {
+        [typeFilter != nil, teamFilter != nil, dateFilter != .all].filter { $0 }.count
+    }
+
+    func clearFilters() {
+        typeFilter = nil
+        teamFilter = nil
+        dateFilter = .all
+    }
+
+    // MARK: - Load
+
+    /// Fetch + build the feed. Skips the network when the same league was
+    /// loaded within the last 10 minutes and already has items, unless
+    /// `forceRefresh` is set (pull-to-refresh).
+    func load(
+        leagueId: String,
+        rosters: [Roster],
+        users: [SleeperUser],
+        playerStore: PlayerStore,
+        valuesStore: PlayerValuesStore,
+        forceRefresh: Bool = false
+    ) async {
+        guard !isLoading else { return }
+        guard !leagueId.isEmpty else { return }
+
+        if !forceRefresh,
+           leagueId == lastLoadedLeagueId,
+           let last = lastLoadedAt,
+           Date().timeIntervalSince(last) < 10 * 60,
+           !items.isEmpty {
+            return
+        }
+
+        isLoading = true
+        defer { isLoading = false }
+        error = nil
+
+        // Fetch every week concurrently; tolerate per-week failures so a
+        // single bad week doesn't blank the feed. Weeks with no moves
+        // return an empty array, not an error.
+        var collected: [(week: Int, txn: Transaction)] = []
+        await withTaskGroup(of: (Int, [Transaction]).self) { group in
+            for week in weekRange {
+                group.addTask { [apiClient] in
+                    let txns = (try? await apiClient.fetchTransactions(leagueId, week: week)) ?? []
+                    return (week, txns)
+                }
+            }
+            for await (week, txns) in group {
+                for txn in txns { collected.append((week, txn)) }
+            }
+        }
+
+        var built: [NewsItem] = []
+        var seen = Set<String>()
+        for entry in collected {
+            guard !seen.contains(entry.txn.transactionId) else { continue }
+            if let item = NewsBuilder.build(
+                transaction: entry.txn,
+                week: entry.week,
+                rosters: rosters,
+                users: users,
+                playerStore: playerStore,
+                valuesStore: valuesStore
+            ) {
+                built.append(item)
+                seen.insert(entry.txn.transactionId)
+            }
+        }
+
+        built.sort { $0.createdAt > $1.createdAt }
+
+        var names: [Int: String] = [:]
+        for item in built {
+            for side in item.sides {
+                names[side.rosterId] = side.teamName
+            }
+        }
+
+        items = built
+        teamNames = names
+        lastLoadedLeagueId = leagueId
+        lastLoadedAt = Date()
+    }
+
+    func reset() {
+        items = []
+        teamNames = [:]
+        error = nil
+        lastLoadedLeagueId = nil
+        lastLoadedAt = nil
+        clearFilters()
+    }
+}
+
+// MARK: - NewsDateWindow
+
+/// Recency filter for the news feed.
+enum NewsDateWindow: String, CaseIterable, Identifiable, Sendable, Hashable {
+    case all
+    case week
+    case month
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .all:    "All"
+        case .week:   "Past Week"
+        case .month:  "Past Month"
+        }
+    }
+
+    func contains(_ date: Date) -> Bool {
+        switch self {
+        case .all:
+            return true
+        case .week:
+            return date >= Date().addingTimeInterval(-7 * 24 * 60 * 60)
+        case .month:
+            return date >= Date().addingTimeInterval(-30 * 24 * 60 * 60)
+        }
+    }
+}
+
+// MARK: - NewsBuilder
+
+/// Turns a raw Sleeper `Transaction` into a graded `NewsItem` with a
+/// deterministic, LLM-free write-up. `@MainActor` because it reads the
+/// player + value stores.
+@MainActor
+enum NewsBuilder {
+
+    static func build(
+        transaction t: Transaction,
+        week: Int,
+        rosters: [Roster],
+        users: [SleeperUser],
+        playerStore: PlayerStore,
+        valuesStore: PlayerValuesStore
+    ) -> NewsItem? {
+        // Only surface completed, recognized moves.
+        guard t.status == nil || t.status == "complete" else { return nil }
+        guard let type = NewsType(sleeperType: t.type) else { return nil }
+
+        let rosterIds = t.rosterIds ?? []
+        guard !rosterIds.isEmpty else { return nil }
+
+        let createdAt = Date(timeIntervalSince1970: Double(t.created ?? 0) / 1000.0)
+
+        let sides: [NewsSide] = rosterIds.map { rid in
+            let acquired = playerAssets(from: t.adds, roster: rid, playerStore: playerStore, valuesStore: valuesStore)
+                + pickAssets(from: t.draftPicks, roster: rid, acquired: true, valuesStore: valuesStore)
+            let relinquished = playerAssets(from: t.drops, roster: rid, playerStore: playerStore, valuesStore: valuesStore)
+                + pickAssets(from: t.draftPicks, roster: rid, acquired: false, valuesStore: valuesStore)
+            return NewsSide(
+                rosterId: rid,
+                teamName: teamName(rid, rosters: rosters, users: users),
+                acquired: acquired,
+                relinquished: relinquished,
+                faab: faab(for: rid, transaction: t, type: type)
+            )
+        }
+
+        // Drop no-op moves (nothing actually changed hands).
+        guard sides.contains(where: { !$0.acquired.isEmpty || !$0.relinquished.isEmpty }) else {
+            return nil
+        }
+
+        let grade: TradeGrade? = {
+            guard type == .trade, sides.count == 2 else { return nil }
+            return TradeGrade.grade(
+                sideA: (sides[0].rosterId, sides[0].acquiredValue),
+                sideB: (sides[1].rosterId, sides[1].acquiredValue)
+            )
+        }()
+
+        return NewsItem(
+            id: t.transactionId,
+            type: type,
+            week: week,
+            createdAt: createdAt,
+            rosterIds: rosterIds,
+            sides: sides,
+            grade: grade,
+            headline: headline(type: type, sides: sides),
+            summary: summary(type: type, sides: sides, grade: grade)
+        )
+    }
+
+    // MARK: Asset building
+
+    private static func playerAssets(
+        from map: [String: Int]?,
+        roster rid: Int,
+        playerStore: PlayerStore,
+        valuesStore: PlayerValuesStore
+    ) -> [NewsAsset] {
+        guard let map else { return [] }
+        return map.compactMap { pid, owner -> NewsAsset? in
+            guard owner == rid else { return nil }
+            let player = playerStore.player(for: pid)
+            let pos = player?.displayPosition ?? valuesStore.position(for: pid) ?? "?"
+            return NewsAsset(
+                id: pid,
+                name: player?.fullDisplayName ?? "Player #\(pid)",
+                position: pos,
+                value: valuesStore.value(for: pid),
+                isPick: false
+            )
+        }
+        .sorted { $0.value > $1.value }
+    }
+
+    private static func pickAssets(
+        from picks: [TradedPick]?,
+        roster rid: Int,
+        acquired: Bool,
+        valuesStore: PlayerValuesStore
+    ) -> [NewsAsset] {
+        guard let picks else { return [] }
+        return picks.compactMap { pick -> NewsAsset? in
+            // A pick only counts if it actually changed owners in this deal.
+            guard pick.ownerId != pick.previousOwnerId else { return nil }
+            let owns = acquired ? pick.ownerId == rid : pick.previousOwnerId == rid
+            guard owns else { return nil }
+            return NewsAsset(
+                id: "pick-\(pick.season)-\(pick.round)-\(pick.rosterId)",
+                name: PickValuation.displayName(season: pick.season, round: pick.round),
+                position: "PICK",
+                value: valuesStore.pickValue(for: PickValuation.fantasyCalcName(season: pick.season, round: pick.round)),
+                isPick: true
+            )
+        }
+        .sorted { $0.value > $1.value }
+    }
+
+    private static func faab(for rid: Int, transaction t: Transaction, type: NewsType) -> Int? {
+        switch type {
+        case .waiver:
+            return t.settings?.waiverBid
+        case .trade:
+            guard let budget = t.waiverBudget, !budget.isEmpty else { return nil }
+            let net = budget.reduce(0) { acc, transfer in
+                acc + (transfer.receiver == rid ? transfer.amount : 0)
+                    - (transfer.sender == rid ? transfer.amount : 0)
+            }
+            return net == 0 ? nil : net
+        case .freeAgent:
+            return nil
+        }
+    }
+
+    private static func teamName(_ rid: Int, rosters: [Roster], users: [SleeperUser]) -> String {
+        guard let roster = rosters.first(where: { $0.rosterId == rid }) else { return "Team \(rid)" }
+        let user = users.first { $0.userId == roster.ownerId }
+        return user?.teamName ?? user?.resolvedDisplayName ?? "Team \(rid)"
+    }
+
+    // MARK: Deterministic write-ups
+
+    private static func headline(type: NewsType, sides: [NewsSide]) -> String {
+        switch type {
+        case .trade:
+            guard sides.count == 2 else { return "Trade" }
+            return "\(sides[0].teamName) ↔ \(sides[1].teamName)"
+        case .waiver, .freeAgent:
+            return sides.first?.teamName ?? type.label
+        }
+    }
+
+    private static func summary(type: NewsType, sides: [NewsSide], grade: TradeGrade?) -> String {
+        switch type {
+        case .trade:
+            guard sides.count == 2 else { return "" }
+            var parts = sides.map { side -> String in
+                "\(side.teamName) received \(list(side.acquired))."
+            }
+            if let grade {
+                if grade.isFair {
+                    parts.append("An even swap — both hauls land within \(percent(grade.percentGap)) on dynasty value.")
+                } else if let winnerId = grade.winnerRosterId,
+                          let winner = sides.first(where: { $0.rosterId == winnerId }) {
+                    parts.append("\(winner.teamName) comes out ahead by \(percent(grade.percentGap)) in dynasty value.")
+                }
+            }
+            return parts.joined(separator: " ")
+
+        case .waiver:
+            return moveSummary(sides.first, verb: "claimed off waivers")
+
+        case .freeAgent:
+            return moveSummary(sides.first, verb: "signed")
+        }
+    }
+
+    private static func moveSummary(_ side: NewsSide?, verb: String) -> String {
+        guard let side else { return "" }
+        var sentence = ""
+
+        if !side.acquired.isEmpty {
+            sentence = "\(side.teamName) \(verb) \(list(side.acquired))"
+            if let faab = side.faab, faab > 0 {
+                sentence += " for $\(faab) FAAB"
+            }
+            sentence += "."
+        }
+
+        if !side.relinquished.isEmpty {
+            let dropped = list(side.relinquished)
+            if sentence.isEmpty {
+                sentence = "\(side.teamName) dropped \(dropped)."
+            } else {
+                sentence += " In the corresponding move, \(side.teamName) dropped \(dropped)."
+            }
+        }
+
+        return sentence.isEmpty ? "\(side.teamName) made a roster move." : sentence
+    }
+
+    /// Oxford-comma join of asset display names.
+    private static func list(_ assets: [NewsAsset]) -> String {
+        let names = assets.map(\.name)
+        switch names.count {
+        case 0:  return "nothing"
+        case 1:  return names[0]
+        case 2:  return "\(names[0]) and \(names[1])"
+        default:
+            let head = names.dropLast().joined(separator: ", ")
+            return "\(head), and \(names.last ?? "")"
+        }
+    }
+
+    private static func percent(_ p: Double) -> String {
+        String(format: "%.0f%%", p * 100)
+    }
+}

--- a/Xomper/Features/Landing/LandingView.swift
+++ b/Xomper/Features/Landing/LandingView.swift
@@ -41,6 +41,9 @@ struct LandingView: View {
     var announcementsStore: AnnouncementsStore
     var historyStore: HistoryStore
     var userStore: UserStore
+    var newsStore: NewsStore
+    var playerStore: PlayerStore
+    var valuesStore: PlayerValuesStore
     var navStore: NavigationStore
     var router: AppRouter
 
@@ -65,6 +68,15 @@ struct LandingView: View {
                 )
 
                 AnnouncementsCard(store: announcementsStore)
+
+                NewsPreviewCard(
+                    newsStore: newsStore,
+                    leagueStore: leagueStore,
+                    playerStore: playerStore,
+                    valuesStore: valuesStore,
+                    navStore: navStore,
+                    router: router
+                )
 
                 StandingsScrollBar(
                     leagueStore: leagueStore,
@@ -110,7 +122,23 @@ struct LandingView: View {
         async let league:   () = leagueStore.loadMyLeague()
         async let ann:      () = announcementsStore.load(force: true)
         async let matchups: () = matchupsController.bumpAndWait()
-        _ = await (ai, nfl, league, ann, matchups)
+        async let news:     () = refreshNews()
+        _ = await (ai, nfl, league, ann, matchups, news)
+    }
+
+    /// Force-refresh the news feed on pull-to-refresh. Gated on rosters
+    /// so team-name resolution has its source data.
+    private func refreshNews() async {
+        guard !leagueStore.myLeagueRosters.isEmpty else { return }
+        await valuesStore.loadValues()
+        await newsStore.load(
+            leagueId: leagueStore.resolvedHomeLeagueId,
+            rosters: leagueStore.myLeagueRosters,
+            users: leagueStore.myLeagueUsers,
+            playerStore: playerStore,
+            valuesStore: valuesStore,
+            forceRefresh: true
+        )
     }
 }
 
@@ -124,6 +152,9 @@ struct LandingView: View {
             announcementsStore: AnnouncementsStore(),
             historyStore: HistoryStore(),
             userStore: UserStore(),
+            newsStore: NewsStore(),
+            playerStore: PlayerStore(),
+            valuesStore: PlayerValuesStore(),
             navStore: NavigationStore(),
             router: AppRouter()
         )

--- a/Xomper/Features/Landing/NewsPreviewCard.swift
+++ b/Xomper/Features/Landing/NewsPreviewCard.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+/// Landing-page preview of the League News feed. Shows the three most
+/// recent moves; tapping anywhere opens the full News destination.
+///
+/// Owns its own one-shot load (mirrors `ThisWeekMatchupsCard`) so it
+/// stays self-contained on the landing surface.
+struct NewsPreviewCard: View {
+    var newsStore: NewsStore
+    var leagueStore: LeagueStore
+    var playerStore: PlayerStore
+    var valuesStore: PlayerValuesStore
+    var navStore: NavigationStore
+    var router: AppRouter
+
+    private var previewItems: [NewsItem] {
+        Array(newsStore.items.prefix(3))
+    }
+
+    var body: some View {
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            navStore.select(.news, router: router)
+        } label: {
+            VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+                header
+
+                if previewItems.isEmpty {
+                    Text(newsStore.isLoading ? "Loading recent moves..." : "No recent moves yet.")
+                        .font(.subheadline)
+                        .foregroundStyle(XomperColors.textSecondary)
+                        .padding(.vertical, XomperTheme.Spacing.xs)
+                } else {
+                    ForEach(previewItems) { item in
+                        previewRow(item)
+                        if item.id != previewItems.last?.id {
+                            Divider().overlay(Color.white.opacity(0.06))
+                        }
+                    }
+                }
+            }
+            .padding(XomperTheme.Spacing.md)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(XomperColors.bgCard)
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+            .overlay(
+                RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                    .strokeBorder(XomperColors.steelBlue.opacity(0.3), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.pressableCard)
+        .task { await load() }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("League news")
+        .accessibilityHint("Double tap to see all trades and moves")
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            Image(systemName: "newspaper.fill")
+                .font(.subheadline)
+                .foregroundStyle(XomperColors.steelBlue)
+            Text("LEAGUE NEWS")
+                .font(.caption.weight(.bold))
+                .tracking(0.5)
+                .foregroundStyle(XomperColors.textSecondary)
+            Spacer()
+            Text("See all")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(XomperColors.steelBlue)
+            Image(systemName: "chevron.right")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(XomperColors.steelBlue)
+        }
+    }
+
+    // MARK: - Row
+
+    private func previewRow(_ item: NewsItem) -> some View {
+        HStack(spacing: XomperTheme.Spacing.sm) {
+            Image(systemName: item.type.systemImage)
+                .font(.caption)
+                .foregroundStyle(item.type.accentColor)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(item.headline)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .lineLimit(1)
+                Text(item.summary)
+                    .font(.caption)
+                    .foregroundStyle(XomperColors.textMuted)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 4)
+
+            if let grade = item.grade, let winnerId = grade.winnerRosterId {
+                let letter = grade.letter(for: winnerId)
+                Text(letter.rawValue)
+                    .font(.caption.weight(.heavy))
+                    .foregroundStyle(letter.color)
+            }
+        }
+    }
+
+    // MARK: - Load
+
+    private func load() async {
+        guard !leagueStore.myLeagueRosters.isEmpty else { return }
+        await valuesStore.loadValues()
+        await newsStore.load(
+            leagueId: leagueStore.resolvedHomeLeagueId,
+            rosters: leagueStore.myLeagueRosters,
+            users: leagueStore.myLeagueUsers,
+            playerStore: playerStore,
+            valuesStore: valuesStore
+        )
+    }
+}

--- a/Xomper/Features/News/MoveNewsCard.swift
+++ b/Xomper/Features/News/MoveNewsCard.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// Feed card for a waiver claim or free-agent move (a single team adding
+/// and/or dropping players). No grade — moves aren't zero-sum trades —
+/// but FAAB spend is surfaced when present.
+struct MoveNewsCard: View {
+    let item: NewsItem
+
+    private var side: NewsSide? { item.sides.first }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            NewsCardHeader(item: item)
+
+            Text(item.headline)
+                .font(.headline)
+                .foregroundStyle(XomperColors.textPrimary)
+                .lineLimit(1)
+
+            if let side {
+                if !side.acquired.isEmpty {
+                    moveGroup(
+                        label: item.type == .waiver ? "Claimed" : "Added",
+                        assets: side.acquired,
+                        tint: XomperColors.successGreen,
+                        faab: side.faab
+                    )
+                }
+                if !side.relinquished.isEmpty {
+                    moveGroup(
+                        label: "Dropped",
+                        assets: side.relinquished,
+                        tint: XomperColors.accentRed,
+                        faab: nil
+                    )
+                }
+            }
+
+            if !item.summary.isEmpty {
+                Text(item.summary)
+                    .font(.subheadline)
+                    .foregroundStyle(XomperColors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(item.type.accentColor.opacity(0.25), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(item.summary.isEmpty ? item.headline : item.summary)
+    }
+
+    private func moveGroup(label: String, assets: [NewsAsset], tint: Color, faab: Int?) -> some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xxs) {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                Text(label.uppercased())
+                    .font(.caption2.weight(.bold))
+                    .tracking(0.5)
+                    .foregroundStyle(tint)
+                if let faab, faab > 0 {
+                    Text("$\(faab) FAAB")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(XomperColors.textMuted)
+                }
+            }
+            ForEach(assets) { AssetRow(asset: $0) }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(XomperTheme.Spacing.sm)
+        .background(XomperColors.surfaceLight.opacity(0.3))
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+    }
+}

--- a/Xomper/Features/News/NewsComponents.swift
+++ b/Xomper/Features/News/NewsComponents.swift
@@ -1,0 +1,155 @@
+import SwiftUI
+
+// MARK: - Style extensions
+
+extension NewsType {
+    /// Accent used for the type chip + card border tint.
+    var accentColor: Color {
+        switch self {
+        case .trade:      XomperColors.championGold
+        case .waiver:     XomperColors.steelBlue
+        case .freeAgent:  XomperColors.successGreen
+        }
+    }
+}
+
+extension LetterGrade {
+    /// Grade color by tier — winner green, fair gold, loser red.
+    var color: Color {
+        switch tier {
+        case .win:   XomperColors.successGreen
+        case .fair:  XomperColors.championGold
+        case .loss:  XomperColors.accentRed
+        }
+    }
+}
+
+// MARK: - Type chip
+
+/// All-caps category chip, matching the AI Review row chip recipe.
+struct NewsTypeChip: View {
+    let type: NewsType
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: type.systemImage)
+                .font(.caption2.weight(.bold))
+            Text(type.label.uppercased())
+                .font(.caption2.weight(.bold))
+                .tracking(0.5)
+        }
+        .foregroundStyle(XomperColors.bgDark)
+        .padding(.horizontal, XomperTheme.Spacing.sm)
+        .padding(.vertical, 4)
+        .background(type.accentColor)
+        .clipShape(Capsule())
+    }
+}
+
+// MARK: - Card header
+
+/// Shared card header: type chip + week + relative date.
+struct NewsCardHeader: View {
+    let item: NewsItem
+
+    var body: some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            NewsTypeChip(type: item.type)
+            Text("Wk \(item.week)")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(XomperColors.textSecondary)
+            Spacer()
+            Text(relativeNewsDate(item.createdAt))
+                .font(.caption2)
+                .foregroundStyle(XomperColors.textMuted)
+                .monospacedDigit()
+        }
+    }
+}
+
+// MARK: - Grade badge
+
+/// Square letter-grade badge tinted by the grade's tier.
+struct GradeBadge: View {
+    let grade: LetterGrade
+
+    var body: some View {
+        Text(grade.rawValue)
+            .font(.headline.weight(.heavy))
+            .foregroundStyle(grade.color)
+            .frame(width: 44, height: 44)
+            .background(grade.color.opacity(0.15))
+            .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md)
+                    .strokeBorder(grade.color.opacity(0.5), lineWidth: 1)
+            )
+            .accessibilityLabel("Grade \(grade.rawValue)")
+    }
+}
+
+// MARK: - Asset row
+
+/// One player/pick line: position tag + name + dynasty value.
+struct AssetRow: View {
+    let asset: NewsAsset
+
+    var body: some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            Text(asset.position)
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(asset.isPick ? XomperColors.steelBlue : XomperColors.textMuted)
+                .frame(width: 34, alignment: .leading)
+            Text(asset.name)
+                .font(.subheadline)
+                .foregroundStyle(XomperColors.textPrimary)
+                .lineLimit(1)
+            Spacer(minLength: 4)
+            if asset.value > 0 {
+                Text("\(asset.value)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(XomperColors.textSecondary)
+                    .monospacedDigit()
+            }
+        }
+    }
+}
+
+// MARK: - Filter chip
+
+/// Capsule filter chip — selected fills championGold, matching
+/// `SeasonPickerBar`. Used for type/team/date filters.
+struct NewsFilterChip: View {
+    let title: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            withAnimation(XomperTheme.defaultAnimation) { action() }
+        } label: {
+            Text(title)
+                .font(.subheadline)
+                .fontWeight(isSelected ? .semibold : .regular)
+                .foregroundStyle(isSelected ? XomperColors.deepNavy : XomperColors.textSecondary)
+                .padding(.horizontal, XomperTheme.Spacing.md)
+                .padding(.vertical, XomperTheme.Spacing.xs)
+                .frame(minHeight: 32)
+                .background(isSelected ? XomperColors.championGold : XomperColors.surfaceLight)
+                .clipShape(Capsule())
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityLabel(title)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+// MARK: - Helpers
+
+/// Abbreviated relative date ("2d", "3w") for card headers.
+func relativeNewsDate(_ date: Date) -> String {
+    let formatter = RelativeDateTimeFormatter()
+    formatter.unitsStyle = .abbreviated
+    return formatter.localizedString(for: date, relativeTo: Date())
+}

--- a/Xomper/Features/News/NewsFilterBar.swift
+++ b/Xomper/Features/News/NewsFilterBar.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+/// Filter bar for the News feed — type, team, and date-window chips.
+/// Mutates the shared `NewsStore` filter state directly (it's a class,
+/// so writes to its `var` filters are observed by the feed).
+struct NewsFilterBar: View {
+    let store: NewsStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            // Type
+            chipRow {
+                NewsFilterChip(title: "All", isSelected: store.typeFilter == nil) {
+                    store.typeFilter = nil
+                }
+                ForEach(NewsType.allCases) { type in
+                    NewsFilterChip(title: type.label, isSelected: store.typeFilter == type) {
+                        store.typeFilter = store.typeFilter == type ? nil : type
+                    }
+                }
+            }
+
+            // Team — only when the feed has teams to filter by.
+            if !store.availableTeams.isEmpty {
+                chipRow {
+                    NewsFilterChip(title: "All Teams", isSelected: store.teamFilter == nil) {
+                        store.teamFilter = nil
+                    }
+                    ForEach(store.availableTeams, id: \.rosterId) { team in
+                        NewsFilterChip(title: team.name, isSelected: store.teamFilter == team.rosterId) {
+                            store.teamFilter = store.teamFilter == team.rosterId ? nil : team.rosterId
+                        }
+                    }
+                }
+            }
+
+            // Date window
+            chipRow {
+                ForEach(NewsDateWindow.allCases) { window in
+                    NewsFilterChip(title: window.label, isSelected: store.dateFilter == window) {
+                        store.dateFilter = window
+                    }
+                }
+            }
+        }
+        .padding(.vertical, XomperTheme.Spacing.sm)
+    }
+
+    private func chipRow<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: XomperTheme.Spacing.sm) {
+                content()
+            }
+            .padding(.horizontal, XomperTheme.Spacing.md)
+        }
+    }
+}

--- a/Xomper/Features/News/NewsView.swift
+++ b/Xomper/Features/News/NewsView.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+/// Top-level News feed — league trades + roster moves, graded and
+/// written up locally (no LLM), with a pinned filter bar.
+///
+/// Reads rosters/users from `LeagueStore`, dynasty values from the
+/// shared `PlayerValuesStore`, and player names from `PlayerStore`.
+struct NewsView: View {
+    var leagueStore: LeagueStore
+    var playerStore: PlayerStore
+    var valuesStore: PlayerValuesStore
+    var newsStore: NewsStore
+
+    var body: some View {
+        Group {
+            if newsStore.isLoading && !newsStore.hasItems {
+                LoadingView(message: "Loading league news...")
+            } else if let error = newsStore.error, !newsStore.hasItems {
+                ErrorView(message: error.localizedDescription) {
+                    Task { await reload(force: true) }
+                }
+            } else if !newsStore.hasItems {
+                EmptyStateView(
+                    icon: "newspaper",
+                    title: "No News Yet",
+                    message: "Trades and roster moves across the league will show up here."
+                )
+            } else {
+                feed
+            }
+        }
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .task { await reload(force: false) }
+        .refreshable { await reload(force: true) }
+        .onChange(of: leagueStore.myLeagueRosters.count) { _, _ in
+            Task { await reload(force: false) }
+        }
+    }
+
+    // MARK: - Feed
+
+    private var feed: some View {
+        ScrollView {
+            LazyVStack(spacing: XomperTheme.Spacing.sm, pinnedViews: [.sectionHeaders]) {
+                Section {
+                    let items = newsStore.filteredItems
+                    if items.isEmpty {
+                        EmptyStateView(
+                            icon: "line.3.horizontal.decrease.circle",
+                            title: "No Matches",
+                            message: "No news matches your current filters."
+                        )
+                        .padding(.top, XomperTheme.Spacing.xl)
+                    } else {
+                        ForEach(items) { item in
+                            card(for: item)
+                                .padding(.horizontal, XomperTheme.Spacing.md)
+                        }
+                    }
+                } header: {
+                    NewsFilterBar(store: newsStore)
+                        .background(XomperColors.bgDark)
+                }
+            }
+            .padding(.bottom, XomperTheme.Spacing.md)
+        }
+    }
+
+    @ViewBuilder
+    private func card(for item: NewsItem) -> some View {
+        switch item.type {
+        case .trade:
+            TradeNewsCard(item: item)
+        case .waiver, .freeAgent:
+            MoveNewsCard(item: item)
+        }
+    }
+
+    // MARK: - Load
+
+    private func reload(force: Bool) async {
+        // Team-name resolution needs rosters + users; wait for them so
+        // the feed doesn't cache placeholder "Team N" labels.
+        guard !leagueStore.myLeagueRosters.isEmpty else { return }
+        await valuesStore.loadValues()
+        await newsStore.load(
+            leagueId: leagueStore.resolvedHomeLeagueId,
+            rosters: leagueStore.myLeagueRosters,
+            users: leagueStore.myLeagueUsers,
+            playerStore: playerStore,
+            valuesStore: valuesStore,
+            forceRefresh: force
+        )
+    }
+}

--- a/Xomper/Features/News/TradeNewsCard.swift
+++ b/Xomper/Features/News/TradeNewsCard.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+/// Feed card for a completed trade. Shows a per-side letter grade, each
+/// team's haul, the raw dynasty-value differential, and a deterministic
+/// write-up. Grades + differential come pre-computed on the `NewsItem`.
+struct TradeNewsCard: View {
+    let item: NewsItem
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.sm) {
+            NewsCardHeader(item: item)
+
+            Text(item.headline)
+                .font(.title3.weight(.bold))
+                .foregroundStyle(XomperColors.championGold)
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
+
+            ForEach(item.sides) { side in
+                sideBlock(side)
+            }
+
+            differentialRow
+
+            if !item.summary.isEmpty {
+                Text(item.summary)
+                    .font(.subheadline)
+                    .foregroundStyle(XomperColors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(item.summary.isEmpty ? item.headline : item.summary)
+    }
+
+    // MARK: - Side block
+
+    private func sideBlock(_ side: NewsSide) -> some View {
+        HStack(alignment: .top, spacing: XomperTheme.Spacing.sm) {
+            if let grade = item.grade {
+                GradeBadge(grade: grade.letter(for: side.rosterId))
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(side.teamName)
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.textPrimary)
+                    .lineLimit(1)
+
+                if side.acquired.isEmpty {
+                    Text("Received nothing")
+                        .font(.caption)
+                        .foregroundStyle(XomperColors.textMuted)
+                } else {
+                    ForEach(side.acquired) { AssetRow(asset: $0) }
+                }
+
+                if let faab = side.faab, faab != 0 {
+                    Text("\(faab > 0 ? "+" : "")\(faab) FAAB")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(XomperColors.textMuted)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(XomperTheme.Spacing.sm)
+        .background(XomperColors.surfaceLight.opacity(0.3))
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+    }
+
+    // MARK: - Differential
+
+    @ViewBuilder
+    private var differentialRow: some View {
+        if let grade = item.grade {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                Image(systemName: "chart.bar.fill")
+                    .font(.caption2)
+                Text(differentialText(grade))
+                    .font(.caption.weight(.semibold))
+            }
+            .foregroundStyle(grade.isFair ? XomperColors.textSecondary : XomperColors.championGold)
+        }
+    }
+
+    private func differentialText(_ grade: TradeGrade) -> String {
+        if grade.isFair {
+            return "Even value — within \(Int(grade.percentGap * 100))%"
+        }
+        let winner = item.sides.first { $0.rosterId == grade.winnerRosterId }?.teamName ?? "Winner"
+        return "Differential \(grade.differential) · \(winner) +\(Int(grade.percentGap * 100))%"
+    }
+}

--- a/Xomper/Features/Shell/DrawerView.swift
+++ b/Xomper/Features/Shell/DrawerView.swift
@@ -26,7 +26,7 @@ struct DrawerView: View {
     /// runtime when `isAdmin == true`.
     /// Drawer sections plus pinned Settings + optional Admin.
     ///
-    /// - Play:    landing, standings, matchups, playoffs, draftHistory, worldCup
+    /// - Play:    landing, standings, matchups, playoffs, news, draftHistory, worldCup
     /// - Team:    myTeam, taxiSquad, teamAnalyzer
     /// - League:  rulebook, scoring, leagueSettings, payouts, ruleProposals, draftOrder
     /// - Admin:   aiReview (full archive), admin (only when isAdmin)
@@ -41,7 +41,7 @@ struct DrawerView: View {
         var out: [TraySection] = [
             TraySection(
                 title: "Play",
-                entries: [.landing, .standings, .matchups, .playoffs, .draftHistory, .worldCup]
+                entries: [.landing, .standings, .matchups, .playoffs, .news, .draftHistory, .worldCup]
             ),
             TraySection(
                 title: "Team",

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -60,6 +60,10 @@ struct MainShell: View {
     /// the Analyzer screen. Lives at the shell so the preload survives
     /// tray destination switches.
     @State private var tradeController = TradeAnalyzerController()
+    /// #145: League News feed (trades + roster moves, graded locally).
+    /// Shared so the Landing preview card and the full News destination
+    /// read the same fetched-and-graded feed without refetching.
+    @State private var newsStore = NewsStore()
 
     // MARK: - Body
 
@@ -163,6 +167,9 @@ struct MainShell: View {
                     announcementsStore: announcementsStore,
                     historyStore: historyStore,
                     userStore: userStore,
+                    newsStore: newsStore,
+                    playerStore: playerStore,
+                    valuesStore: valuesStore,
                     navStore: navStore,
                     router: router
                 )
@@ -190,6 +197,14 @@ struct MainShell: View {
                     leagueStore: leagueStore,
                     historyStore: historyStore,
                     playerStore: playerStore
+                )
+
+            case .news:
+                NewsView(
+                    leagueStore: leagueStore,
+                    playerStore: playerStore,
+                    valuesStore: valuesStore,
+                    newsStore: newsStore
                 )
 
             case .draftHistory:

--- a/Xomper/Features/Shell/TrayDestination.swift
+++ b/Xomper/Features/Shell/TrayDestination.swift
@@ -14,6 +14,7 @@ enum TrayDestination: Hashable {
     case standings
     case matchups
     case playoffs
+    case news
     // Legacy name — the user-facing label is "Draft" and the
     // renderer is the post-F3 sub-tabbed `DraftHistoryView` (Live /
     // Mocks / Recap on the current season; Picks / Recap on past
@@ -46,6 +47,7 @@ enum TrayDestination: Hashable {
         case .standings:      "Standings"
         case .matchups:       "Matchups"
         case .playoffs:       "Playoffs"
+        case .news:           "News"
         case .draftHistory:   "Draft"
         case .matchupHistory: "Matchup History"
         case .worldCup:       "World Cup"
@@ -74,6 +76,7 @@ enum TrayDestination: Hashable {
         case .standings:      "list.number"
         case .matchups:       "sportscourt.fill"
         case .playoffs:       "trophy.fill"
+        case .news:           "newspaper.fill"
         case .draftHistory:   "list.clipboard.fill"
         case .matchupHistory: "clock.arrow.circlepath"
         case .worldCup:       "globe.americas.fill"


### PR DESCRIPTION
Closes #145

## What
A **League News** feed that turns Sleeper transactions into a graded, filterable timeline with deterministic, local write-ups (no LLM). Reachable from the drawer (Play → News) and previewed on the landing page.

## Stacked PR
Based on `feature/143-trade-analysis-page` (PR #147), which itself carries #144's player-values fix — a real dependency, since without it graded values return 0. **Retarget to `main` once #147/#146 merge.** The diff here is News-only.

## Highlights
- **NewsStore** (`@Observable @MainActor`) — fans out `/league/{id}/transactions/{week}` across weeks 1…18 concurrently (tolerates per-week failures), builds graded `NewsItem`s, filters by **type / team / date**, 10-min freshness cache + force-refresh.
- **Models** — `NewsItem` / `NewsSide` / `NewsAsset` plus a deterministic `TradeGrade`: each side earns a letter (A+…F) from its share of the exchanged dynasty value; `differential` is the raw value gap. Headlines/summaries are generated locally.
- **Draft picks valued at the Mid tier** (per approved decision) — Sleeper trade payloads carry only season+round, so picks resolve to the FantasyCalc `"{year} Mid {round}"` catalog value.
- **Transaction model extended** to decode `draft_picks`, `waiver_budget`, and `settings.waiver_bid` (FAAB).
- **Views** — `NewsView` with a pinned filter bar; `TradeNewsCard` (per-side grade + differential + write-up); `MoveNewsCard` (waiver/free-agent adds & drops with FAAB); `NewsPreviewCard` on the landing page. All follow the Midnight Emerald card conventions.
- **Nav wiring** — `.news` added to `TrayDestination`, drawer Play section, and `MainShell`; one shared `NewsStore` backs both the preview and the full feed.

## Decisions honored
- Email delivery = backend follow-up (**descoped**).
- Local deterministic write-ups, **no LLM**.
- Draft picks valued at **Mid tier**.

## Verification
- `xcodegen generate` ✅
- `xcodebuild -scheme Xomper -sdk iphonesimulator` → **BUILD SUCCEEDED** ✅