### PR TITLE
#99 auto-regen mocks when draft order changes

### DIFF
--- a/Xomper/Core/Stores/MockDraftStore.swift
+++ b/Xomper/Core/Stores/MockDraftStore.swift
@@ -86,6 +86,10 @@ final class MockDraftStore {
     /// snapshots change so `ensureLoaded` knows to regenerate.
     private var lastBuildKey: String?
 
+    /// Fingerprint of the last slot order. Triggers regen when commish
+    /// sets a new draft order mid-session.
+    private var lastSlotFingerprint: String?
+
     // MARK: - Public API
 
     /// Idempotent loader. Builds `TeamContext`, derives the rookie
@@ -173,10 +177,16 @@ final class MockDraftStore {
             valuesLoadedAt: playerValuesStore.lastLoadedAt,
             seed: currentSeed
         )
-        if buildKey == lastBuildKey { return }
+
+        // Detect slot order changes (commish set 2026 draft order mid-session)
+        let newFingerprint = Self.slotFingerprint(resolvedSlots)
+        let orderChanged = lastSlotFingerprint != nil && lastSlotFingerprint != newFingerprint
+
+        if buildKey == lastBuildKey && !orderChanged { return }
 
         slotOrder = resolvedSlots
         usingFallbackSlotOrder = isFallback
+        lastSlotFingerprint = newFingerprint
 
         // Build the rookie pool.
         let (pool, didFallback) = buildRookiePool(
@@ -439,5 +449,10 @@ final class MockDraftStore {
     ) -> String {
         let stamp = valuesLoadedAt.map { String(Int($0.timeIntervalSince1970)) } ?? "nil"
         return "\(draftId)|\(stamp)|\(seed)"
+    }
+
+    /// Hash of slot order to detect when commish sets draft order.
+    static func slotFingerprint(_ slots: [Int: SlotTeam]) -> String {
+        slots.keys.sorted().map { "\($0):\(slots[$0]!.rosterId)" }.joined(separator: ",")
     }
 }

--- a/docs/features/my-team-rework/BRAINSTORM.md
+++ b/docs/features/my-team-rework/BRAINSTORM.md
@@ -1,0 +1,328 @@
+# My Team — Page Rework
+
+Status: Draft
+Owner: Dominick
+Source: screenshot review feedback
+
+## TL;DR + Recommendation
+
+The current My Team page is a single dense scroll: header card, then four
+position sections (Starters → Bench → Taxi → IR). The user wants navigation
+within it (tabs), an embedded hexagon strengths chart, trade suggestions, and
+"quick hitters" up top — and **we already own the data and algorithms for all
+four**. `TeamAnalysisBuilder`, `HexagonChartView`, and `RecommendedTradeBuilder`
+exist and are battle-tested inside `TeamAnalyzerView`. The rework is mostly an
+IA + extraction job, not a data job.
+
+**Recommended: Option B — Sectioned tabs with a sticky summary header.** Three
+tabs (Roster · Strengths · Trades), one always-visible quick-hitter header.
+Biggest tradeoff: tabs inside an already-nested `NavigationStack` add a third
+selection layer (drawer → tab → in-page tab) that the user has to learn.
+
+---
+
+## Current-State Audit
+
+| Section | Role today | Status |
+|---|---|---|
+| `teamHeader` (avatar, name, record, streak, league/division rank) | Identity + standings snapshot | Keep — already does double duty |
+| `startersSection` | Slot-ordered starting lineup | Keep, but cramped: 9+ rows before bench |
+| `benchSection` | Position-sorted bench | Keep — dynasty value is mostly here |
+| `taxiSection` | Taxi rows | Often empty mid-season — wastes vertical space |
+| `irSection` | Reserve rows | Often empty — same |
+| (none) | Dynasty value totals | **Missing** — exists in `TeamAnalysis` but never shown on My Team |
+| (none) | Position strengths vs league | **Missing** — exists, lives only in TeamAnalyzer |
+| (none) | Trade ideas | **Missing** — exists as `RecommendedTradeBuilder`, locked inside Analyzer's Trade tab |
+| (none) | Recent form / weekly points | **Missing** — `PlayerPointsStore` + `HistoryStore` already populated |
+
+Net: today's page is roster-only. Everything the screenshot asks for already
+exists elsewhere in the app — the rework is consolidation + extraction.
+
+---
+
+## The 4 Asks, Unpacked
+
+### 1. Navigation / tabs
+
+"Good" here means: the user can land on the page and reach roster, strengths,
+or trade ideas in one tap without scrolling past the full bench. Inside an
+already-pushed `NavigationStack` (TeamView is the root of the My Team
+destination — see `MainShell.myTeamRoot`), a SwiftUI `Picker(.segmented)` or a
+local `HStack` tab bar is the right shape — **not** a sub-`NavigationStack` and
+**not** `TabView` (which would conflict with the system tab bar pattern and
+swallow swipe-to-pop).
+
+Pattern to copy: `TeamAnalyzerView.tabBar` (custom `HStack` with underline +
+`championGold` active state). It already matches the theme and handles
+`UIImpactFeedbackGenerator`.
+
+**Data plumbing**: none — pure view state, `@State private var activeTab`.
+
+### 2. Quick hitters
+
+What's the right set? Argue for **four**, all derivable from already-loaded
+data, sized for a single horizontal row of badges:
+
+- **Total dynasty value** (`TeamAnalysis.totalValue`) + delta vs league avg
+  ("+842 vs avg" with up/down arrow color)
+- **League rank by value** (sort `analyses.totalValue` desc, find self) — this
+  is the *real* power ranking, distinct from record-based standings
+- **Record + streak** (already in `teamHeader`, just compacted into the strip)
+- **Biggest weakness** — the axis where my value falls furthest below league
+  avg, expressed as "Weakness: TE" with a tap-jumps-to-Strengths-tab affordance
+
+Not picked: total points (FPTS) — already in standings table and not
+actionable. Win projection / playoff odds — needs model we don't have.
+
+**Data plumbing**: build the strip from `TeamAnalysis` for self +
+`leagueAverageAxes(analyses)` for delta. The team store doesn't currently hold
+`TeamAnalysis`; the rework needs to either (a) compute it in `TeamView.body`
+each render (cheap — 12 rosters × ~25 players each, integer sums) or (b) cache
+it in a new `MyTeamAnalysisStore` keyed by leagueId. **Recommend (a)** — same
+pattern Analyzer uses, no new store.
+
+### 3. Embedded hexagon chart
+
+Three placements considered:
+
+- **Full hex on its own tab** — clearest, but burns a tap when the chart is
+  what the user came for.
+- **Mini hex in header strip** (~120pt) — too small to read 6 axis labels.
+- **Hex as hero on Strengths tab + thumbnail glance in Quick Hitters** — best
+  of both. The thumbnail is decorative (no labels, primary polygon only); the
+  full chart with league-average underlay lives on the Strengths tab.
+
+Recommend the third. **`HexagonChartView` is already reusable** — it takes
+plain `[HexAxis]` arrays and an `axisMaxes` dict. No extraction needed beyond
+passing it `nil` for `comparison` and giving it a smaller `minHeight` when used
+as the thumbnail.
+
+**Data plumbing**: call `TeamAnalysisBuilder.build(...)` and `axisMaxes(...)`
+in `TeamView` exactly as `TeamAnalyzerView` does today. Same inputs, same
+outputs. No backend change.
+
+### 4. Trade suggestions
+
+Algorithm is already implemented in `RecommendedTradeBuilder.recommend(...)`:
+
+1. Find my weak positions (≤85% of league avg).
+2. Find my strong positions (≥105% of league avg).
+3. For each league partner, find positions where they're surplus and I'm weak.
+4. Match their best player at that position against one of my strong-position
+   players whose FantasyCalc value is within 5%.
+5. Return ranked by my-side improvement, capped at 5 suggestions.
+
+This is exactly the algorithm the user asked for and it's working in
+`TeamAnalyzerView.tradeTab`. The My Team rework just needs to call it. The
+"What" question is purely presentation: pairs (full give/receive) vs outbound
+only vs inbound only. The existing builder produces **pairs**, so present them
+as pairs — the inbound/outbound split is unnecessary complexity.
+
+**Data plumbing**: `RecommendedTradeBuilder.recommend(myAnalysis:analyses:rosters:playerStore:valuesStore:)`
+returns `[RecommendedTrade]` ready to render. Tap on one should deep-link into
+the existing `TeamAnalyzerView` Trade tab with the trade pre-loaded — that
+already works for the in-Analyzer recommended trades, we just need the deep
+link via `AppRouter`.
+
+---
+
+## Open Design Questions (with positions)
+
+### Q1: Tabs vs accordion vs sub-page push
+
+**Position: in-page segmented tabs.** Accordion makes the page feel like a
+form. Sub-page push doubles the nav stack (TeamView is already on the stack;
+pushing again creates `… → TeamView → StrengthsView → PlayerDetail` chains
+that get confusing with system swipe-to-pop). Tabs keep the user grounded.
+
+**Case against**: three tabs inside a drawer destination inside a nav stack is
+three selection layers. If a future tab is added, this gets noisy. Mitigation:
+hard-cap at three tabs in the spec.
+
+### Q2: Hex placement — top, sticky, or own tab
+
+**Position: hero of its own Strengths tab.** Sticky-pinned hex eats ~280pt on
+iPhone 17 Pro (smaller phones worse), leaving ~400pt for the roster — not
+worth it. The Quick Hitters strip already shows the "weakness" callout, so the
+hex isn't needed permanently visible.
+
+**Case against**: forces a tap to see the chart. Acceptable given the strip
+already names the weak axis.
+
+### Q3: Trade suggestions — outbound, inbound, or pairs
+
+**Position: pairs.** `RecommendedTradeBuilder` already builds pairs and the
+user can see give/receive at a glance. Splitting into "players to acquire"
+and "players to shop" doubles the work to read a suggestion and breaks the
+existing builder contract. Tap on a pair → push to Analyzer Trade tab
+pre-loaded.
+
+**Case against**: pairs hide the fact that *some* of my players are
+universally tradeable. If we want a "league shopping list," that's a separate
+feature on the Analyzer page, not My Team.
+
+### Q4: Quick hitters — which 4 stats?
+
+**Position: Value + Value Rank + Record/Streak + Weakness axis.** Argued
+above. Reject "total FPTS" (not actionable) and "playoff odds" (model not
+built).
+
+---
+
+## IA Mapping — Proposed Structure
+
+```
+┌─────────────────────────────────────────────┐
+│ teamHeader (avatar + name + record + ranks) │  ← unchanged, slim it
+├─────────────────────────────────────────────┤
+│ QuickHittersStrip                            │  ← NEW
+│  [Value 12,400 ▲842] [#3 by Value]           │
+│  [8-3 · W3]          [Weakness: TE →]        │
+├─────────────────────────────────────────────┤
+│ ┌─Roster─┬─Strengths─┬─Trades─┐              │  ← in-page tab bar
+│ └────────┴───────────┴────────┘              │
+├─────────────────────────────────────────────┤
+│                                              │
+│ Tab content                                  │
+│                                              │
+└─────────────────────────────────────────────┘
+```
+
+- **Roster tab**: today's Starters → Bench → Taxi → IR sections, unchanged.
+- **Strengths tab**: hero `HexagonChartView` (mine + league avg underlay) +
+  per-position breakdown grid (reuse `breakdownGrid` from Analyzer's Compare
+  tab — only it without an opponent column).
+- **Trades tab**: list of `RecommendedTrade` cards (reuse `recommendedTradeRow`
+  from Analyzer). Empty state when no fair-value matches. Tap → deep-link into
+  Analyzer Trade tab.
+
+---
+
+## Risks
+
+- **Nav stack interactions**: TeamView already presents `PlayerDetailView` as
+  a sheet — safe. The Trades-tab deep-link to Analyzer needs a new
+  `AppRoute.tradeAnalyzer(preload:)` case (or push and set state via a shared
+  store). Don't double-push from inside a tab.
+- **TeamAnalysis compute cost on render**: 12 rosters × ~25 players = ~300
+  dict lookups. Cheap, but `TeamView.body` runs on every roster change.
+  Memoize via `let analyses = ...` outside the tab switch (already the pattern
+  in Analyzer).
+- **Taxi/IR edge cases**: today's view hides empty taxi/IR sections. Keep
+  that behavior in the Roster tab. The hex chart's Taxi axis will read zero
+  for most teams — that's fine, it's already designed for it.
+- **PlayerValuesStore freshness**: if the user opens My Team before
+  Analyzer has ever loaded, `valuesStore.hasValues` is false and the
+  Strengths/Trades tabs need to either load on-tab-activate or show an
+  empty-loading state. Recommend loading in `TeamView.task` (mirrors
+  Analyzer).
+- **Refresh contract**: the existing pull-to-refresh reloads
+  `playerStore.loadPlayers()`. Strengths/Trades depend on `valuesStore` and
+  league rosters — add those to the refresh.
+
+---
+
+## Phase 0 Pre-work
+
+1. **Verify `HexagonChartView` is reusable as-is.** It already lives in
+   `Features/TeamAnalyzer/` and takes plain structs — no extraction needed.
+   Just import the file and instantiate. Future polish: move to
+   `Features/Shared/` if a third surface ever needs it.
+2. **Extract `breakdownGrid` and `breakdownRow`** from `TeamAnalyzerView` into
+   a `PositionBreakdownView` so My Team's Strengths tab and Analyzer's Compare
+   tab share one implementation. Single source of truth for the per-position
+   bars + delta colors.
+3. **Extract `recommendedTradeRow`** into a `RecommendedTradeCard` view for
+   the same reason. The card already renders standalone (no internal state).
+4. **Add `AppRoute.tradeAnalyzer(preload: RecommendedTrade?)`** so the My Team
+   Trades tab can deep-link into the Analyzer with a trade pre-loaded into the
+   builder. Today the Analyzer's own "Recommended trades" section sets the
+   trade-builder state directly via `@State` — we need to surface those
+   setters via a small `TradeAnalyzerController` or pass a `preload` argument
+   on the view init.
+
+---
+
+## Converged Options
+
+### Option A: Quick Hitters strip only
+
+**What**: Add the four-badge summary strip at the top of TeamView. Leave the
+roster sections as-is. Skip embedded hex and trade suggestions.
+
+**How it works**: Compute `TeamAnalysis` for self in `TeamView`, compute
+`leagueAverageAxes` for delta, render strip. Roster sections unchanged.
+
+**Pros**:
+- ~1-day scope. One file changed.
+- Zero nav stack risk, zero new routes.
+- Delivers the most-glanceable improvement first.
+
+**Cons / Risks**:
+- Doesn't address the user's "tabs" or "octagon" asks.
+- Probably needs a follow-up feature within weeks.
+
+**Best if**: We want to ship something this week and re-evaluate trade
+suggestions/hex placement after seeing the strip in production.
+
+### Option B: Sectioned tabs with sticky Quick Hitters (RECOMMENDED)
+
+**What**: Quick Hitters strip + three-tab in-page nav (Roster · Strengths ·
+Trades). Hex chart on Strengths tab. Recommended trades on Trades tab.
+
+**How it works**: Wrap today's roster sections in a `Roster` tab. Add
+`Strengths` tab pulling `HexagonChartView` + extracted breakdown grid. Add
+`Trades` tab pulling `RecommendedTradeBuilder.recommend(...)`. All data
+sourced from existing stores. Deep-link Trades cards to Analyzer.
+
+**Feature breakdown for `/orchestrate`**:
+- F1: extract shared views (`PositionBreakdownView`, `RecommendedTradeCard`)
+- F2: Quick Hitters strip + value/rank/weakness compute
+- F3: in-page tab bar + Roster tab (move existing sections)
+- F4: Strengths tab (hex + breakdown)
+- F5: Trades tab + Analyzer deep-link route
+
+**Pros**:
+- Hits all four user asks.
+- Reuses every existing algorithm — zero backend change.
+- Aligns My Team with Analyzer visually (same tab bar, same cards).
+
+**Cons / Risks**:
+- Three nesting layers (drawer → page → in-page tab).
+- Trades tab requires the new `AppRoute` case.
+- Phase 0 extraction is upfront cost before any user-visible change.
+
+**Best if**: We want the full rework in one epic, batched cleanly.
+
+### Option C: Tabs without Trades (minimum complete rework)
+
+**What**: Quick Hitters + two tabs (Roster · Strengths). Drop the embedded
+Trades tab; users still get trade suggestions via the Analyzer.
+
+**How it works**: Same as B without F5. Roster tab + Strengths tab only.
+
+**Pros**:
+- No new `AppRoute` case, no Analyzer deep-link.
+- Two-tab UX is genuinely simpler than three.
+- Hex is the visually flashy ask; covering it with the breakdown is enough.
+
+**Cons / Risks**:
+- The user explicitly asked for trade suggestions. Punting them feels like
+  a partial answer.
+
+**Best if**: The deep-link or new route plumbing turns out to be heavier than
+expected, and we want to ship B-minus.
+
+---
+
+## Recommendation
+
+**Option B.** All four asks are addressable, all data exists, and the
+biggest risk (the new route) is well-scoped to one feature in the breakdown.
+The user's framing — "we already have like all the data" — is correct, and
+the rework is a consolidation play.
+
+Depends on: how heavy `AppRoute.tradeAnalyzer(preload:)` ends up being. If
+the Analyzer's trade-builder state can't be hoisted into a `@State` parent
+or a small controller without rewriting the view, fall back to **Option C**
+and re-spec the deep-link as its own follow-up.

--- a/docs/features/my-team-rework/PLAN.md
+++ b/docs/features/my-team-rework/PLAN.md
@@ -1,0 +1,154 @@
+# Plan: My Team Rework
+
+**Status**: Ready
+**Created**: 2026-06-03
+**Last updated**: 2026-06-03 (Phase 0a + 0b complete; 0c pending PR #138 review)
+**Brainstorm**: [BRAINSTORM.md](./BRAINSTORM.md)
+
+## TL;DR
+
+Implement **Option B** from the brainstorm: rework `TeamView` into a 3-tab page (Roster / Strengths / Trades) with a sticky Quick Hitters strip on top. Zero backend work — reuses `TeamAnalysisBuilder`, `HexagonChartView`, and `RecommendedTradeBuilder` already in production inside `TeamAnalyzerView`.
+
+## Approach
+
+Single-feature scope (not an epic). Phase 0 lifts two view-builders out of `TeamAnalyzerView` into shared components AND hoists the Trade Analyzer's trade-builder `@State` into a new `@Observable TradeAnalyzerController`. The controller pays off the moment a second consumer (My Team's Trades tab) needs to seed a preloaded trade, and unlocks future deep-link sources (announcement cards, suggested-partner DMs, etc.) at zero marginal cost. **No button-launch fallback** — Branch A (controller-hoisted preload) is the only path forward per the locked decision.
+
+## Scope
+
+**In**:
+- 3-tab `TeamView`: `.roster` (today's content) / `.strengths` (hex + breakdown) / `.trades` (recommendation list + deep-link to Analyzer)
+- Sticky `QuickHittersStrip` above the picker — **6 stats**: record, league rank, total dynasty value, weakness chip, total FPTS (season-to-date), best position chip. Horizontal scroll on phone; fits without scroll on iPad.
+- Extract `breakdownGrid` + `breakdownRow` into a shared `PositionBreakdownCard` view
+- Extract `recommendedTradeRow` into a shared `RecommendedTradeCard` view
+- `TeamAnalyzerView` refactored to use both extracted components (lossless — same rendering)
+- Update both `TeamView` call sites in `MainShell` to pass any new dependencies
+
+**Out**:
+- New analytics / metrics — Quick Hitters use existing fields (`StandingsTeam.wins/losses/streak/leagueRank`, `TeamAnalysis.totalValue`, `leagueAverageAxes`, `PlayerPointsStore` for season FPTS sum)
+- Changes to `RecommendedTradeBuilder` algorithm — render as-is
+- Theme / palette changes — Midnight Emerald sweep handled by the parity epic
+- Backend / Supabase / Sleeper API work — purely client-side IA reshuffle
+- Weekly form / recent points (deferred from brainstorm's "missing" audit)
+
+## Phase 0 Pre-work
+
+Must complete before any visible TeamView change lands:
+
+1. **Open GitHub issue**: `feat: My Team rework — tabs, quick hitters, embedded analyzer`. Use that number for the branch (`feat/<n>-my-team-rework`) and commit prefixes.
+2. **Hoist trade-builder state into `@Observable TradeAnalyzerController`** — locked decision (long-term right call per user 2026-06-03): pull `tradePartnerRosterId`, `tradeSideAPlayerIds`, `tradeSideBPlayerIds` out of `TeamAnalyzerView` into a new `@Observable @MainActor final class TradeAnalyzerController` in `Xomper/Core/Stores/`. Instantiate once at `MainShell` (alongside the other stores), inject into `TeamAnalyzerView`, expose a `func preload(_ rec: RecommendedTrade)` that seeds the three fields atomically. The controller pays for itself the moment the Trades tab needs to seed a preloaded trade, and unlocks future deep-link sources (announcement cards, suggested-partner DMs) at zero marginal cost. **No time-box, no fallback** — this is the only path.
+3. **Lossless refactor PR (separate commit, can land first)**:
+   - Create `Xomper/Features/Shared/PositionBreakdownCard.swift` exposing `init(my: TeamAnalysis, opp: TeamAnalysis?, averages: [TeamAnalysis.HexAxis], maxes: [String: Int])`. Body is the existing `breakdownGrid` + `breakdownRow` verbatim (privatize the `deltaColor` helper into the file).
+   - Create `Xomper/Features/Shared/RecommendedTradeCard.swift` exposing `init(_ rec: RecommendedTrade)`. Body is the existing `recommendedTradeRow` verbatim.
+   - Update `TeamAnalyzerView` to consume both. Confirm the Compare tab and the Trades section still render identically (manual diff on simulator).
+
+## Affected Files / Components
+
+| File / Component | Change | Why |
+|------------------|--------|-----|
+| `Xomper/Features/Shared/PositionBreakdownCard.swift` | NEW | Hoist breakdown grid out of TeamAnalyzerView for reuse on Strengths tab |
+| `Xomper/Features/Shared/RecommendedTradeCard.swift` | NEW | Hoist recommended-trade row out of TeamAnalyzerView for reuse on Trades tab |
+| `Xomper/Features/TeamAnalyzer/TeamAnalyzerView.swift` | EDIT | Replace inline `breakdownGrid` / `recommendedTradeRow` with shared components; (conditional on Phase 0 result) accept optional `preloadedTrade` init param |
+| `Xomper/Features/Team/TeamView.swift` | EDIT | Add `TeamSection` enum, `@State activeSection`, segmented `Picker`, `QuickHittersStrip`, three section bodies, `task`/`refreshable` plumbing for `valuesStore` |
+| `Xomper/Features/Team/QuickHittersStrip.swift` | NEW | 4-tile horizontal summary (record, rank, value, weakness) — pure presentation, takes a `QuickHittersData` struct |
+| `Xomper/Features/Shell/MainShell.swift` | EDIT | Pass `leagueStore`, `valuesStore`, `authStore`, `router` into both `TeamView(...)` call sites (`myTeamRoot` + `.teamDetail` push) |
+| `Xomper/Navigation/AppRouter.swift` | EDIT (conditional) | If preload branch wins Phase 0: no change (use existing `teamAnalyzer` tray destination switch + a transient preload via shared store). If a new route case is cleaner, add `case teamAnalyzerWithTrade(RecommendedTrade)` — decided in Phase 0. |
+| `Xomper/Features/Team/PlayerDetailView.swift` | NO CHANGE | Sheet presentation stays as-is |
+
+## Implementation Steps
+
+- [ ] **Step 1 — Phase 0**: Open issue, run trade-preload investigation, land lossless extraction PR (`PositionBreakdownCard` + `RecommendedTradeCard`). Confirm Analyzer renders unchanged on iPhone 17 Pro sim.
+- [ ] **Step 2 — TeamSection scaffold**: In `TeamView.swift`, add `private enum TeamSection: String, CaseIterable { case roster, strengths, trades }`. Add `@State private var activeSection: TeamSection = .roster`. Insert a `Picker("Section", selection: $activeSection)` with `.pickerStyle(.segmented)` directly below the Quick Hitters strip placeholder. Wrap the existing roster body (`startersSection` / `benchSection` / `taxiSection` / `irSection`) in `case .roster:`.
+- [ ] **Step 3 — QuickHittersStrip component**: Create `QuickHittersStrip.swift` rendering 4 horizontal tiles:
+  - **Record**: `team.wins-team.losses` + `team.streak.displayString` chip (data already on `StandingsTeam`)
+  - **League rank**: `team.leagueRank` with ordinal suffix (existing `ordinalSuffix` helper — move to extension)
+  - **Total value**: `myAnalysis.totalValue` with delta vs league avg (sum of `leagueAverageAxes` / 6 × 6, i.e. compare to mean of `analyses.map(\.totalValue)`)
+  - **Weakness**: axis label where `myAnalysis.hexAxes[i].value / leagueAverages[i].value` is smallest; tappable → sets `activeSection = .strengths`
+  - **Total FPTS**: sum of `playerPointsStore.points(for: playerId)` across `roster.starters` (starter PF — matches the league standings PF column). Decide on starters-only vs full-roster sum during impl; default to starters.
+  - **Best position**: axis label where `myAnalysis.hexAxes[i].value / leagueAverages[i].value` is largest; tappable → sets `activeSection = .strengths`.
+  - Layout: horizontal `ScrollView(.horizontal, showsIndicators: false)` of `xomperCard()` tiles on phone — six tiles won't fit at default Dynamic Type on iPhone 17 Pro without scroll. Each tile snaps to a fixed min-width so labels read consistently. iPad gets a non-scrolling `LazyHStack`.
+- [ ] **Step 4 — Strengths tab**: `case .strengths:` body renders:
+  - `HexagonChartView(primary: myAnalysis.hexAxes, comparison: nil, leagueAverage: leagueAverages, axisMaxes: axisMaxes)`
+  - `PositionBreakdownCard(my: myAnalysis, opp: nil, averages: leagueAverages, maxes: axisMaxes)`
+- [ ] **Step 5 — Trades tab**: `case .trades:` body:
+  - Compute `recs = RecommendedTradeBuilder.recommend(myAnalysis: ..., analyses: ..., rosters: leagueStore.myLeagueRosters, playerStore:, valuesStore:)`
+  - Empty state when `recs.isEmpty` — reuse the same copy from TeamAnalyzerView's recommended-trades section.
+  - `ForEach(recs) { rec in Button { ... } label: { RecommendedTradeCard(rec) } }`.
+  - **Button action**: `tradeController.preload(rec)` then `navigationStore.select(.teamAnalyzer)`. The controller persists across the tray switch; `TeamAnalyzerView` reads from it on appear, so the partner + both sides are populated before the user sees the screen. No fallback path — the controller hoist landed in Phase 0.
+- [ ] **Step 6 — Wire data dependencies**: `TeamView` needs `leagueStore: LeagueStore`, `valuesStore: PlayerValuesStore`, `authStore: AuthStore`, `playerPointsStore: PlayerPointsStore` (for FPTS tile), `tradeController: TradeAnalyzerController` (for Trades-tab preload). Add as `let` props. Compute `analyses` / `axisMaxes` / `leagueAverages` / `myAnalysis` once at the top of `body` (before the `switch`), exactly mirroring `TeamAnalyzerView.content`. Add `await valuesStore.loadValues()` to the existing `.task`. Add `await valuesStore.loadValues(forceRefresh: true)` to `.refreshable`.
+- [ ] **Step 7 — Update call sites**: In `MainShell.swift` lines 344 and 406, pass the new dependencies. Both call sites already have access to `leagueStore`, `authStore`, and `valuesStore` (used elsewhere in MainShell for `TeamAnalyzerView` — line 228). Update the preview block in `TeamView.swift` accordingly.
+- [ ] **Step 8 — Sticky behavior**: Try `safeAreaInset(edge: .top)` for the Quick Hitters strip so it stays pinned during scroll of the section content. **Risk gate**: if iPhone 17 Pro shows strip + picker eating > 30% of viewport before content shows, drop sticky and let it scroll with the page. Decide on-device.
+- [ ] **Step 9 — Build + manual verify**: `xcodegen generate` then the standard build command. On iPhone 17 Pro sim verify:
+  - Roster tab matches today's UI pixel-for-pixel.
+  - Strengths tab renders hex chart + breakdown grid, no missing axes.
+  - Trades tab lists recommendations (or empty state) and deep-links correctly.
+  - No double-push when tapping a trade card (Branch A) or a nav-stack glitch (Branch B).
+  - Pull-to-refresh on each tab re-loads both player data and values without thrash.
+- [ ] **Step 10 — Commit + PR**: Branch `feat/<n>-my-team-rework`. Commit message prefix `#<n>`. PR description includes `Closes #<n>`. No Co-Authored-By lines.
+
+## Data Flow
+
+```
+TeamView.body
+ ├── Inputs: team (StandingsTeam), roster (Roster), league, playerStore, leagueStore, valuesStore, authStore
+ ├── analyses = TeamAnalysisBuilder.build(rosters: leagueStore.myLeagueRosters, users: leagueStore.myLeagueUsers, playerStore, valuesStore)
+ ├── myAnalysis = analyses.first { $0.userId == authStore.sleeperUserId } ?? analyses.first
+ ├── axisMaxes = TeamAnalysisBuilder.axisMaxes(analyses)
+ ├── leagueAverages = TeamAnalysisBuilder.leagueAverageAxes(analyses)
+ │
+ ├── QuickHittersStrip
+ │    ├── record    ← team.wins / team.losses / team.streak
+ │    ├── rank      ← team.leagueRank
+ │    ├── value     ← myAnalysis.totalValue (+ delta vs mean(analyses.totalValue))
+ │    └── weakness  ← argmin(myAnalysis.hexAxes[i] / leagueAverages[i])
+ │
+ ├── Picker(activeSection)
+ │
+ └── switch activeSection
+      ├── .roster    → existing starters/bench/taxi/IR sections
+      ├── .strengths → HexagonChartView(myAnalysis, nil, leagueAverages, axisMaxes) + PositionBreakdownCard
+      └── .trades    → ForEach(RecommendedTradeBuilder.recommend(...)) → RecommendedTradeCard
+                       Tap → preload or button-launch (Phase 0 decision)
+```
+
+Quick Hitters' record + rank source: `StandingsTeam` (already passed into `TeamView` — `team.wins`, `team.losses`, `team.streak`, `team.leagueRank`). No new `LeagueStore` field needed; the `StandingsBuilder` ran upstream during bootstrap.
+
+## Risks / Tradeoffs
+
+- **NavigationStack double-push (Trades deep-link)**: If we wire the trade card button to `router.navigate(to: .teamAnalyzerWithTrade)` from inside the in-page tab, and the user is already on the My Team tray destination, that pushes onto My Team's stack — not the Team Analyzer's. *Mitigation*: route via `navigationStore.select(.teamAnalyzer)` (drawer-level switch) plus a handoff store, not a stack push. Confirm during Step 5.
+- **TeamAnalysis recompute on every render**: 12 rosters × ~25 players × dict lookups runs on every body invocation. *Accepted* — same pattern Analyzer uses, no measured perf issue today. If profiling shows otherwise, memoize behind a computed-once `let` outside the `switch` (already covered in Step 6).
+- **Compact iPhones (vertical-space crunch)**: Sticky strip + segmented picker + hex chart on Strengths tab risks zero scroll room on iPhone 16e / SE-class. *Mitigation*: Step 8 risk gate — drop sticky if it eats more than ~30% viewport. Acceptable simpler fallback: strip scrolls with the page.
+- **PlayerValuesStore cold load**: User lands on Strengths/Trades before values have ever loaded → empty axes. *Mitigation*: explicit loading view when `!valuesStore.hasValues`, gated identically to TeamAnalyzerView.
+- **Roster tab regression risk**: This is the highest-traffic surface in the app. *Mitigation*: lift-and-shift the four section view-builders inside `case .roster:` without altering their bodies. Manual diff on sim.
+- **Phase 0 fallback churn**: If trade-preload investigation fails, Branch B (button-launch) is a degraded experience. *Accepted* — the brainstorm flagged Option C as the fallback explicitly.
+
+## Decisions (locked 2026-06-03)
+
+- [x] **D-1: Trades-tab UX → Branch A (controller-hoisted preload).** Long-term right call. New `@Observable TradeAnalyzerController` owns the trade-builder state; injected at `MainShell`; both `TeamAnalyzerView` and the My Team Trades-tab card buttons consume it. No button-launch fallback. Pays off the moment a second deep-link source needs preloading.
+- [x] **D-2: Quick Hitters → 6 stats.** Record / rank / total dynasty value / weakness / total FPTS / best position. Horizontal scroll on phone (six tiles don't fit unscrolled at default Dynamic Type); non-scrolling LazyHStack on iPad.
+- [x] **D-3: Issue naming → `feat: My Team rework — tabs, quick hitters, embedded analyzer`.** Standalone; no parity-epic prefix.
+- [x] **D-4: Tab order → Roster / Strengths / Trades.** Roster leads because it's the highest-traffic surface; Strengths and Trades follow in dependency order (Strengths reads the data Trades acts on).
+- [ ] **D-5 (deferred to Step 8): Sticky vs scrolling Quick Hitters.** Final call made on-device — drop sticky if it eats > 30% viewport on iPhone 17 Pro.
+
+## Success Criteria
+
+- Roster tab is visually identical to today's My Team page (no regressions in slot ordering, badges, or sheet presentation).
+- Strengths tab renders the same hex chart + per-position breakdown as the Analyzer's Compare tab (sans opponent column), seeded from existing stores with no new data loaders.
+- Trades tab lists up to 5 ranked `RecommendedTrade`s (or the documented empty-state copy) and tapping one either preloads the Analyzer's builder (Branch A) or opens the Analyzer tray (Branch B) without nav-stack glitches.
+- Quick Hitters strip surfaces record / rank / total value / weakness, updates on pull-to-refresh, and the weakness chip jumps to the Strengths tab on tap.
+- Build succeeds (`xcodebuild` command from CLAUDE.md), no new warnings, manual smoke test on iPhone 17 Pro sim passes the Step 9 checklist.
+
+## Skills / Agents to Use
+
+- **planner**: this doc (done).
+- **swiftui-builder** (or general implementation agent): Steps 2–8 — straightforward SwiftUI refactor, well-scoped.
+- **xcode-build-verify** (or shell-runner): Step 9 — runs `xcodegen generate` and the build command, surfaces errors.
+
+## Next Step
+
+Plan is `Ready`. Next command:
+
+```
+/execute my-team-rework
+```
+
+Phase 0 prereqs (open issue, hoist `TradeAnalyzerController`, extract `PositionBreakdownCard` + `RecommendedTradeCard`) ship as their own commit/PR before the visible TeamView changes land.

--- a/docs/migrations/2026-06-02-week-preview-cron-row.sql
+++ b/docs/migrations/2026-06-02-week-preview-cron-row.sql
@@ -1,0 +1,17 @@
+-- Migration: add the admin_cron_settings row for notif_week_preview.
+-- Default `enabled=true, test_mode=true` so the first fire after the
+-- terraform apply lands in the admin inbox ONLY — flip test_mode=false
+-- from the Cron Settings screen once the copy looks right.
+--
+-- Run in Supabase dashboard SQL editor. Idempotent — ON CONFLICT
+-- skips if a row with the same cron_key already exists.
+
+INSERT INTO admin_cron_settings (cron_key, enabled, test_mode, description, updated_at)
+VALUES (
+    'notif_week_preview',
+    true,
+    true,
+    'Week Preview newsletter — Wed 9am ET',
+    NOW()
+)
+ON CONFLICT (cron_key) DO NOTHING;

--- a/docs/migrations/2026-07-02-fix-placeholder-emails.sql
+++ b/docs/migrations/2026-07-02-fix-placeholder-emails.sql
@@ -1,0 +1,22 @@
+-- Migration: replace placeholder emails with real emails for 3 whitelisted users.
+--
+-- These rows already exist and already have the correct sleeper_user_id (backfilled
+-- 2026-06-02), but were seeded with a bare nickname in the `email` column. The login
+-- gate (AuthStore.checkWhitelist) matches on real email, so these members CANNOT log
+-- in until the email is corrected. Emails confirmed via league DM 2026-07-02.
+--
+-- Run in Supabase dashboard SQL editor. Idempotent — no-ops once emails are set.
+
+UPDATE whitelisted_users
+  SET email = 'murchisdm@bellsouth.net', sleeper_username = 'dmurchis'
+  WHERE email = 'duncan';   -- sleeper_user_id 741140723985997824
+
+UPDATE whitelisted_users
+  SET email = 'mwynne16@gmail.com', sleeper_username = 'mwynne16'
+  WHERE email = 'mike';     -- sleeper_user_id 1001254799347658752
+
+UPDATE whitelisted_users
+  SET email = 'andrewga23@gmail.com', sleeper_username = 'andrewga23'
+  WHERE email = 'tony';     -- sleeper_user_id 1127420529155227648
+
+-- Still on placeholder emails (real emails not yet collected): jim, tibor, kyle, alex


### PR DESCRIPTION
Adds slot order fingerprint detection so mocks regenerate when the commish sets the 2026 draft order mid-session.

Closes #99