### PR TITLE
#153 make navigation drawer opaque

### DIFF
--- a/Xomper/Features/Shell/DrawerView.swift
+++ b/Xomper/Features/Shell/DrawerView.swift
@@ -122,7 +122,7 @@ struct DrawerView: View {
             LinearGradient(
                 colors: [
                     XomperColors.bgDark,
-                    XomperColors.bgCard.opacity(0.85),
+                    XomperColors.bgCard,
                 ],
                 startPoint: .top,
                 endPoint: .bottom


### PR DESCRIPTION
Closes #153

## Problem
The slide-out navigation drawer was see-through — content behind it bled through, making the tray text hard to read.

## Fix
Removed the `.opacity(0.85)` on the bottom stop of the drawer background `LinearGradient` in `DrawerView.swift`. Both gradient stops (`bgDark` → `bgCard`) are now fully opaque, so the panel is solid and readable over any underlying content.

## Testing
- `xcodebuild` build succeeded for iPhone 17 Pro simulator.