### PR TITLE
#150 News feed UI: dropdown filters, no scroll gap, richer trade write-ups

### DIFF
--- a/Xomper/Core/Stores/NewsStore.swift
+++ b/Xomper/Core/Stores/NewsStore.swift
@@ -339,19 +339,7 @@ enum NewsBuilder {
     private static func summary(type: NewsType, sides: [NewsSide], grade: TradeGrade?) -> String {
         switch type {
         case .trade:
-            guard sides.count == 2 else { return "" }
-            var parts = sides.map { side -> String in
-                "\(side.teamName) received \(list(side.acquired))."
-            }
-            if let grade {
-                if grade.isFair {
-                    parts.append("An even swap — both hauls land within \(percent(grade.percentGap)) on dynasty value.")
-                } else if let winnerId = grade.winnerRosterId,
-                          let winner = sides.first(where: { $0.rosterId == winnerId }) {
-                    parts.append("\(winner.teamName) comes out ahead by \(percent(grade.percentGap)) in dynasty value.")
-                }
-            }
-            return parts.joined(separator: " ")
+            return tradeSummary(sides: sides, grade: grade)
 
         case .waiver:
             return moveSummary(sides.first, verb: "claimed off waivers")
@@ -359,6 +347,33 @@ enum NewsBuilder {
         case .freeAgent:
             return moveSummary(sides.first, verb: "signed")
         }
+    }
+
+    /// Multi-sentence trade write-up: each side's haul with its dynasty
+    /// value, then a verdict that names the winner, the letter grade, and
+    /// the point gap. Deterministic — no LLM.
+    private static func tradeSummary(sides: [NewsSide], grade: TradeGrade?) -> String {
+        guard sides.count == 2 else { return "" }
+
+        var parts = sides.map { side -> String in
+            var line = "\(side.teamName) landed \(list(side.acquired))"
+            if side.acquiredValue > 0 {
+                line += " (\(side.acquiredValue) in dynasty value)"
+            }
+            return line + "."
+        }
+
+        if let grade {
+            if grade.isFair {
+                parts.append("The board grades it a wash — both hauls land within \(percent(grade.percentGap)) on dynasty value, so each side walks away with a fair-market return.")
+            } else if let winnerId = grade.winnerRosterId,
+                      let winner = sides.first(where: { $0.rosterId == winnerId }),
+                      let loser = sides.first(where: { $0.rosterId != winnerId }) {
+                let letter = grade.letter(for: winnerId).rawValue
+                parts.append("\(winner.teamName) wins this one (\(letter)), clearing \(loser.teamName) by \(grade.differential) points of dynasty value — a \(percent(grade.percentGap)) edge.")
+            }
+        }
+        return parts.joined(separator: " ")
     }
 
     private static func moveSummary(_ side: NewsSide?, verb: String) -> String {
@@ -379,6 +394,19 @@ enum NewsBuilder {
                 sentence = "\(side.teamName) dropped \(dropped)."
             } else {
                 sentence += " In the corresponding move, \(side.teamName) dropped \(dropped)."
+            }
+        }
+
+        // Value-added context so a pickup isn't just a bare name — how
+        // much dynasty value the move nets the roster.
+        if side.acquiredValue > 0 || side.relinquishedValue > 0 {
+            let net = side.netValue
+            if net > 0 {
+                sentence += " Adds \(net) in dynasty value to the roster."
+            } else if net < 0 {
+                sentence += " Sheds \(abs(net)) in dynasty value."
+            } else {
+                sentence += " A value-neutral roster shuffle."
             }
         }
 

--- a/Xomper/Features/News/NewsComponents.swift
+++ b/Xomper/Features/News/NewsComponents.swift
@@ -115,36 +115,6 @@ struct AssetRow: View {
     }
 }
 
-// MARK: - Filter chip
-
-/// Capsule filter chip — selected fills championGold, matching
-/// `SeasonPickerBar`. Used for type/team/date filters.
-struct NewsFilterChip: View {
-    let title: String
-    let isSelected: Bool
-    let action: () -> Void
-
-    var body: some View {
-        Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            withAnimation(XomperTheme.defaultAnimation) { action() }
-        } label: {
-            Text(title)
-                .font(.subheadline)
-                .fontWeight(isSelected ? .semibold : .regular)
-                .foregroundStyle(isSelected ? XomperColors.deepNavy : XomperColors.textSecondary)
-                .padding(.horizontal, XomperTheme.Spacing.md)
-                .padding(.vertical, XomperTheme.Spacing.xs)
-                .frame(minHeight: 32)
-                .background(isSelected ? XomperColors.championGold : XomperColors.surfaceLight)
-                .clipShape(Capsule())
-        }
-        .buttonStyle(.pressableCard)
-        .accessibilityLabel(title)
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
-    }
-}
-
 // MARK: - Helpers
 
 /// Abbreviated relative date ("2d", "3w") for card headers.

--- a/Xomper/Features/News/NewsFilterBar.swift
+++ b/Xomper/Features/News/NewsFilterBar.swift
@@ -1,57 +1,132 @@
 import SwiftUI
 
-/// Filter bar for the News feed — type, team, and date-window chips.
+/// Filter bar for the News feed — type, team, and date-window dropdowns.
 /// Mutates the shared `NewsStore` filter state directly (it's a class,
 /// so writes to its `var` filters are observed by the feed).
+///
+/// Rendered as `Menu` dropdowns (matching `TeamAnalyzerView`'s opponent
+/// picker) rather than a wall of pill toggles. Lives in a fixed strip
+/// above the feed's `ScrollView`, so it stays pinned with no scroll gap.
 struct NewsFilterBar: View {
     let store: NewsStore
 
     var body: some View {
-        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
-            // Type
-            chipRow {
-                NewsFilterChip(title: "All", isSelected: store.typeFilter == nil) {
-                    store.typeFilter = nil
-                }
-                ForEach(NewsType.allCases) { type in
-                    NewsFilterChip(title: type.label, isSelected: store.typeFilter == type) {
-                        store.typeFilter = store.typeFilter == type ? nil : type
-                    }
-                }
-            }
-
-            // Team — only when the feed has teams to filter by.
-            if !store.availableTeams.isEmpty {
-                chipRow {
-                    NewsFilterChip(title: "All Teams", isSelected: store.teamFilter == nil) {
-                        store.teamFilter = nil
-                    }
-                    ForEach(store.availableTeams, id: \.rosterId) { team in
-                        NewsFilterChip(title: team.name, isSelected: store.teamFilter == team.rosterId) {
-                            store.teamFilter = store.teamFilter == team.rosterId ? nil : team.rosterId
-                        }
-                    }
-                }
-            }
-
-            // Date window
-            chipRow {
-                ForEach(NewsDateWindow.allCases) { window in
-                    NewsFilterChip(title: window.label, isSelected: store.dateFilter == window) {
-                        store.dateFilter = window
-                    }
-                }
-            }
-        }
-        .padding(.vertical, XomperTheme.Spacing.sm)
-    }
-
-    private func chipRow<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: XomperTheme.Spacing.sm) {
-                content()
+                typeMenu
+                if !store.availableTeams.isEmpty { teamMenu }
+                dateMenu
+                if store.activeFilterCount > 0 { clearButton }
             }
             .padding(.horizontal, XomperTheme.Spacing.md)
+            .padding(.vertical, XomperTheme.Spacing.sm)
         }
+    }
+
+    // MARK: - Menus
+
+    private var typeMenu: some View {
+        Menu {
+            Button { select { store.typeFilter = nil } } label: {
+                menuRow("All Types", selected: store.typeFilter == nil)
+            }
+            ForEach(NewsType.allCases) { type in
+                Button { select { store.typeFilter = type } } label: {
+                    menuRow(type.label, selected: store.typeFilter == type)
+                }
+            }
+        } label: {
+            dropdown(store.typeFilter?.label ?? "All Types", active: store.typeFilter != nil)
+        }
+        .accessibilityLabel("Filter by type")
+    }
+
+    private var teamMenu: some View {
+        let selectedName = store.availableTeams.first { $0.rosterId == store.teamFilter }?.name
+        return Menu {
+            Button { select { store.teamFilter = nil } } label: {
+                menuRow("All Teams", selected: store.teamFilter == nil)
+            }
+            ForEach(store.availableTeams, id: \.rosterId) { team in
+                Button { select { store.teamFilter = team.rosterId } } label: {
+                    menuRow(team.name, selected: store.teamFilter == team.rosterId)
+                }
+            }
+        } label: {
+            dropdown(selectedName ?? "All Teams", active: store.teamFilter != nil)
+        }
+        .accessibilityLabel("Filter by team")
+    }
+
+    private var dateMenu: some View {
+        Menu {
+            ForEach(NewsDateWindow.allCases) { window in
+                Button { select { store.dateFilter = window } } label: {
+                    menuRow(window.label, selected: store.dateFilter == window)
+                }
+            }
+        } label: {
+            dropdown(store.dateFilter == .all ? "All Time" : store.dateFilter.label,
+                     active: store.dateFilter != .all)
+        }
+        .accessibilityLabel("Filter by date")
+    }
+
+    private var clearButton: some View {
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            withAnimation(XomperTheme.defaultAnimation) { store.clearFilters() }
+        } label: {
+            HStack(spacing: XomperTheme.Spacing.xxs) {
+                Image(systemName: "xmark")
+                    .font(.caption2.weight(.bold))
+                Text("Clear")
+                    .font(.subheadline.weight(.semibold))
+            }
+            .foregroundStyle(XomperColors.accentRed)
+            .padding(.horizontal, XomperTheme.Spacing.md)
+            .frame(minHeight: 36)
+            .background(XomperColors.surfaceLight)
+            .clipShape(Capsule())
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityLabel("Clear filters")
+    }
+
+    // MARK: - Building blocks
+
+    /// Capsule dropdown label — fills `championGold` when the filter is
+    /// active, matching the selected state of `SeasonPickerBar`.
+    private func dropdown(_ title: String, active: Bool) -> some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(active ? XomperColors.deepNavy : XomperColors.textSecondary)
+                .lineLimit(1)
+            Image(systemName: "chevron.down")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(active ? XomperColors.deepNavy : XomperColors.textSecondary)
+        }
+        .padding(.horizontal, XomperTheme.Spacing.md)
+        .frame(minHeight: 36)
+        .background(active ? XomperColors.championGold : XomperColors.surfaceLight)
+        .clipShape(Capsule())
+    }
+
+    /// One menu entry — title plus a checkmark on the active option.
+    private func menuRow(_ title: String, selected: Bool) -> some View {
+        HStack {
+            Text(title)
+            if selected {
+                Spacer()
+                Image(systemName: "checkmark")
+            }
+        }
+    }
+
+    /// Apply a filter mutation with a light haptic + standard animation.
+    private func select(_ mutate: () -> Void) {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        withAnimation(XomperTheme.defaultAnimation) { mutate() }
     }
 }

--- a/Xomper/Features/News/NewsView.swift
+++ b/Xomper/Features/News/NewsView.swift
@@ -40,9 +40,15 @@ struct NewsView: View {
     // MARK: - Feed
 
     private var feed: some View {
-        ScrollView {
-            LazyVStack(spacing: XomperTheme.Spacing.sm, pinnedViews: [.sectionHeaders]) {
-                Section {
+        // Filter bar lives in a fixed strip above the ScrollView (not a
+        // pinned section header) so it stays put with no gap between it
+        // and the content as the feed scrolls underneath.
+        VStack(spacing: 0) {
+            NewsFilterBar(store: newsStore)
+                .background(XomperColors.bgDark)
+
+            ScrollView {
+                LazyVStack(spacing: XomperTheme.Spacing.sm) {
                     let items = newsStore.filteredItems
                     if items.isEmpty {
                         EmptyStateView(
@@ -57,12 +63,10 @@ struct NewsView: View {
                                 .padding(.horizontal, XomperTheme.Spacing.md)
                         }
                     }
-                } header: {
-                    NewsFilterBar(store: newsStore)
-                        .background(XomperColors.bgDark)
                 }
+                .padding(.top, XomperTheme.Spacing.sm)
+                .padding(.bottom, XomperTheme.Spacing.md)
             }
-            .padding(.bottom, XomperTheme.Spacing.md)
         }
     }
 

--- a/Xomper/Features/News/TradeNewsCard.swift
+++ b/Xomper/Features/News/TradeNewsCard.swift
@@ -23,10 +23,7 @@ struct TradeNewsCard: View {
             differentialRow
 
             if !item.summary.isEmpty {
-                Text(item.summary)
-                    .font(.subheadline)
-                    .foregroundStyle(XomperColors.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                analysisBlock
             }
         }
         .padding(XomperTheme.Spacing.md)
@@ -39,6 +36,24 @@ struct TradeNewsCard: View {
         )
         .accessibilityElement(children: .combine)
         .accessibilityLabel(item.summary.isEmpty ? item.headline : item.summary)
+    }
+
+    // MARK: - Analysis write-up
+
+    /// The deterministic trade write-up, presented under an "ANALYSIS"
+    /// label so it reads as commentary rather than a bare data dump.
+    private var analysisBlock: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xxs) {
+            Text("ANALYSIS")
+                .font(.caption2.weight(.bold))
+                .tracking(0.5)
+                .foregroundStyle(XomperColors.championGold)
+            Text(item.summary)
+                .font(.subheadline)
+                .foregroundStyle(XomperColors.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Side block


### PR DESCRIPTION
Closes #150

## Problems addressed
1. **Scroll gap** between the filter bar and content — the filters lived in a pinned `LazyVStack` section header, which left a visible gap as content scrolled under it.
2. **Ugly pill toggles** — three rows of horizontally-scrolling capsule chips.
3. **Bare trade data** — trade cards showed hauls + a grade but no real write-up.
4. **FA/waiver pickups** with no value context.

## Changes
### `NewsFilterBar.swift`
- Replaced the pill-toggle rows with compact `Menu` **dropdowns** for Type, Team, and Date, plus a **Clear** button that appears when any filter is active.
- Follows the existing `TeamAnalyzerView` opponent-picker / `SeasonPickerBar` recipe (championGold-on-active capsule, chevron, light haptic).

### `NewsView.swift`
- Moved the filter bar into a **fixed strip above the `ScrollView`** instead of a pinned section header. The bar stays put and there's **no gap** between it and the feed on scroll.

### `TradeNewsCard.swift`
- The write-up now renders under an **ANALYSIS** label so it reads as commentary rather than a data dump.

### `NewsStore.swift` (`NewsBuilder`)
- **Richer trade summaries**: each side's haul with its dynasty value, then a graded verdict naming the winner, letter grade, and the point gap ("… wins this one (A-), clearing … by 420 points of dynasty value — a 21% edge").
- **Value-added context** on FA/waiver moves: "Adds N in dynasty value to the roster" / "Sheds N…" / "A value-neutral roster shuffle."

### Cleanup
- Removed the now-unused `NewsFilterChip` component.

## Acceptance criteria
- [x] Filters are dropdowns / better-styled pickers
- [x] No gap between filter bar and content on scroll
- [x] Trade news has write-up/analysis content
- [x] FA pickups show value context

## Verification
- `xcodebuild` for the iPhone 17 Pro simulator: **BUILD SUCCEEDED**
- No LLM — all write-ups remain deterministic and offline/preview-safe.