### PR TITLE
fix: handle decimal player values from FantasyCalc API

### DIFF
--- a/Xomper/Core/Models/PlayerValue.swift
+++ b/Xomper/Core/Models/PlayerValue.swift
@@ -51,7 +51,15 @@ struct PlayerValue: Codable, Sendable {
         self.sleeperId = try? player?.decodeIfPresent(String.self, forKey: .sleeperId)
         self.position = try? player?.decodeIfPresent(String.self, forKey: .position)
         self.name = try? player?.decodeIfPresent(String.self, forKey: .name)
-        self.value = (try? c.decode(Int.self, forKey: .value)) ?? 0
+        if let i = try? c.decode(Int.self, forKey: .value) {
+            self.value = i
+        } else if let d = try? c.decode(Double.self, forKey: .value) {
+            self.value = Int(d.rounded())
+        } else if let s = try? c.decode(String.self, forKey: .value), let n = Double(s) {
+            self.value = Int(n.rounded())
+        } else {
+            self.value = 0
+        }
         self.overallRank = try? c.decodeIfPresent(Int.self, forKey: .overallRank)
         self.positionRank = try? c.decodeIfPresent(Int.self, forKey: .positionRank)
         self.trend30Day = try? c.decodeIfPresent(Int.self, forKey: .trend30Day)


### PR DESCRIPTION
## Summary
- Fixed issue where mock draft player values were showing as 0
- FantasyCalc API returns decimal values, but decoder was using `Int.self` which throws on decimals
- The `try?` silently converted decode failures to 0

## Changes
Updated `PlayerValue.swift` to handle multiple value formats:
1. Try `Int` first (for whole numbers)
2. Try `Double` and round (for decimal values)
3. Try `String` -> `Double` and round (for string-encoded numbers)
4. Fall back to 0 only if all above fail

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)