### PR TITLE
#151 Trade Center hub

### DIFF
--- a/Xomper.xcodeproj/project.pbxproj
+++ b/Xomper.xcodeproj/project.pbxproj
@@ -227,6 +227,7 @@
 		FC8AD0A6A8B4648E71C63553 /* AnnouncementsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C814C64F50004B297F6808 /* AnnouncementsStore.swift */; };
 		FCC663F09AC754C35DF93A3D /* AdminStorePreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46FB9B5B4B8700EACD4A9CFD /* AdminStorePreviewTests.swift */; };
 		FCD03562C1879183A5DC02E2 /* PlayerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3F6B5022E8151683A45F4F /* PlayerStore.swift */; };
+		FD74C82C594CDC1B73DFE4BD /* TradeCenterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D35311441AC3DB76F9FBF42 /* TradeCenterView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -365,6 +366,7 @@
 		9AD03A165767A043D34A9499 /* AdminStorePreseasonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminStorePreseasonTests.swift; sourceTree = "<group>"; };
 		9B7C85CB880ABD7D373E49A6 /* RuleProposal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleProposal.swift; sourceTree = "<group>"; };
 		9C57E1F397386BF980992CF7 /* LogEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEvent.swift; sourceTree = "<group>"; };
+		9D35311441AC3DB76F9FBF42 /* TradeCenterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeCenterView.swift; sourceTree = "<group>"; };
 		9DBFB7D900A09D0B904F5836 /* ReportFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportFlag.swift; sourceTree = "<group>"; };
 		9E8B04D9DD0B2952BBABAB46 /* LeagueEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeagueEditView.swift; sourceTree = "<group>"; };
 		9E94170F987E8EFE5C566B9B /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
@@ -569,6 +571,7 @@
 				6901B56E6449F5FCF4E986E7 /* TaxiSquad */,
 				3E62B7EC555EA6961ADE3151 /* Team */,
 				6C903B9D928F907691888954 /* TeamAnalyzer */,
+				C1D2DEC09C12F608D1948D8A /* TradeCenter */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -824,6 +827,14 @@
 				2C12289B5D74747C89E09283 /* XomperAPIClientProtocol+TestStubs.swift */,
 			);
 			path = Support;
+			sourceTree = "<group>";
+		};
+		C1D2DEC09C12F608D1948D8A /* TradeCenter */ = {
+			isa = PBXGroup;
+			children = (
+				9D35311441AC3DB76F9FBF42 /* TradeCenterView.swift */,
+			);
+			path = TradeCenter;
 			sourceTree = "<group>";
 		};
 		CF0EB2B68A2AB44A16E88FB9 /* Shared */ = {
@@ -1294,6 +1305,7 @@
 				98D5EE595D14742780A47B81 /* ThisWeekMatchupsCard.swift in Sources */,
 				E38EEC7B1F19582B9975C236 /* TradeAnalysisView.swift in Sources */,
 				B7BD3E81860C8271FA1C068F /* TradeAnalyzerController.swift in Sources */,
+				FD74C82C594CDC1B73DFE4BD /* TradeCenterView.swift in Sources */,
 				B645CF88B5881CBE29EE6705 /* TradeNewsCard.swift in Sources */,
 				57C17293587E8DBED9A14970 /* TradedPick.swift in Sources */,
 				78094B6DF90F54E0FA59898A /* TrayDestination.swift in Sources */,

--- a/Xomper/Features/Shell/DrawerView.swift
+++ b/Xomper/Features/Shell/DrawerView.swift
@@ -45,7 +45,7 @@ struct DrawerView: View {
             ),
             TraySection(
                 title: "Team",
-                entries: [.myTeam, .taxiSquad, .teamAnalyzer, .tradeAnalysis]
+                entries: [.myTeam, .taxiSquad, .teamAnalyzer, .tradeCenter]
             ),
             TraySection(
                 title: "League",

--- a/Xomper/Features/Shell/MainShell.swift
+++ b/Xomper/Features/Shell/MainShell.swift
@@ -253,11 +253,13 @@ struct MainShell: View {
                     tradeController: tradeController
                 )
 
-            case .tradeAnalysis:
-                TradeAnalysisView(
+            case .tradeCenter:
+                TradeCenterView(
                     leagueStore: leagueStore,
                     playerStore: playerStore,
-                    valuesStore: valuesStore
+                    valuesStore: valuesStore,
+                    newsStore: newsStore,
+                    teamStore: teamStore
                 )
 
             case .payouts:

--- a/Xomper/Features/Shell/TrayDestination.swift
+++ b/Xomper/Features/Shell/TrayDestination.swift
@@ -26,7 +26,7 @@ enum TrayDestination: Hashable {
     case myTeam
     case taxiSquad
     case teamAnalyzer
-    case tradeAnalysis
+    case tradeCenter
     case rulebook
     case scoring
     case leagueSettings
@@ -54,7 +54,7 @@ enum TrayDestination: Hashable {
         case .myTeam:         "My Team"
         case .taxiSquad:      "Taxi Squad"
         case .teamAnalyzer:   "Team Analyzer"
-        case .tradeAnalysis:  "Trade Analysis"
+        case .tradeCenter:    "Trade Center"
         case .rulebook:       "Rulebook"
         case .scoring:        "Scoring"
         case .leagueSettings: "League Settings"
@@ -83,7 +83,7 @@ enum TrayDestination: Hashable {
         case .myTeam:         "person.crop.square.fill"
         case .taxiSquad:      "bus.fill"
         case .teamAnalyzer:   "chart.dots.scatter"
-        case .tradeAnalysis:  "arrow.left.arrow.right.circle.fill"
+        case .tradeCenter:    "arrow.left.arrow.right.circle.fill"
         case .rulebook:       "book.fill"
         case .scoring:        "function"
         case .leagueSettings: "slider.horizontal.3"

--- a/Xomper/Features/TradeCenter/TradeCenterView.swift
+++ b/Xomper/Features/TradeCenter/TradeCenterView.swift
@@ -1,0 +1,364 @@
+import SwiftUI
+
+/// Trade Center — the single hub that consolidates every trade surface
+/// in the app behind one pill-segmented control (#151):
+///
+/// - **Recent**      → league-wide completed trades, graded + written up,
+///                      reusing the News feed's `TradeNewsCard`.
+/// - **Builder**     → the standalone any-team-vs-any-team
+///                      `TradeAnalysisView`, embedded verbatim.
+/// - **Suggestions** → fair-value upgrade ideas for *my* weak positions,
+///                      via `RecommendedTradeBuilder`.
+/// - **My Trades**   → the Recent feed filtered to deals my team was in.
+///
+/// Trade + roster-move data comes from the shared `NewsStore` (no LLM,
+/// graded locally); dynasty values from the shared `PlayerValuesStore`.
+/// My roster is resolved from `TeamStore.myTeam` — sections that need it
+/// degrade to an explanatory empty state until the team loads.
+struct TradeCenterView: View {
+    var leagueStore: LeagueStore
+    var playerStore: PlayerStore
+    var valuesStore: PlayerValuesStore
+    var newsStore: NewsStore
+    var teamStore: TeamStore
+
+    @State private var selectedTab: TradeCenterTab = .recent
+
+    private var myRosterId: Int? { teamStore.myTeam?.rosterId }
+
+    /// Completed trades only, newest first (NewsStore already sorts).
+    private var tradeItems: [NewsItem] {
+        newsStore.items.filter { $0.type == .trade }
+    }
+
+    /// Trades my team was a party to.
+    private var myTradeItems: [NewsItem] {
+        guard let myRosterId else { return [] }
+        return tradeItems.filter { $0.involves(rosterId: myRosterId) }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            TradeCenterTabBar(selection: $selectedTab)
+
+            Group {
+                switch selectedTab {
+                case .recent:      recentTab
+                case .builder:     builderTab
+                case .suggestions: suggestionsTab
+                case .myTrades:    myTradesTab
+                }
+            }
+        }
+        .background(XomperColors.bgDark.ignoresSafeArea())
+        .task { await reloadNews(force: false) }
+        .onChange(of: leagueStore.myLeagueRosters.count) { _, _ in
+            Task { await reloadNews(force: false) }
+        }
+    }
+
+    // MARK: - Recent
+
+    private var recentTab: some View {
+        tradeFeed(
+            items: tradeItems,
+            emptyIcon: "arrow.left.arrow.right.circle",
+            emptyTitle: "No Trades Yet",
+            emptyMessage: "Completed trades across the league will show up here, graded and written up."
+        )
+    }
+
+    // MARK: - Builder
+
+    private var builderTab: some View {
+        // The standalone builder owns its own values load + refresh.
+        TradeAnalysisView(
+            leagueStore: leagueStore,
+            playerStore: playerStore,
+            valuesStore: valuesStore
+        )
+    }
+
+    // MARK: - Suggestions
+
+    private var suggestionsTab: some View {
+        Group {
+            if !valuesStore.hasValues {
+                loadingOrValues
+            } else if myRosterId == nil {
+                EmptyStateView(
+                    icon: "person.crop.square",
+                    title: "Team Not Loaded",
+                    message: "Trade suggestions appear once your team finishes loading."
+                )
+            } else {
+                let recs = suggestions()
+                if recs.isEmpty {
+                    ScrollView {
+                        VStack(spacing: XomperTheme.Spacing.md) {
+                            suggestionsExplainer
+                            EmptyStateView(
+                                icon: "sparkles",
+                                title: "No Fair-Value Upgrades",
+                                message: "We couldn't find a balanced deal that improves a weak spot right now. Check back after roster or value changes."
+                            )
+                            .padding(.top, XomperTheme.Spacing.lg)
+                        }
+                        .padding(.horizontal, XomperTheme.Spacing.md)
+                        .padding(.vertical, XomperTheme.Spacing.sm)
+                    }
+                    .refreshable { await valuesStore.loadValues(forceRefresh: true) }
+                } else {
+                    ScrollView {
+                        LazyVStack(spacing: XomperTheme.Spacing.md) {
+                            suggestionsExplainer
+                            ForEach(recs) { rec in
+                                Button {
+                                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                                    withAnimation(XomperTheme.defaultAnimation) {
+                                        selectedTab = .builder
+                                    }
+                                } label: {
+                                    RecommendedTradeCard(rec)
+                                }
+                                .buttonStyle(.pressableCard)
+                            }
+                        }
+                        .padding(.horizontal, XomperTheme.Spacing.md)
+                        .padding(.vertical, XomperTheme.Spacing.sm)
+                    }
+                    .refreshable { await valuesStore.loadValues(forceRefresh: true) }
+                }
+            }
+        }
+    }
+
+    private var suggestionsExplainer: some View {
+        VStack(alignment: .leading, spacing: XomperTheme.Spacing.xs) {
+            HStack(spacing: XomperTheme.Spacing.xs) {
+                Image(systemName: "sparkles")
+                    .foregroundStyle(XomperColors.championGold)
+                Text("Fair-value upgrades")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(XomperColors.championGold)
+            }
+            Text("Balanced deals that ship a surplus player from a strong position and bring back help at one of your weak spots. Tap a suggestion to open the Builder and war-game it.")
+                .font(.caption)
+                .foregroundStyle(XomperColors.textSecondary)
+        }
+        .padding(XomperTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(XomperColors.bgCard)
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.lg)
+                .strokeBorder(XomperColors.championGold.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    /// Build fair-value upgrade suggestions for my team. Empty until
+    /// values + rosters load, or when no weak/surplus pairing exists.
+    private func suggestions() -> [RecommendedTrade] {
+        guard let myRosterId,
+              !leagueStore.myLeagueRosters.isEmpty else { return [] }
+
+        let analyses = TeamAnalysisBuilder.build(
+            rosters: leagueStore.myLeagueRosters,
+            users: leagueStore.myLeagueUsers,
+            playerStore: playerStore,
+            valuesStore: valuesStore
+        )
+        guard let mine = analyses.first(where: { $0.rosterId == myRosterId }) else { return [] }
+
+        return RecommendedTradeBuilder.recommend(
+            myAnalysis: mine,
+            analyses: analyses,
+            rosters: leagueStore.myLeagueRosters,
+            playerStore: playerStore,
+            valuesStore: valuesStore
+        )
+    }
+
+    // MARK: - My Trades
+
+    private var myTradesTab: some View {
+        Group {
+            if myRosterId == nil {
+                EmptyStateView(
+                    icon: "person.crop.square",
+                    title: "Team Not Loaded",
+                    message: "Your trade history appears once your team finishes loading."
+                )
+            } else {
+                tradeFeed(
+                    items: myTradeItems,
+                    emptyIcon: "clock.arrow.circlepath",
+                    emptyTitle: "No Trades Yet",
+                    emptyMessage: "Trades involving your team will show up here once you make one."
+                )
+            }
+        }
+    }
+
+    // MARK: - Shared trade feed
+
+    /// Loading / error / empty / content states for a list of graded
+    /// trades. Mirrors `NewsView`'s state machine but scoped to trades.
+    @ViewBuilder
+    private func tradeFeed(
+        items: [NewsItem],
+        emptyIcon: String,
+        emptyTitle: String,
+        emptyMessage: String
+    ) -> some View {
+        if newsStore.isLoading && !newsStore.hasItems {
+            LoadingView(message: "Loading league trades...")
+        } else if let error = newsStore.error, !newsStore.hasItems {
+            ErrorView(message: error.localizedDescription) {
+                Task { await reloadNews(force: true) }
+            }
+        } else if items.isEmpty {
+            ScrollView {
+                EmptyStateView(
+                    icon: emptyIcon,
+                    title: emptyTitle,
+                    message: emptyMessage
+                )
+                .padding(.top, XomperTheme.Spacing.xl)
+                .frame(maxWidth: .infinity)
+            }
+            .refreshable { await reloadNews(force: true) }
+        } else {
+            ScrollView {
+                LazyVStack(spacing: XomperTheme.Spacing.sm) {
+                    ForEach(items) { item in
+                        TradeNewsCard(item: item)
+                            .padding(.horizontal, XomperTheme.Spacing.md)
+                    }
+                }
+                .padding(.top, XomperTheme.Spacing.sm)
+                .padding(.bottom, XomperTheme.Spacing.md)
+            }
+            .refreshable { await reloadNews(force: true) }
+        }
+    }
+
+    // MARK: - Loading helpers
+
+    @ViewBuilder
+    private var loadingOrValues: some View {
+        if valuesStore.isLoading {
+            LoadingView(message: "Fetching player values...")
+        } else if let error = valuesStore.error {
+            ErrorView(message: error.localizedDescription) {
+                Task { await valuesStore.loadValues(forceRefresh: true) }
+            }
+        } else {
+            EmptyStateView(
+                icon: "arrow.left.arrow.right.circle",
+                title: "Values Not Loaded",
+                message: "Pull to refresh to load dynasty values."
+            )
+            .task { await valuesStore.loadValues() }
+        }
+    }
+
+    // MARK: - Load
+
+    /// Fetch + grade the league trade feed. Needs rosters + users for
+    /// team-name resolution, so it waits for them (matches `NewsView`).
+    private func reloadNews(force: Bool) async {
+        guard !leagueStore.myLeagueRosters.isEmpty else { return }
+        await valuesStore.loadValues()
+        await newsStore.load(
+            leagueId: leagueStore.resolvedHomeLeagueId,
+            rosters: leagueStore.myLeagueRosters,
+            users: leagueStore.myLeagueUsers,
+            playerStore: playerStore,
+            valuesStore: valuesStore,
+            forceRefresh: force
+        )
+    }
+}
+
+// MARK: - Tabs
+
+/// The four Trade Center sections, in bar order.
+enum TradeCenterTab: String, CaseIterable, Identifiable, Sendable, Hashable {
+    case recent
+    case builder
+    case suggestions
+    case myTrades
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .recent:      "Recent"
+        case .builder:     "Builder"
+        case .suggestions: "Suggestions"
+        case .myTrades:    "My Trades"
+        }
+    }
+}
+
+/// Pill-segmented control for the Trade Center tabs. Mirrors
+/// `DraftSubTabBar`'s styling — championGold fill on the selected pill,
+/// muted text otherwise — so the visual language matches the Draft
+/// surface. Horizontally scrollable since four labels are tight in
+/// portrait.
+private struct TradeCenterTabBar: View {
+    @Binding var selection: TradeCenterTab
+
+    var body: some View {
+        HStack(spacing: XomperTheme.Spacing.xs) {
+            ForEach(TradeCenterTab.allCases) { tab in
+                tabButton(tab)
+            }
+        }
+        .padding(2)
+        .background(XomperColors.surfaceLight.opacity(0.4))
+        .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md + 2))
+        .padding(.horizontal, XomperTheme.Spacing.md)
+        .padding(.vertical, XomperTheme.Spacing.sm)
+    }
+
+    private func tabButton(_ tab: TradeCenterTab) -> some View {
+        let isSelected = selection == tab
+        return Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            withAnimation(XomperTheme.defaultAnimation) {
+                selection = tab
+            }
+        } label: {
+            Text(tab.label)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(isSelected ? XomperColors.bgDark : XomperColors.textSecondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+                .padding(.horizontal, XomperTheme.Spacing.sm)
+                .padding(.vertical, 6)
+                .frame(maxWidth: .infinity)
+                .background(isSelected ? XomperColors.championGold : Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: XomperTheme.CornerRadius.md))
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityLabel(tab.label)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        TradeCenterView(
+            leagueStore: LeagueStore(),
+            playerStore: PlayerStore(),
+            valuesStore: PlayerValuesStore(),
+            newsStore: NewsStore(),
+            teamStore: TeamStore()
+        )
+    }
+    .preferredColorScheme(.dark)
+}


### PR DESCRIPTION
## Trade Center hub — Closes #151

Consolidates every trade surface behind a single **Trade Center** drawer destination with a four-tab pill bar (styling mirrors the Draft sub-tabs).

### Sections
| Tab | Source | Notes |
|-----|--------|-------|
| **Recent** | `NewsStore` trades | Reuses `TradeNewsCard` (grade + write-up + differential) |
| **Builder** | `TradeAnalysisView` | Embedded verbatim — any-team-vs-any-team builder |
| **Suggestions** | `RecommendedTradeBuilder` | Fair-value upgrades for my weak positions; tapping a card opens the Builder |
| **My Trades** | `NewsStore` trades filtered to my `rosterId` | Resolved from `TeamStore.myTeam` |

### Wiring
- New `TrayDestination.tradeCenter`; retired the now-redundant `.tradeAnalysis` entry (the builder lives inside the hub).
- `MainShell` renders `TradeCenterView` with the shared `newsStore` / `valuesStore` so the feed isn't refetched.
- Drawer **Team** section: `Trade Analysis` → `Trade Center`.

### Draft recap grades (the "also fix")
The recap-grades-showing-0 fix already landed in `a2990f2` — `PlayerValuesStore.loadValues()` is called in `DraftRecapView.task(id:)` and the FantasyCalc endpoint now uses `limit=2000`. Verified still in place; no further change needed.

### Verification
- `xcodegen generate` + `xcodebuild -scheme Xomper -sdk iphonesimulator` → **BUILD SUCCEEDED**
- New/changed sections degrade to explanatory empty states before team/values load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
